### PR TITLE
docs(project): initialize project documentation and expand root README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,21 +38,14 @@ Do not push directly to `main`.
 ## Branch naming
 
 Use clear and predictable branch names.
+Use descriptive branch names in `snake_case` where applicable.
 
-Recommended format:
+Recommended format / Examples:
 
-- `feature/<issue-number>-short-description`
-- `fix/<issue-number>-short-description`
-- `chore/<issue-number>-short-description`
-- `docs/<issue-number>-short-description`
-- `build/<issue-number>-short-description`
-- `ci/<issue-number>-short-description`
-
-Examples:
-
-- `feature/12-login-screen`
-- `fix/18-card-draw-bug`
-- `chore/4-editorconfig-setup`
+- `feature/home_screen`
+- `feature/create_lobby`
+- `fix/join_lobby_validation`
+- `chore/add_ci_workflow`
 
 Use lowercase letters and hyphens.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Untitled
+# SE2 Group Project – Rummikub Game
 
-# SE2 Group Project – UNO Card Game
-
-> Monorepo for our SE2 group project: an UNO-inspired multiplayer card game with an **Android frontend** and a **Spring Boot backend**, both written in **Kotlin**.
+> Monorepo for our SE2 group project: a Rummikub-inspired multiplayer game with an **Android frontend** and a **Spring Boot backend**, both written in **Kotlin**.
 
 ## Project Status
 
@@ -14,15 +12,29 @@
 
 ## Overview
 
-The goal of this project is to build a digital card game inspired by UNO.
+The goal of this project is to design and implement a digital game inspired by Rummikub as part of the SE2 group project. The application is being developed as a shared monorepo so the Android frontend, Spring Boot backend, and all project documentation can evolve together in one repository with consistent structure, tooling, and workflow.
 
-The application consists of:
+The system is currently planned around two main technical parts:
 
-- an **Android app** for players
-- a **Spring Boot backend** for lobbies, game state, and scoring
-- a shared repository structure for team collaboration and future scaling
+- an **Android application** that provides the user interface and the player experience
+- a **Spring Boot backend** that manages lobbies, game state, validation, and future score-related functionality
 
-This repository is organized as a **monorepo** so frontend, backend, and shared setup can evolve together in one place.
+In addition to the implementation itself, the repository also contains project documentation, development conventions, and collaboration resources intended to support smooth teamwork throughout the course of the project.
+
+---
+
+## Project Goals
+
+The main objective is to deliver one polished multiplayer card game experience instead of several loosely connected mini-projects. The focus is on building a clear, maintainable, and well-documented application that can be developed collaboratively by the whole team.
+
+The project aims to:
+
+- build a stable Android client in Kotlin
+- build a structured backend in Kotlin with Spring Boot
+- define clear contracts between frontend and backend
+- maintain a clean monorepo structure for the whole team
+- document setup, architecture, workflow, and technical decisions inside the repository
+- keep project organization transparent through GitHub and Notion
 
 ---
 
@@ -45,12 +57,13 @@ This repository is organized as a **monorepo** so frontend, backend, and shared 
 - GitHub
 - GitHub Actions
 - Notion for project management
+- IntelliJ IDEA / Android Studio
 
 ---
 
 ## Repository Structure
 
-```
+```text
 .
 ├── apps/
 │   ├── android/              # Android application
@@ -65,34 +78,87 @@ This repository is organized as a **monorepo** so frontend, backend, and shared 
 ├── build.gradle.kts          # Root Gradle configuration
 ├── settings.gradle.kts       # Included modules
 ├── gradle.properties         # Shared Gradle defaults
-├── gradlew
-├── gradlew.bat
+├── gradlew                   # Gradle wrapper for macOS / Linux
+├── gradlew.bat               # Gradle wrapper for Windows
 └── README.md
 ```
 
+### Repository Notes
+
+- `apps/android` contains the Android client
+- `apps/backend` contains the Spring Boot backend
+- `docs` contains the main project documentation
+- `.github` contains collaboration and workflow templates
+- the root Gradle files define shared build configuration for the whole monorepo
+
+---
+
 ## Project Management
 
-We use:
+The team currently uses:
 
-- **GitHub** for source code, issues, and pull requests
-- **Notion** for planning, user stories, sprint tracking, and team organization
+- **GitHub** for source code, issues, pull requests, and code review
+- **Notion** for planning, user stories, meeting notes, and project organization
 
 ### Project Links
 
-- **GitHub Repository:** `<add-repo-link-here>`
-- **GitHub Organization:** `<add-org-link-here>`
-- **Notion Workspace / Hub:** `<add-notion-link-here>`
+- **GitHub Repository:** `<https://github.com/SE2-Gruppenprojekt/se2-group-codebase>`
+- **GitHub Organization:** `<https://github.com/SE2-Gruppenprojekt>`
+- **Notion Workspace / Hub:** `<https://kingjulien1.notion.site/SE2-Project-Team-Gamma-Hub-33086e6823a4809eb050f4a8335b695d?source=copy_link>`
+
+---
+
+## Team
+
+The following team members are currently part of the project.
+
+### Erik `@erzeber`
+
+- **Role:** Team Leader
+- **Workspace:** Organisational / Frontend / Backend / Reviewer
+
+### Julian Blaschke `@Julian`
+
+- **Role:** Architect
+- **Workspace:** Organisational / Backend / Reviewer
+
+### Stefan `@Stefan`
+
+- **Role:** Developer
+- **Workspace:** Backend
+
+### Katrin Herold `@Katrin Herold`
+
+- **Role:** Developer
+- **Workspace:** Backend
+
+### Vanessa `@Vanessa`
+
+- **Role:** Developer
+- **Workspace:** Frontend
+
+### Miriam `@Miri`
+
+- **Role:** Developer
+- **Workspace:** Backend
+
+### Sabine
+
+- **Role:** Developer
+- **Workspace:** Frontend
 
 ---
 
 ## Requirements
 
-Before starting, make sure you have:
+Before starting, make sure the following tools are installed:
 
 - **JDK 17**
 - **Android Studio**
 - **Git**
-- optionally **IntelliJ IDEA** for backend or general Kotlin work
+- optionally **IntelliJ IDEA** for backend work or general Kotlin development
+
+It is also recommended that all contributors use the committed Gradle Wrapper instead of a globally installed Gradle version.
 
 ---
 
@@ -100,7 +166,7 @@ Before starting, make sure you have:
 
 ### 1. Clone the repository
 
-```
+```bash
 git clone <your-repository-url>
 cd codebase
 ```
@@ -109,41 +175,53 @@ cd codebase
 
 On macOS / Linux:
 
-```
+```bash
 ./gradlew tasks
 ```
 
 On Windows:
 
-```
+```bat
 gradlew.bat tasks
 ```
+
+If Gradle does not run successfully, verify that the Gradle Wrapper files are present and that the project is using **JDK 17**.
 
 ---
 
 ## Running the Backend
 
-From the repository root:
+From the repository root, start the backend with:
 
-```
+```bash
 ./gradlew :apps:backend:bootRun
 ```
 
-Expected local endpoint:
+The backend should start using the local configuration defined in the backend module.
 
-```
-GET /api/health
-```
+### Notes
+
+- run the backend from the repository root
+- use the Gradle Wrapper instead of a system Gradle installation
+- update backend-specific documentation when endpoints or configuration change
 
 ---
 
 ## Running the Android App
 
-1. Open the repository in **Android Studio**
-2. Wait for **Gradle sync**
-3. Select the Android app configuration
+To run the Android application:
+
+1. Open the repository in **Android Studio**
+2. Wait for **Gradle sync** to complete
+3. Select the Android app run configuration
 4. Start an emulator or connect a physical device
-5. Run the app
+5. Run the application
+
+### Notes
+
+- make sure the Android SDK is installed correctly
+- let Gradle sync fully before running the app
+- use the shared repository configuration instead of creating local project variants
 
 ---
 
@@ -151,7 +229,9 @@ GET /api/health
 
 ### Branch Naming
 
-Use clear and short branch names:
+Use clear and concise branch names.
+
+Examples:
 
 - `feature/homescreen`
 - `feature/create-lobby`
@@ -162,13 +242,13 @@ Use clear and short branch names:
 
 ### Commit Messages
 
-Use **Conventional Commits** where possible.
+Use **Conventional Commits** where possible.
 
 Examples:
 
-```
+```text
 feat(android): add homescreen UI
-feat(backend): add health endpoint
+feat(backend): add mock lobby endpoint
 feat(game): implement deal cards use case
 fix(android): validate username input
 chore(repo): add root gradle configuration
@@ -188,107 +268,23 @@ Before opening a pull request:
 
 ---
 
-## Issue Management
-
-We split work into **small technical issues** that can be implemented independently.
-
-Typical categories:
-
-- **repo/setup**
-- **android**
-- **backend**
-- **game logic**
-- **docs**
-- **ci**
-- **testing**
-
-Each issue should ideally include:
-
-- a clear title
-- a short description
-- acceptance criteria
-- labels
-- assignee / reviewer if known
-
----
-
 ## Definition of Done
 
 A task is considered done when:
 
 - acceptance criteria are fulfilled
 - code builds locally
-- relevant tests are added or updated
+- relevant tests are added or updated where appropriate
 - code follows project conventions
-- no obvious debug or placeholder code remains
+- no obvious debug or placeholder code remains unless explicitly intended
 - documentation is updated if required
-- the PR has been reviewed
-
----
-
-## Planned Features
-
-Current project scope includes features such as:
-
-- homescreen
-- username input
-- leaderboard
-- create lobby
-- browse lobbies
-- join lobby by ID
-- lobby game options
-- start game
-- initial game state
-- first dealt card
-- deal cards
-- play a card
-- take a card
-- timer handling
-- win game
-- game results and score updates
-
----
-
-## Suggested Sprint 0 / Setup Scope
-
-Before feature implementation, the repository should provide:
-
-- monorepo folder structure
-- root Gradle configuration
-- Gradle wrapper
-- `.gitignore`
-- `.editorconfig`
-- Android bootstrap project
-- backend bootstrap project
-- README and docs skeleton
-- issue / PR templates
-- CI workflow
-
----
-
-## Documentation
-
-The `docs/` directory should contain technical project documentation such as:
-
-- `architecture.md`
-- `setup.md`
-- `api.md`
-- `contributing.md`
-
----
-
-## Team Conventions
-
-- Prefer **small issues** over large vague tasks
-- Keep pull requests focused
-- Discuss bigger architecture changes before implementation
-- Do not commit secrets or local environment files
-- Use consistent Kotlin formatting and naming conventions
-- Keep frontend and backend contracts explicit and documented
+- the pull request has been reviewed
 
 ---
 
 ## Contributing
+
+Basic contribution flow:
 
 1. Pick or create an issue
 2. Create a branch
@@ -298,4 +294,63 @@ The `docs/` directory should contain technical project documentation such as:
 6. Request review
 7. Merge after approval
 
+For more detailed contribution guidance, see the linked project documentation below.
+
 ---
+
+## Project Documentation
+
+The `docs/` directory contains the main project documentation. These files should be kept up to date as the project evolves.
+
+### Core Guides
+
+- [Setup Guide](docs/setup.md)
+- [Architecture Overview](docs/architecture.md)
+- [API Overview](docs/api.md)
+- [Testing Guide](docs/testing.md)
+
+### Supporting Documentation
+
+- [Database Notes](docs/database.md)
+- [Design System Notes](docs/design-system.md)
+- [Meeting Notes Guide](docs/meetings.md)
+- [Meeting Notes Template](docs/meeting_notes_template.md)
+- [Project Roadmap](docs/roadmap.md)
+
+### Meeting Files
+
+- [Launch Session](docs/meetings/meeting_01_launch_session.md)
+- [Pre-Kickoff Meeting](docs/meetings/meeting_02_pre_kickoff.md)
+- [Kickoff Meeting](docs/meetings/meeting_03_kickoff.md)
+
+---
+
+## Resources
+
+### Internal Resources
+
+- [GitHub Repository](https://github.com/SE2-Gruppenprojekt/se2-group-codebase)
+- [GitHub Organization](https://github.com/SE2-Gruppenprojekt)
+- [Notion Workspace / Hub](https://kingjulien1.notion.site/SE2-Project-Team-Gamma-Hub-33086e6823a4809eb050f4a8335b695d?source=copy_link)
+
+### External References
+
+- [Kotlin Documentation](https://kotlinlang.org/docs/home.html)
+- [Android Developers Documentation](https://developer.android.com/docs)
+- [Jetpack Compose Documentation](https://developer.android.com/jetpack/compose)
+- [Spring Boot Reference Documentation](https://docs.spring.io/spring-boot/documentation.html)
+- [Gradle Documentation](https://docs.gradle.org/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [EditorConfig Documentation](https://editorconfig.org/)
+- [GitHub Actions Documentation](https://docs.github.com/actions)
+
+---
+
+## Additional Notes
+
+- keep the repository clean and well-structured
+- prefer small, focused pull requests over large mixed changes
+- discuss larger architectural changes before implementation
+- do not commit secrets, local environment files, or generated build output
+- keep frontend/backend contracts explicit and documented
+- use the repository documentation as the main technical reference whenever possible

--- a/README.md
+++ b/README.md
@@ -242,9 +242,35 @@ Examples:
 
 ### Commit Messages
 
-Use **Conventional Commits** where possible.
+Use **Conventional Commits** for all commit messages where possible.
 
-Examples:
+### Commit Message Format
+
+```text
+<type>(<scope>): <short summary>
+```
+
+### Format Rules
+
+- use a lowercase commit `type`
+- use a short and specific `scope` when applicable
+- write the summary in the imperative mood
+- keep the summary concise and descriptive
+- do not end the summary with a period
+- prefer one logical change per commit
+
+### Common Types
+
+- `feat` for a new feature
+- `fix` for a bug fix
+- `docs` for documentation changes
+- `chore` for maintenance, setup, or repository tasks
+- `refactor` for code changes that do not add features or fix bugs
+- `test` for adding or updating tests
+- `ci` for CI or workflow-related changes
+- `build` for build system or dependency changes
+
+### Good Examples
 
 ```text
 feat(android): add homescreen UI
@@ -254,7 +280,13 @@ fix(android): validate username input
 chore(repo): add root gradle configuration
 docs(readme): add setup instructions
 ci(github): add build workflow
+build(gradle): add gradle wrapper
 ```
+
+### References
+
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+- [How to Write a Git Commit Message](https://cbea.ms/git-commit/)
 
 ### Pull Requests
 
@@ -266,7 +298,44 @@ Before opening a pull request:
 - update documentation if needed
 - add screenshots for UI changes if applicable
 
----
+### Pull Request Title Format
+
+Use a title structure similar to the commit message format.
+
+```text
+<type>(<scope>): <short summary>
+```
+
+### Pull Request Title Rules
+
+- use a lowercase `type`
+- use a meaningful `scope` when applicable
+- keep the summary short, clear, and review-friendly
+- describe the overall purpose of the PR, not every internal detail
+- do not end the title with a period
+- make sure the title aligns with the linked issue and branch purpose
+
+### Good Examples
+
+```text
+feat(android): add lobby screen skeleton
+feat(backend): add mock lobby endpoint
+docs(project): initialize project documentation
+chore(repo): add github templates and ci workflow
+build(gradle): configure root monorepo build
+fix(android): correct username validation state
+```
+
+### Pull Request Description
+
+The pull request description should usually include:
+
+- a short summary of the change
+- the motivation or goal of the PR
+- the main files or areas affected
+- references to related issues
+- testing or verification notes
+- screenshots for UI changes when relevant
 
 ## Definition of Done
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,18 @@
+# API
+
+## Overview
+
+This document provides a high-level overview of the backend API currently available for frontend integration.
+
+## Current Status
+
+The backend API is still in an early stage.  
+Some endpoints may return mocked or hardcoded sample data until real business logic is implemented.
+
+## Base Path
+
+Current API endpoints are expected under a base path similar to:
+
+```text
+/api
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,56 @@
+# Architecture
+
+## Overview
+
+This project is a multiplayer card game inspired by UNO. It is developed as a monorepo containing:
+
+- an Android frontend written in Kotlin
+- a Spring Boot backend written in Kotlin
+- shared documentation and project configuration
+
+## High-Level Structure
+
+```text
+apps/
+  android/   # Android application
+  backend/   # Spring Boot backend
+docs/        # Project documentation
+infra/       # Infrastructure and deployment related files
+```
+
+Frontend Responsibilities
+
+The Android app is responsible for:
+• rendering the user interface
+• handling user input
+• managing screen navigation
+• displaying lobby and game state
+• communicating with the backend API
+
+Backend Responsibilities
+
+The backend is responsible for:
+• lobby management
+• game state management
+• player actions and validation
+• score handling
+• exposing API endpoints for the frontend
+
+Planned Architecture Principles
+• clear separation between frontend and backend responsibilities
+• feature-oriented frontend structure where practical
+• layered backend structure with controller, service, and DTO/domain separation
+• shared team conventions for naming, formatting, and Git workflow
+
+Current Scope
+
+At the current stage, the project is in bootstrap/setup phase.
+The architecture will evolve as the first gameplay and lobby features are implemented.
+
+Future Considerations
+
+Possible future additions:
+• shared Kotlin module for common DTOs or models
+• persistent storage for scores, users, or match history
+• real-time communication for live game updates
+• deployment and hosting configuration

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,39 @@
+# Database
+
+## Overview
+
+This document describes the current and planned persistence approach for the project.
+
+## Current Status
+
+At the current stage, the backend may use hardcoded or in-memory data for early development and frontend integration.
+
+No production-ready persistence layer is defined yet.
+
+## Planned Use Cases for Persistence
+
+A database may later be used for:
+
+- player statistics
+- leaderboard data
+- match history
+- user profiles
+- saved settings
+- lobby persistence if needed
+
+## Open Questions
+
+Questions to decide later:
+
+- Should the first version use no database, in-memory storage, or a relational database?
+- What data actually needs persistence for the MVP?
+- Which entities should be temporary and which should be stored permanently?
+
+## Future Notes
+
+When a database is introduced, this document should be updated with:
+
+- selected database technology
+- local setup instructions
+- schema overview
+- migration strategy

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,44 @@
+# Design System
+
+## Overview
+
+This document captures the visual and UI consistency rules for the Android app.
+
+## Goals
+
+The design system should help keep the app:
+
+- consistent
+- readable
+- simple to extend
+- easy to maintain
+
+## Current Direction
+
+The Android app uses Jetpack Compose and should define shared UI foundations such as:
+
+- colors
+- typography
+- spacing
+- reusable buttons
+- reusable cards
+- reusable feedback components
+
+## Design Principles
+
+- keep screens simple and focused
+- prioritize readability over decoration
+- use consistent spacing and alignment
+- use reusable components instead of duplicating UI code
+- make important actions visually clear
+
+## Future Additions
+
+This file can later be expanded with:
+
+- color palette
+- typography scale
+- component usage rules
+- button variants
+- card styles
+- loading and error state patterns

--- a/docs/meeting_notes_template.md
+++ b/docs/meeting_notes_template.md
@@ -1,0 +1,34 @@
+# Meeting Notes — <Title>
+
+**Date:** <YYYY-MM-DD>  
+**Participants:** <Names>  
+**Topic:** <Main topic>
+
+## Summary
+
+Short summary of what was discussed and why the meeting took place.
+
+## Discussion Points
+
+-
+-
+-
+
+## Decisions
+
+-
+-
+
+## Action Items
+
+- [ ] <Task> — Owner: <Name>
+- [ ] <Task> — Owner: <Name>
+
+## Open Questions
+
+-
+
+## Next Meeting
+
+- **Date/Time:** <Date and time>
+- **Focus:** <Planned focus>

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -1,0 +1,44 @@
+# Meetings
+
+## Overview
+
+This document describes how meeting notes and decisions should be handled for the project.
+
+## Purpose
+
+Meeting notes should help the team track:
+
+- decisions
+- open questions
+- responsibilities
+- next steps
+
+## Recommended Structure for Meeting Notes
+
+For each meeting, capture:
+
+- date
+- participants
+- agenda
+- key decisions
+- action items
+- blockers
+- next meeting notes
+
+## Storage
+
+Detailed meeting notes may live in Notion or another shared workspace.  
+This file can serve as an index or summary for important project-level decisions.
+
+## Important Rule
+
+Important technical or product decisions should not stay only in chat messages.  
+They should be documented in a place the whole team can find later.
+
+## Future Additions
+
+This document can later include:
+
+- meeting note templates
+- decision log links
+- recurring meeting schedule

--- a/docs/meetings/meeting_01_launch_session.md
+++ b/docs/meetings/meeting_01_launch_session.md
@@ -1,0 +1,44 @@
+# Meeting Notes — Launch Session
+
+**Date:** Last Saturday  
+**Participants:** Julian, Erik  
+**Topic:** General ideas for modelling, work split, and architecture
+
+## Summary
+
+This meeting served as an initial working session focused on the technical direction of the project. The main objective was to discuss how the project should be structured at a high level and how responsibilities should be divided within the team. The discussion covered architectural modelling, ownership, and the question of where core game logic should be implemented.
+
+The session also helped frame the project as a focused product rather than a collection of loosely related ideas. A shared understanding emerged that the team should build one polished game experience instead of trying to implement multiple games or overly broad feature scope.
+
+## Discussion Points
+
+- Initial thoughts on project modelling and overall system architecture.
+- Possible distribution of responsibilities between team leads and contributors.
+- Whether important game logic should primarily live in the backend, the frontend, or be split between both.
+- The need to structure the project in a way that allows leads to prepare and distribute clear development tasks.
+- The importance of focusing the scope on one game and polishing it properly instead of attempting multiple game concepts.
+- Coordination with the rest of the team for a final game decision in the following meeting.
+
+## Decisions
+
+- The project should aim for one polished game rather than multiple game concepts.
+- Team coordination should include a clearer split of responsibility, potentially through lead roles.
+- Setup and task preparation should be organized in a way that allows developers to work from defined TODOs and issues.
+- The final game decision would be confirmed with the broader team in the next discussion.
+
+## Action Items
+
+- [ ] Prepare a more concrete proposal for architecture and responsibility split — Owner: Julian / erzeber
+- [ ] Discuss final game choice with the rest of the team — Owner: Team
+- [ ] Start outlining technical tasks for contributors based on architectural areas — Owner: Leads
+
+## Open Questions
+
+- Which parts of the game logic should remain exclusively on the backend?
+- Which responsibilities should be assigned to frontend versus backend implementation?
+- How should lead roles be formally distributed within the team?
+
+## Next Meeting
+
+- **Date/Time:** Following day / next team discussion
+- **Focus:** Final game choice and continuation of setup, modelling, and architecture planning.

--- a/docs/meetings/meeting_02_pre_kickoff.md
+++ b/docs/meetings/meeting_02_pre_kickoff.md
@@ -1,0 +1,47 @@
+# Meeting Notes — Pre-Kickoff Discussion
+
+**Date:** Last Sunday  
+**Participants:** Julian, Erik  
+**Topic:** Preliminary discussion on tech stack and basic architecture
+
+## Summary
+
+This meeting functioned as a preparatory discussion before the broader kickoff. The purpose was to align on the technical stack, establish an initial architectural direction, and identify the most important groundwork needed before implementation begins. The conversation focused on selecting suitable technologies, thinking through repository organization, and outlining the first technical documents needed for the project.
+
+The discussion also highlighted that the project needed a clear technical baseline before feature work could start. In particular, the team identified the importance of documenting technology choices and capturing architecture decisions early to reduce confusion once tasks are distributed to more contributors.
+
+## Discussion Points
+
+- Review of the proposed technology stack for the project.
+- Early architectural ideas for how the Android app and backend should interact.
+- The need for dedicated documentation on both the tech stack and the architecture.
+- The role of this preparatory discussion in enabling a more structured kickoff meeting.
+- Gaps in the current notes structure, including placeholders for decisions, open questions, and to-dos that still needed to be filled in.
+
+## Documents / Work Items Identified
+
+- **Tech Stack** document to summarize selected tools and frameworks.
+- **Architecture** document to describe the overall system structure and responsibility split.
+
+## Decisions
+
+- The team should explicitly document the tech stack rather than relying on verbal agreement.
+- Architecture should be captured early in written form to support later implementation planning.
+- The pre-kickoff session should feed directly into the first formal kickoff meeting.
+
+## Action Items
+
+- [ ] Create a first written version of the tech stack document — Owner: Julian / erzeber
+- [ ] Draft a first architecture overview for the repository and system — Owner: Julian / erzeber
+- [ ] Use the output of this session as preparation for the kickoff meeting — Owner: Team
+
+## Open Questions
+
+- What level of detail is needed in the initial architecture document?
+- Should documentation be maintained mainly in Notion, in the repository, or in both?
+- Which setup decisions need to be finalized before development tasks are assigned?
+
+## Next Meeting
+
+- **Date/Time:** Kickoff meeting with the wider team
+- **Focus:** Confirm project direction, review user stories, and align on setup and responsibilities.

--- a/docs/meetings/meeting_03_kickoff.md
+++ b/docs/meetings/meeting_03_kickoff.md
@@ -1,0 +1,72 @@
+# Meeting Notes — Kickoff Meeting
+
+**Date:** Last Sunday  
+**Participants:** Erik, Julian, Vanessa, Miri, Sabine, Stefan,
+**Topic:** Preliminary discussion on tech stack and basic architecture, team setup, and project direction
+
+## Summary
+
+This kickoff meeting marked the first broader alignment across the project team. The purpose was to review the current preparation work, discuss the initial product direction, and identify the most important setup and planning tasks required before implementation. The meeting consolidated earlier one-on-one preparation discussions and extended them to the full group.
+
+A central part of the conversation focused on narrowing the product idea. Several card game ideas were considered, but the team selected an UNO-based concept with custom variations or special game modes as the preferred direction. This gave the project a recognizable foundation while still leaving room for originality and differentiation.
+
+The meeting also covered organizational and technical groundwork. The team reviewed role allocation, the creation of user stories, tooling choices, code style considerations, and expectations around pull requests and testing. In addition, several follow-up tasks were identified to move the project from planning into a working repository and initial implementation setup.
+
+## Discussion Points
+
+- Review of team roles and general responsibility allocation.
+- Confirmation that initial user stories had been created as a basis for further task breakdown.
+- Brainstorming and comparison of possible card game concepts.
+- Selection of UNO with special versions or game modes as the preferred project direction.
+- Initial setup decisions regarding development tools and repository conventions.
+- Expectations for pull requests, including the expectation that unit tests should generally be included where feasible.
+- Immediate next steps needed to translate user stories into technical tasks and set up frontend and backend foundations.
+
+## Brainstormed Game Ideas
+
+- UNO with special variations / game modes
+- Schnapsen / Hosen Obe
+- The Mind
+
+## Selected Direction
+
+The team agreed to proceed with an UNO-based game concept and to differentiate it through custom rules, special versions, or alternative game modes.
+
+## Setup and Tooling
+
+The following tools and conventions were mentioned during the meeting:
+
+- IntelliJ IDEA
+- Android Studio
+- `.editorconfig` for consistent formatting and uniform code style
+
+## Development Process Notes
+
+- Pull requests should contain unit tests whenever the change is suitable for testing.
+- If a change is too complex to reasonably test within the same PR, support may be provided by Julian Blaschke or erzeber.
+- User stories should be refined into concrete technical tasks before implementation begins in earnest.
+
+## Decisions
+
+- The project direction will be an UNO-based card game with differentiated modes or variations.
+- Existing user stories will be used as the foundation for creating concrete development tasks.
+- The team will proceed with setting up both frontend and backend project foundations.
+- Formatting consistency will be supported through shared configuration such as `.editorconfig`.
+
+## Action Items
+
+- [ ] Split user stories into concrete technical tasks — Owner: erzeber
+- [ ] Set up backend and frontend project foundations — Owner: Team
+- [ ] Distribute concrete technical tasks among team members — Owner: Team Leads
+- [ ] Continue refining architecture and setup decisions based on the selected game direction — Owner: Team
+
+## Open Questions
+
+- Which exact special rules or game modes should be included to make the UNO concept distinct enough?
+- How should responsibilities be divided between frontend and backend in the first development phase?
+- What should be the first milestone after repository setup is complete?
+
+## Next Meeting
+
+- **Date/Time:** Last Thursday, 20:00
+- **Focus:** Task distribution, project setup progress, and clarification of remaining architecture decisions.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,55 @@
+# Roadmap
+
+## Overview
+
+This document captures the current high-level project direction and major milestones.
+
+## Current Phase
+
+The project is currently in the initial setup and bootstrap phase.
+
+## Suggested Early Milestones
+
+### Milestone 1 — Project Setup
+
+- initialize monorepo structure
+- configure Gradle
+- bootstrap Android app
+- bootstrap backend
+- add documentation baseline
+- add repository standards and CI
+
+### Milestone 2 — Frontend and Backend Foundations
+
+- add starter frontend screens
+- add backend mock endpoint(s)
+- document API contracts
+- prepare frontend/backend integration
+
+### Milestone 3 — Core Lobby Flow
+
+- create lobby
+- browse lobbies
+- join lobby
+- lobby screen UI
+- basic lobby state handling
+
+### Milestone 4 — Core Game Flow
+
+- initialize game state
+- display player hand
+- play cards
+- draw cards
+- implement turn flow
+
+### Milestone 5 — Polish
+
+- improve UI
+- improve validation and error handling
+- add tests
+- improve documentation
+- stabilize integration
+
+## Notes
+
+This roadmap is intentionally high-level and should evolve as the project progresses.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,75 @@
+# Setup
+
+## Overview
+
+This document explains how to set up the project locally for development.
+
+## Prerequisites
+
+Make sure the following tools are installed:
+
+- Git
+- JDK 17
+- Android Studio
+- IntelliJ IDEA (optional, useful for backend work)
+
+## Clone the Repository
+
+```bash
+git clone <repository-url>
+cd <repository-folder>#
+```
+
+Gradle
+
+This project uses the Gradle Wrapper.
+Always use the wrapper instead of a globally installed Gradle version.
+
+**MacOs / Linux**
+
+```bash
+./gradlew tasks
+```
+
+**Windows**
+`
+
+```bat
+./gradlew tasks
+```
+
+---
+
+Android App
+
+To run the Android frontend: 1. Open the repository in Android Studio 2. Wait for Gradle sync to finish 3. Select the Android run configuration 4. Start an emulator or connect a device 5. Run the app
+
+Backend
+
+To run the backend from the repository root:
+
+```bash
+./gradlew :apps:backend:bootRun
+```
+
+The backend should start with the local configuration from application.yml.
+
+Configuration Notes
+• local IDE files must not be committed
+• secrets or private keys must not be committed
+• use repository-level configuration and shared conventions where possible
+
+Troubleshooting
+
+Gradle sync fails
+• check that JDK 17 is selected
+• ensure Gradle wrapper files are present
+• refresh Gradle project in the IDE
+
+Android app does not run
+• verify emulator/device setup
+• check SDK installation in Android Studio
+
+Backend does not start
+• check terminal output for configuration errors
+• verify module path and Gradle setup

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,49 @@
+# Testing
+
+## Overview
+
+This document outlines the intended testing approach for the project.
+
+## Goals
+
+The project should gradually introduce testing for both frontend and backend code to reduce regressions and improve confidence during development.
+
+## Backend Testing
+
+Planned backend testing areas:
+
+- controller tests for endpoints
+- service tests for business logic
+- validation and error handling tests
+
+## Android Testing
+
+Planned Android testing areas:
+
+- ViewModel tests
+- UI tests for important screens
+- validation tests for user input
+- integration tests for API-connected flows where practical
+
+## Minimum Expectations Before Merge
+
+At minimum, before merging:
+
+- the project should build successfully
+- changed code should be manually verified
+- obvious regressions should be checked
+- new logic should be covered by tests when practical
+
+## Initial Testing Scope
+
+At the current project stage, manual testing is acceptable for bootstrap/setup tasks.  
+As feature complexity increases, automated tests should be added incrementally.
+
+## Future Improvements
+
+Possible future additions:
+
+- CI test execution
+- code coverage reporting
+- UI test plans
+- backend integration test setup


### PR DESCRIPTION
## Summary

This PR establishes the initial documentation baseline for the project and turns the repository into a more complete and navigable starting point for the whole team.

The main goal of this PR is to create a clear documentation structure, add useful starter content to the core project documents, and expand the root `README.md` so it serves as the primary entry point for onboarding, navigation, and collaboration.

This includes:
- initializing the `docs/` structure
- adding starter content to the main documentation files
- expanding the root `README.md`
- linking the documentation from the root README
- adding useful project and external resource references
- documenting setup, contribution workflow, architecture, API, and testing at a starter level
- improving consistency across document naming, headings, and links

## Changes included

### Documentation structure
Created and initialized the core documentation files in the `docs/` directory so the project has a dedicated place for development and collaboration knowledge.

### Root README expansion
Extended the root `README.md` to include:
- project overview
- tech stack
- repository structure
- setup and run information
- documentation navigation
- collaboration/development summary
- useful resources and references

### Core project guides
Added starter content for the main project guides, including:
- `docs/setup.md`
- `docs/contributing.md`
- `docs/architecture.md`
- `docs/api.md`
- `docs/testing.md`

### Additional starter documentation
Added initial placeholder/starter content for supporting project documents such as:
- `docs/database.md`
- `docs/design-system.md`
- `docs/meetings.md`
- `docs/roadmap.md`

### Consistency pass
Reviewed the documentation structure to make sure:
- file names are consistent
- headings are aligned
- README links point to the correct files
- no documentation file is left empty

## Why this PR is needed

Until now, a lot of project information has been spread across issues, chats, Notion pages, and informal discussion. This PR creates a first documentation baseline directly inside the repository so the team has a shared and versioned source of truth.

This should make it easier to:
- onboard new contributors
- find setup instructions quickly
- understand the intended architecture
- follow contribution conventions
- connect frontend and backend work through documented API notes
- keep project knowledge inside the repository instead of only in conversation threads

## Related issues

- Related to #36 
- Closes #35 
- Closes #34 


## Files / areas affected

- `README.md`
- `docs/architecture.md`
- `docs/setup.md`
- `docs/contributing.md`
- `docs/api.md`
- `docs/testing.md`
- `docs/database.md`
- `docs/design-system.md`
- `docs/meetings.md`
- `docs/roadmap.md`

## Notes

This PR is intended as a documentation baseline, not as final project documentation.  
The content is intentionally lightweight but structured enough to be extended as the project evolves.

Some sections currently describe the project at a high level or document the current state in a simplified form. These should be refined further as implementation progresses.

## Checklist

- [ ] Root `README.md` expanded
- [ ] Documentation files created in `docs/`
- [ ] Starter content added to all documentation files
- [ ] README links to documentation files
- [ ] Useful resources section added
- [ ] Setup, contribution, architecture, API, and testing guides added
- [ ] Documentation naming and links checked for consistency