### PR TITLE
feat(backend): bootstrap Spring Boot backend with sample endpoint

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -38,7 +38,6 @@ android {
     }
 }
 
-// ✅ NEW Kotlin config (outside android block)
 kotlin {
     compilerOptions {
         jvmTarget.set(
@@ -50,8 +49,18 @@ kotlin {
 }
 
 dependencies {
+    implementation(projects.apps.shared)
+
+    // Ktor HTTP client
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.jackson)
+
     implementation(libs.core.ktx)
     implementation(libs.lifecycle.runtime)
+    implementation(libs.lifecycle.viewmodel.compose)
+
 
     implementation(platform(libs.compose.bom))
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
     }
 
     buildFeatures {

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Permissions must be OUTSIDE the <application> tag -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,7 +14,10 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Tempapp">
+        android:theme="@style/Theme.Tempapp"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -18,10 +25,10 @@
             android:theme="@style/Theme.Tempapp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/apps/android/app/src/main/java/at/aau/serg/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/MainActivity.kt
@@ -7,41 +7,44 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import at.aau.serg.android.ui.screens.HomeScreen
+import at.aau.serg.android.ui.screens.LeaderboardScreen
 import at.aau.serg.android.ui.theme.TempappTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
         setContent {
             TempappTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+
+                var currentScreen by remember { mutableStateOf(Screen.HOME) }
+
+                Scaffold(
+                    modifier = Modifier.fillMaxSize()
+                ) { innerPadding ->
+
+                    when (currentScreen) {
+
+                        Screen.HOME -> HomeScreen(
+                            modifier = Modifier.padding(innerPadding),
+                            onShowLeaderboard = {
+                                currentScreen = Screen.LEADERBOARD
+                            }
+                        )
+
+                        Screen.LEADERBOARD -> LeaderboardScreen(
+                            modifier = Modifier.padding(innerPadding),
+                            onBack = {
+                                currentScreen = Screen.HOME
+                            }
+                        )
+                    }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TempappTheme {
-        Greeting("Android")
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/Screen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/Screen.kt
@@ -1,0 +1,6 @@
+package at.aau.serg.android
+
+enum class Screen {
+    HOME,
+    LEADERBOARD
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/LeaderboardAPI.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/LeaderboardAPI.kt
@@ -1,0 +1,21 @@
+package at.aau.serg.android.network
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.okhttp.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.serialization.jackson.*
+import shared.models.LeaderboardEntry
+
+object LeaderboardApi {
+    private val client = HttpClient(OkHttp) {
+        install(ContentNegotiation) {
+            jackson()
+        }
+    }
+
+    suspend fun fetchLeaderboard(): List<LeaderboardEntry> {
+        return client.get("http://10.0.2.2:8080/api/leaderboard").body()
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/HomeScreen.kt
@@ -1,0 +1,29 @@
+package at.aau.serg.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun HomeScreen(
+    modifier: Modifier = Modifier,
+    onShowLeaderboard: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Welcome to the App!")
+
+        Spacer(Modifier.height(16.dp))
+
+        Button(onClick = onShowLeaderboard) {
+            Text("Open Leaderboard")
+        }
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/LeaderboardScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/LeaderboardScreen.kt
@@ -1,0 +1,72 @@
+package at.aau.serg.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import shared.models.LeaderboardEntry
+
+@Composable
+fun LeaderboardScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: LeaderboardViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+) {
+    val players by viewModel.players.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Button(onClick = onBack) {
+            Text("Back")
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = "Leaderboard",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        LazyColumn {
+            items(players.sortedBy { it.rank }) { entry ->
+                LeaderboardRow(entry)
+            }
+        }
+    }
+}
+
+@Composable
+fun LeaderboardRow(entry: LeaderboardEntry) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("#${entry.rank}  ${entry.playerName}", style = MaterialTheme.typography.bodyLarge)
+            Text("${entry.score} pts", style = MaterialTheme.typography.bodyLarge)
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("Wins: ${entry.wins}", style = MaterialTheme.typography.bodyMedium)
+            Text("Games: ${entry.gamesPlayed}", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/LeaderboardViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/LeaderboardViewModel.kt
@@ -1,0 +1,32 @@
+package at.aau.serg.android.ui.screens
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import at.aau.serg.android.network.LeaderboardApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import shared.models.LeaderboardEntry
+
+class LeaderboardViewModel : ViewModel() {
+
+    private val _players = MutableStateFlow<List<LeaderboardEntry>>(emptyList())
+    val players = _players.asStateFlow()
+
+    init {
+        loadLeaderboard()
+    }
+
+    private fun loadLeaderboard() {
+        viewModelScope.launch {
+            runCatching {
+                LeaderboardApi.fetchLeaderboard()
+            }.onSuccess { list ->
+                _players.value = list
+            }.onFailure {
+                // you can log or show error state later
+                _players.value = emptyList()
+            }
+        }
+    }
+}

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
 }
 
 dependencies {
+    implementation(projects.apps.shared)
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.jackson.module.kotlin)

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -7,13 +7,20 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(
+            JavaLanguageVersion.of(
+                libs.versions.jvmTarget.get().toInt()
+            )
+        )
     }
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(
+        libs.versions.jvmTarget.get().toInt()
+    )
 }
+
 
 dependencies {
     implementation(projects.apps.shared)

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.kotlin.reflect)
+
+    testImplementation(libs.spring.boot.starter.test)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/BackendApplication.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/BackendApplication.kt
@@ -1,0 +1,11 @@
+package at.se2group.backend
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class BackendApplication
+
+fun main(args: Array<String>) {
+    runApplication<BackendApplication>(*args)
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LeaderboardController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LeaderboardController.kt
@@ -1,0 +1,33 @@
+package at.se2group.backend.api
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+data class LeaderboardEntry(
+    val rank: Int,
+    val playerName: String,
+    val score: Int,
+    val gamesPlayed: Int,
+    val wins: Int
+)
+
+@RestController
+@RequestMapping("/api/leaderboard")
+class LeaderboardController {
+
+    @GetMapping
+    fun getLeaderboard(): List<LeaderboardEntry> =
+        listOf(
+            LeaderboardEntry(1, "Julian", 1840, 42, 28),
+            LeaderboardEntry(2, "Erik", 1765, 40, 24),
+            LeaderboardEntry(3, "Vanessa", 1690, 38, 22),
+            LeaderboardEntry(4, "Stefan", 1615, 36, 20),
+            LeaderboardEntry(5, "Katrin", 1580, 35, 18),
+            LeaderboardEntry(6, "Miriam", 1495, 33, 16),
+            LeaderboardEntry(7, "Sabine", 1430, 31, 14),
+            LeaderboardEntry(8, "Alex", 1375, 29, 12),
+            LeaderboardEntry(9, "Nina", 1310, 27, 11),
+            LeaderboardEntry(10, "Lukas", 1260, 25, 9)
+        )
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LeaderboardController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LeaderboardController.kt
@@ -3,14 +3,7 @@ package at.se2group.backend.api
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-
-data class LeaderboardEntry(
-    val rank: Int,
-    val playerName: String,
-    val score: Int,
-    val gamesPlayed: Int,
-    val wins: Int
-)
+import shared.models.LeaderboardEntry
 
 @RestController
 @RequestMapping("/api/leaderboard")

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: se2-group-backend
+
+server:
+  port: 8080

--- a/apps/backend/src/test/kotlin/at/se2group/backend/BackendApplicationTests.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/BackendApplicationTests.kt
@@ -1,0 +1,12 @@
+package at.se2group.backend
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    fun contextLoads() {
+    }
+}

--- a/apps/shared/build.gradle.kts
+++ b/apps/shared/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(
+            org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(
+                libs.versions.jvmTarget.get()
+            )
+        )
+    }
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/apps/shared/build.gradle.kts
+++ b/apps/shared/build.gradle.kts
@@ -3,17 +3,14 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(
-            org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(
-                libs.versions.jvmTarget.get()
-            )
-        )
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/apps/shared/build.gradle.kts
+++ b/apps/shared/build.gradle.kts
@@ -4,13 +4,21 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(
+            JavaLanguageVersion.of(
+                libs.versions.jvmTarget.get().toInt()
+            )
+        )
     }
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(
+            org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(
+                libs.versions.jvmTarget.get()
+            )
+        )
     }
 }
 

--- a/apps/shared/src/main/kotlin/shared/models/LeaderboardEntry.kt
+++ b/apps/shared/src/main/kotlin/shared/models/LeaderboardEntry.kt
@@ -1,0 +1,9 @@
+package shared.models
+
+data class LeaderboardEntry(
+    val rank: Int,
+    val playerName: String,
+    val score: Int,
+    val gamesPlayed: Int,
+    val wins: Int
+)

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,3 +16,142 @@ Current API endpoints are expected under a base path similar to:
 ```text
 /api
 ```
+
+# API
+
+## Overview
+
+This document provides a high-level overview of the backend API currently available for frontend integration.
+
+## Current Status
+
+The backend API is still in an early stage.  
+Some endpoints may return mocked or hardcoded sample data until real business logic is implemented.
+
+## Base Path
+
+Current API endpoints are expected under a base path similar to:
+
+```text
+/api
+```
+
+## Leaderboard Endpoint
+
+### Purpose
+
+The leaderboard endpoint provides sample ranking data for the game backend. It can be used by the Android frontend to test API integration, JSON parsing, list rendering, and leaderboard UI screens before real persistence and gameplay logic are implemented.
+
+### Endpoint
+
+```text
+GET /api/leaderboard
+```
+
+### Description
+
+Returns a list of mocked leaderboard entries sorted by rank in ascending order. Each entry represents one player and their current leaderboard statistics.
+
+### Response Format
+
+The endpoint returns a JSON array of leaderboard entry objects.
+
+Each object contains the following fields:
+
+| Field         | Type    | Description                               |
+| ------------- | ------- | ----------------------------------------- |
+| `rank`        | integer | The player's current leaderboard position |
+| `playerName`  | string  | The display name of the player            |
+| `score`       | integer | The player's total score                  |
+| `gamesPlayed` | integer | The total number of games played          |
+| `wins`        | integer | The total number of wins                  |
+
+### Example Response
+
+```json
+[
+    {
+        "rank": 1,
+        "playerName": "Julian",
+        "score": 1840,
+        "gamesPlayed": 42,
+        "wins": 28
+    },
+    {
+        "rank": 2,
+        "playerName": "Erik",
+        "score": 1765,
+        "gamesPlayed": 40,
+        "wins": 24
+    },
+    {
+        "rank": 3,
+        "playerName": "Vanessa",
+        "score": 1690,
+        "gamesPlayed": 38,
+        "wins": 22
+    },
+    {
+        "rank": 4,
+        "playerName": "Stefan",
+        "score": 1615,
+        "gamesPlayed": 36,
+        "wins": 20
+    },
+    {
+        "rank": 5,
+        "playerName": "Katrin",
+        "score": 1580,
+        "gamesPlayed": 35,
+        "wins": 18
+    },
+    {
+        "rank": 6,
+        "playerName": "Miriam",
+        "score": 1495,
+        "gamesPlayed": 33,
+        "wins": 16
+    },
+    {
+        "rank": 7,
+        "playerName": "Sabine",
+        "score": 1430,
+        "gamesPlayed": 31,
+        "wins": 14
+    },
+    {
+        "rank": 8,
+        "playerName": "Alex",
+        "score": 1375,
+        "gamesPlayed": 29,
+        "wins": 12
+    },
+    {
+        "rank": 9,
+        "playerName": "Nina",
+        "score": 1310,
+        "gamesPlayed": 27,
+        "wins": 11
+    },
+    {
+        "rank": 10,
+        "playerName": "Lukas",
+        "score": 1260,
+        "gamesPlayed": 25,
+        "wins": 9
+    }
+]
+```
+
+### Success Response
+
+| Status Code | Meaning                                        |
+| ----------- | ---------------------------------------------- |
+| `200 OK`    | The leaderboard data was returned successfully |
+
+### Notes
+
+- The returned data is currently mocked sample data
+- The endpoint is intended for initial frontend-backend integration
+- Future versions may connect this endpoint to persistent storage and real game statistics
+- The response structure may be extended later with additional fields such as player ID, avatar, win rate, or last active timestamp

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,3 +155,56 @@ Each object contains the following fields:
 - The endpoint is intended for initial frontend-backend integration
 - Future versions may connect this endpoint to persistent storage and real game statistics
 - The response structure may be extended later with additional fields such as player ID, avatar, win rate, or last active timestamp
+
+
+# APP Update
+
+## Shared Directory
+
+**Path:**  
+`/apps/shared/src/main/kotlin/shared/models`
+
+A new directory has been introduced to hold shared code between the backend and frontend. This helps avoid code duplication and improves maintainability.
+
+### Example
+
+```kotlin
+data class LeaderboardEntry(
+    val rank: Int,
+    val playerName: String,
+    val score: Int,
+    val gamesPlayed: Int,
+    val wins: Int
+)
+```
+
+This class is required by both the frontend and backend. By keeping the structure consistent, JSON parsing via Jackson becomes automatic.
+
+---
+
+## Manifest Updates
+
+### Required Permissions
+
+These permissions are necessary to allow network communication:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+
+### Network Configuration
+
+Additional configuration via `network_security_config.xml` enables extended network options (e.g., allowing cleartext traffic for local Spring Boot testing):
+
+```xml
+android:usesCleartextTraffic="true"
+android:networkSecurityConfig="@xml/network_security_config"
+```
+
+---
+
+## Dependencies
+
+- **krossbow** → WebSockets & STOMP support
+- **ktor** → HTTP client for RESTful API calls

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,56 +1,636 @@
-# Architecture
+# Backend Architecture Overview
 
-## Overview
+## Purpose
 
-This project is a multiplayer card game inspired by UNO. It is developed as a monorepo containing:
+This document outlines a rough backend architecture for the Rummikub game. It describes how the Android client should communicate with the backend, where the game logic should live, and how the backend can be structured in a clean and maintainable way.
 
-- an Android frontend written in Kotlin
-- a Spring Boot backend written in Kotlin
-- shared documentation and project configuration
+## Core Architectural Idea
 
-## High-Level Structure
+The backend should be the **single source of truth** for all important gameplay state.
+
+This includes:
+
+- game state
+- turn order
+- tile distribution
+- meld validation
+- scoring
+- win detection
+- timers
+- reconnect state
+
+The Android client should mainly be responsible for:
+
+- rendering the UI
+- sending player actions and intentions
+- receiving validated game state updates
+- handling animations and user feedback
+
+This keeps all players in sync, avoids rule mismatches between clients, and prevents cheating.
+
+---
+
+## Communication Strategy
+
+The recommended communication model is a mix of **REST** and **WebSocket**.
+
+### REST for non-live features
+
+Use REST endpoints for features that are request-response based and do not require live updates.
+
+Examples:
+
+- authentication
+- user profile
+- create lobby
+- join lobby
+- leave lobby
+- start match
+- fetch match history
+- fetch leaderboard
+
+Possible example endpoints:
 
 ```text
-apps/
-  android/   # Android application
-  backend/   # Spring Boot backend
-docs/        # Project documentation
-infra/       # Infrastructure and deployment related files
+POST /api/lobbies
+POST /api/lobbies/{id}/join
+POST /api/matches/{id}/start
+GET /api/leaderboard
+GET /api/matches/{id}
 ```
 
-Frontend Responsibilities
+REST is simple, easy to test, and well suited for non-realtime interactions.
 
-The Android app is responsible for:
-• rendering the user interface
-• handling user input
-• managing screen navigation
-• displaying lobby and game state
-• communicating with the backend API
+### WebSocket for live gameplay
 
-Backend Responsibilities
+Use WebSocket for everything that happens during a running match.
 
-The backend is responsible for:
-• lobby management
-• game state management
-• player actions and validation
-• score handling
-• exposing API endpoints for the frontend
+Examples:
 
-Planned Architecture Principles
-• clear separation between frontend and backend responsibilities
-• feature-oriented frontend structure where practical
-• layered backend structure with controller, service, and DTO/domain separation
-• shared team conventions for naming, formatting, and Git workflow
+- player connected or disconnected
+- match started
+- turn changed
+- board updated
+- tile placed
+- move submitted
+- move rejected
+- timer updates
+- game ended
 
-Current Scope
+Typical flow:
 
-At the current stage, the project is in bootstrap/setup phase.
-The architecture will evolve as the first gameplay and lobby features are implemented.
+1. The client opens the match screen.
+2. The client opens a WebSocket connection.
+3. The client subscribes to the match channel.
+4. The client sends player actions.
+5. The server validates the actions.
+6. The server broadcasts the updated state to all players.
 
-Future Considerations
+This is much better than polling REST continuously for game updates.
 
-Possible future additions:
-• shared Kotlin module for common DTOs or models
-• persistent storage for scores, users, or match history
-• real-time communication for live game updates
-• deployment and hosting configuration
+---
+
+## Backend as the Authority
+
+### Why the backend should own the rules
+
+The backend should validate all actual game rules.
+
+This includes:
+
+- whether a set or run is valid
+- whether joker usage is valid
+- whether board rearrangement is legal
+- whether the first meld meets the minimum threshold
+- whether the move leaves all table groups valid
+- whether the player is allowed to end the turn
+- whether the player must draw a tile
+- whether the match is finished
+
+The client must not be trusted to decide:
+
+- that a meld is valid
+- that a player has won
+- that a score is correct
+- that a turn is over
+
+The client may perform local preview validation for better user experience, but the backend must be the final authority.
+
+### What should remain on the client
+
+The client should keep only lightweight logic for interaction and presentation.
+
+Examples:
+
+- drag and drop handling
+- visual grouping of tiles
+- local tentative arrangement before submit
+- optimistic previews if needed
+- animations and feedback
+
+When the player submits a move, the backend decides whether it is accepted.
+
+---
+
+## Recommended Backend Structure
+
+A good high-level package structure for the Spring Boot backend could look like this:
+
+```text
+apps/backend/src/main/kotlin/at/se2group/backend/
+├── common/
+├── config/
+├── auth/
+├── user/
+├── lobby/
+├── match/
+│   ├── api/
+│   ├── service/
+│   ├── domain/
+│   ├── engine/
+│   ├── dto/
+│   └── persistence/
+├── leaderboard/
+└── websocket/
+```
+
+### Layer responsibilities
+
+#### `api/`
+
+Contains REST controllers and WebSocket message handlers.
+
+Responsibilities:
+
+- receive requests
+- validate basic input shape
+- map request and response DTOs
+- call services
+- return responses or push events
+
+#### `service/`
+
+Contains application-level orchestration.
+
+Responsibilities:
+
+- start a match
+- join a match
+- submit a move
+- end a turn
+- draw a tile
+- handle reconnects
+
+#### `domain/`
+
+Contains the core game entities and value objects.
+
+Examples:
+
+- `Match`
+- `Player`
+- `Tile`
+- `TileColor`
+- `Meld`
+- `BoardGroup`
+- `TurnState`
+- `Rack`
+- `GamePhase`
+
+#### `engine/`
+
+Contains the pure game rules engine.
+
+This is one of the most important parts of the backend.
+
+Responsibilities:
+
+- validate runs and sets
+- validate the first move threshold
+- apply rearrangements
+- calculate scores
+- determine the next player
+- detect victory and game over
+
+This layer should be kept as isolated and pure as possible so it is easy to unit test.
+
+#### `persistence/`
+
+Contains repositories and persistence models.
+
+#### `dto/`
+
+Contains API request and response models, as well as WebSocket payloads.
+
+---
+
+## Key Design Principle
+
+Keep these three concerns clearly separated:
+
+- game rules
+- transport
+- persistence
+
+The Rummikub rules engine should not depend on:
+
+- HTTP
+- WebSocket
+- Spring annotations
+- database tables
+
+Instead, it should receive a game state and an action and return either:
+
+- a valid new game state
+- or a validation error
+
+This makes the game logic easier to test and much easier to maintain.
+
+---
+
+## Gameplay Flow
+
+### 1. Lobby phase
+
+Players create or join a lobby.
+
+The backend stores:
+
+- lobby ID
+- player list
+- ready states
+- host
+- settings
+
+### 2. Match start
+
+When the host starts the match:
+
+- the backend creates a shuffled tile pool
+- tiles are distributed to players
+- the first player is selected
+- the initial match state is created
+- each player receives their private rack state
+- all players receive the public match state
+
+### 3. During a turn
+
+A player may:
+
+- drag tiles locally
+- rearrange the board locally
+- prepare a move in the client
+
+When the player submits the move, the client sends the turn result to the backend.
+
+The backend then validates and applies it.
+
+### 4. On success
+
+If the move is valid, the backend:
+
+- updates the authoritative state
+- persists the new state or event
+- broadcasts the updated public state
+- sends updated private rack data to the relevant player
+- advances the turn if needed
+
+### 5. On failure
+
+If the move is invalid, the backend:
+
+- rejects the action
+- returns the reason
+- allows the client to restore the authoritative state
+
+---
+
+## How Moves Should Be Submitted
+
+There are two common strategies for submitting live game actions.
+
+### Option A: low-level tile operations
+
+Examples:
+
+- move tile X from rack position 3 to board group 2 position 1
+- move tile Y from board group 1 to board group 4
+
+Advantages:
+
+- smaller payloads
+- detailed replay possibilities
+
+Disadvantages:
+
+- harder validation
+- the server must reconstruct the full player intent step by step
+
+### Option B: submit the proposed final turn state
+
+The client sends:
+
+- the proposed final board
+- the proposed remaining rack
+
+Advantages:
+
+- much easier to validate for Rummikub
+- well suited for complex rearrangement of existing tiles
+- simpler server-side rule checking
+
+Disadvantages:
+
+- larger payloads
+
+### Recommendation
+
+For Rummikub, **Option B** is recommended.
+
+Rummikub allows complex manipulation of already placed tiles. In that case, validating the final board and rack state is usually easier and cleaner than replaying many small drag-and-drop operations one by one.
+
+The backend can then:
+
+1. compare the original state and the proposed state
+2. verify that the player only used allowed tiles
+3. validate that all resulting groups are legal
+4. validate special turn rules such as the first meld threshold
+5. accept or reject the move
+
+---
+
+## Public and Private Game State
+
+The backend should clearly separate public and private match information.
+
+### Public match state
+
+Visible to all players:
+
+- board groups
+- current turn
+- player names
+- number of tiles in each opponent rack
+- timer
+- match status
+- winner, if the game is finished
+
+### Private player state
+
+Visible only to the specific player:
+
+- exact tiles in that player's rack
+- possible personal action hints later if needed
+
+The backend must never broadcast all players' rack contents to everyone.
+
+---
+
+## Persistence Strategy
+
+### First version
+
+Keep persistence simple in the first version.
+
+Store at least:
+
+- users
+- lobbies
+- matches
+- final match results
+- current match snapshot if needed
+
+For a student project, it is usually enough to store the current match state as JSON instead of fully normalizing every tile group into many relational tables.
+
+### Later extensions
+
+Later, the backend can be extended with:
+
+- move history
+- reconnect snapshots
+- analytics
+- replay support
+
+A practical approach would be:
+
+- PostgreSQL as the database
+- standard tables for users, lobbies, and matches
+- JSON snapshot storage for current match state
+- optional match event tables later
+
+---
+
+## Concurrency and State Consistency
+
+One common problem in multiplayer games is inconsistent state when actions arrive close together.
+
+Each match should therefore be processed sequentially.
+
+For a given match:
+
+- only one move should be applied at a time
+- updates should be locked by match ID
+- stale actions should be rejected
+
+A simple approach is to store a `version` field in the match state.
+
+The client sends actions together with the expected version.
+The backend rejects the action if the state has already changed.
+
+This also helps with reconnects and duplicate requests.
+
+---
+
+## Suggested Backend Modules
+
+### Auth and User
+
+Handles:
+
+- registration and login if needed
+- guest accounts if that is simpler
+- player profile
+- display name
+
+### Lobby
+
+Handles:
+
+- create lobby
+- join lobby
+- leave lobby
+- ready state
+- game settings
+- match start
+
+### Match and Game
+
+Handles:
+
+- gameplay state
+- turn flow
+- rule validation
+- win conditions
+- timers
+
+### Leaderboard
+
+Handles:
+
+- ranking
+- statistics
+- win/loss tracking
+
+### WebSocket Gateway
+
+Handles:
+
+- live subscriptions
+- pushing updates
+- connection lifecycle
+
+---
+
+## DTO Strategy
+
+API payloads should be separated from internal domain models.
+
+Examples:
+
+- `SubmitMoveRequest`
+- `MatchStateResponse`
+- `PlayerPrivateStateResponse`
+- `LobbyResponse`
+
+Internal engine classes should not be exposed directly through the API. This keeps the transport format stable even when internal implementation changes.
+
+---
+
+## Suggested Initial REST Endpoints
+
+```text
+POST /api/lobbies
+POST /api/lobbies/{lobbyId}/join
+POST /api/lobbies/{lobbyId}/ready
+POST /api/lobbies/{lobbyId}/start
+GET /api/matches/{matchId}
+GET /api/leaderboard
+```
+
+## Suggested Initial WebSocket Messages
+
+### Client to server
+
+- `match.join`
+- `move.submit`
+- `turn.draw`
+- `turn.end`
+- `ping`
+
+### Server to client
+
+- `match.state.updated`
+- `match.player.private`
+- `match.error`
+- `match.turn.changed`
+- `match.ended`
+- `player.connected`
+- `player.disconnected`
+
+---
+
+## Validation Strategy
+
+Validation should happen in multiple layers.
+
+### Input validation
+
+Checks whether the incoming request is structurally correct.
+
+Examples:
+
+- required fields are present
+- IDs are valid
+- the player belongs to the match
+
+### State validation
+
+Checks whether the action is allowed in the current match context.
+
+Examples:
+
+- it is the player's turn
+- the match is still active
+- the request references the correct state version
+
+### Rule validation
+
+Checks whether the move is valid according to Rummikub rules.
+
+Examples:
+
+- all board groups are valid
+- the first meld threshold is satisfied
+- no tile duplication exists
+- rack and board conservation holds
+
+This separation keeps the implementation easier to understand and maintain.
+
+---
+
+## Things to Avoid
+
+The following design choices should be avoided:
+
+- putting all logic into controllers
+- trusting the client for game rule validation
+- using only REST polling for live gameplay
+- duplicating full rule logic independently on frontend and backend
+- overengineering the project as multiple microservices
+
+For this project, a **modular monolith** is the recommended approach: one Spring Boot backend with clearly separated packages and responsibilities.
+
+---
+
+## Recommended Practical Setup for This Project
+
+A practical architecture for this monorepo would be:
+
+### Android app
+
+Responsible for:
+
+- UI rendering
+- local drag-and-drop interaction
+- REST client
+- WebSocket client
+- lightweight view models and UI state handling
+
+### Spring Boot backend
+
+Responsible for:
+
+- REST controllers for lobby, profile, history, and leaderboard
+- WebSocket communication for live gameplay
+- service layer orchestration
+- pure Rummikub rules engine
+- persistence with PostgreSQL
+- JSON snapshots for current match state
+
+This setup offers:
+
+- maintainability
+- testability
+- fair multiplayer synchronization
+- clean frontend-backend integration
+
+---
+
+## Simple Rule of Thumb
+
+Use this split throughout the project:
+
+- the client decides what the player wants to do
+- the server decides whether it is allowed
+- the server publishes the new truth
+- the client renders that truth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,19 @@ Typical flow:
 
 This is much better than polling REST continuously for game updates.
 
+### Why this split works well for Rummikub
+
+Rummikub has both turn-based structure and complex in-match state changes.
+
+A split between REST and WebSocket fits this well:
+
+- REST works well for actions that create, fetch, or update stable resources such as users, lobbies, match metadata, history, and leaderboard entries
+- WebSocket works well for highly interactive game actions and rapid state updates during an active match
+- this keeps the API easier to understand because non-live operations and live gameplay are handled differently on purpose
+- it also makes frontend development easier because the Android app can use normal HTTP for setup flows and one persistent socket connection for the match itself
+
+This hybrid approach is a practical balance between simplicity and realtime capability.
+
 ---
 
 ## Backend as the Authority
@@ -139,88 +152,495 @@ A good high-level package structure for the Spring Boot backend could look like 
 ```text
 apps/backend/src/main/kotlin/at/se2group/backend/
 ├── common/
+│   ├── exception/
+│   ├── util/
+│   └── validation/
 ├── config/
 ├── auth/
 ├── user/
 ├── lobby/
+│   ├── api/
+│   ├── service/
+│   ├── dto/
+│   └── persistence/
 ├── match/
 │   ├── api/
 │   ├── service/
 │   ├── domain/
 │   ├── engine/
 │   ├── dto/
-│   └── persistence/
+│   ├── persistence/
+│   └── mapper/
 ├── leaderboard/
+│   ├── api/
+│   ├── service/
+│   ├── dto/
+│   └── persistence/
 └── websocket/
+    ├── config/
+    ├── handler/
+    └── dto/
 ```
 
 ### Layer responsibilities
 
 #### `api/`
 
-Contains REST controllers and WebSocket message handlers.
+Contains REST controllers and WebSocket entrypoints.
 
-Responsibilities:
+This layer is the outer boundary of the backend. It should deal with transport concerns, but it should not contain the actual game rules.
 
-- receive requests
-- validate basic input shape
-- map request and response DTOs
-- call services
-- return responses or push events
+Typical responsibilities:
+
+- receive HTTP requests
+- receive WebSocket messages
+- validate basic request structure
+- read path parameters, query parameters, headers, and authentication context
+- map incoming payloads into DTOs
+- call application services
+- return HTTP responses or publish outgoing socket events
+- translate domain or service errors into transport-level error responses
+
+Suggested classes:
+
+- `AuthController`
+- `UserController`
+- `LobbyController`
+- `MatchController`
+- `LeaderboardController`
+- `MatchWebSocketController` or `MatchSocketHandler`
+
+Example functionality:
+
+- `AuthController` handles guest login, logout, and current session lookup
+- `LobbyController` handles creating lobbies, joining, leaving, ready state changes, and lobby settings updates
+- `MatchController` handles fetching match metadata, public state, private state, match summary, and reconnect snapshots
+- `LeaderboardController` handles leaderboard and ranking endpoints
+- `MatchSocketHandler` handles live match messages such as `move.submit`, `turn.draw`, and `match.subscribe`
+
+Important rule:
+
+This layer should stay thin. It should coordinate request and response flow, but not decide whether a Rummikub move is valid.
 
 #### `service/`
 
-Contains application-level orchestration.
+Contains application-level orchestration and use-case logic.
 
-Responsibilities:
+This layer coordinates backend workflows. It sits between controllers and the domain or engine layer.
 
-- start a match
-- join a match
-- submit a move
-- end a turn
-- draw a tile
-- handle reconnects
+Typical responsibilities:
+
+- execute use cases such as creating lobbies or starting matches
+- load and save data through repositories
+- call the game engine when rule validation is needed
+- coordinate public and private state responses
+- enforce application-level policies such as permissions or host-only actions
+- publish WebSocket events after state changes
+- handle reconnect and recovery flows
+
+Suggested classes:
+
+- `AuthService`
+- `UserService`
+- `LobbyService`
+- `MatchService`
+- `LeaderboardService`
+- `MatchConnectionService`
+- `MatchBroadcastService`
+
+Example functionality:
+
+- `AuthService` creates guest users or authenticated sessions
+- `LobbyService` creates lobbies, manages ready states, validates whether a lobby can start, and starts the first match
+- `MatchService` loads the current match, applies actions, coordinates validation, and persists the next state
+- `MatchConnectionService` manages active socket sessions and reconnect behavior
+- `MatchBroadcastService` sends public and private socket updates to the correct players after accepted actions
+- `LeaderboardService` calculates or fetches ranking data
+
+Important note:
+
+This layer is a strong place for use-case methods such as:
+
+- `createLobby()`
+- `joinLobby()`
+- `startMatch()`
+- `submitMove()`
+- `drawTile()`
+- `endTurn()`
+- `reconnectToMatch()`
 
 #### `domain/`
 
-Contains the core game entities and value objects.
+Contains the core game concepts and value objects.
 
-Examples:
+This layer represents the business model of the game itself. It should describe what exists in the game world and what state needs to be tracked.
+
+Typical responsibilities:
+
+- represent matches, players, tiles, melds, and phases
+- model immutable or carefully controlled state transitions
+- express important game concepts in code
+- provide domain-level helper behavior when useful
+
+Suggested classes:
 
 - `Match`
 - `Player`
+- `PlayerId`
 - `Tile`
 - `TileColor`
-- `Meld`
-- `BoardGroup`
-- `TurnState`
+- `TileNumber`
+- `JokerTile`
 - `Rack`
+- `BoardGroup`
+- `Meld`
+- `TurnState`
 - `GamePhase`
+- `MatchStatus`
+- `MoveResult`
+- `MoveRejectionReason`
+
+Example functionality:
+
+- `Match` holds the current authoritative match state
+- `Rack` models the tiles currently held by a player
+- `BoardGroup` models a set or run placed on the table
+- `TurnState` tracks whose turn it is, whether a draw already happened, and similar turn-specific facts
+- `MatchStatus` distinguishes states such as waiting, active, finished, or cancelled
+
+Important guideline:
+
+The domain model should describe the game clearly. It should not contain controller annotations, database annotations unless intentionally reused, or WebSocket-specific concerns.
 
 #### `engine/`
 
-Contains the pure game rules engine.
+Contains the pure Rummikub rules engine.
 
-This is one of the most important parts of the backend.
+This layer is one of the most important parts of the backend. It should contain the actual rule validation and state transition logic for the game.
 
-Responsibilities:
+Typical responsibilities:
 
+- validate whether a board arrangement is legal
 - validate runs and sets
-- validate the first move threshold
-- apply rearrangements
-- calculate scores
-- determine the next player
-- detect victory and game over
+- validate joker placement and reuse rules
+- validate the first meld threshold
+- check tile conservation between rack, board, and pool
+- determine whether a player may end a turn
+- determine whether a player must draw
+- apply accepted moves to produce the next authoritative state
+- determine victory, game over, and score results
 
-This layer should be kept as isolated and pure as possible so it is easy to unit test.
+Suggested classes:
+
+- `RummikubRuleEngine`
+- `MoveValidator`
+- `BoardValidator`
+- `MeldValidator`
+- `JokerRuleValidator`
+- `FirstMeldValidator`
+- `TileConservationValidator`
+- `TurnResolver`
+- `ScoreCalculator`
+- `WinnerDetector`
+- `InitialDealFactory`
+
+Example functionality:
+
+- `MoveValidator` validates a submitted proposed final turn state
+- `BoardValidator` ensures that all board groups remain valid after rearrangement
+- `MeldValidator` checks whether a group forms a legal set or run
+- `FirstMeldValidator` ensures that the opening meld meets the minimum threshold
+- `TileConservationValidator` verifies that no tiles were duplicated, removed, or illegally introduced
+- `TurnResolver` determines the next active player and the next turn state
+- `ScoreCalculator` computes end-of-game scoring or ranking values
+- `InitialDealFactory` creates the shuffled tile pool and starting racks when a match begins
+
+Important guideline:
+
+This layer should be as pure as possible. It should be easy to unit test without Spring Boot, a database, or WebSocket infrastructure.
 
 #### `persistence/`
 
 Contains repositories and persistence models.
 
+This layer handles how data is stored and loaded.
+
+Typical responsibilities:
+
+- persist users, lobbies, matches, and leaderboard data
+- load the latest authoritative match snapshot
+- save match results and optional history data
+- isolate database-specific concerns from the rest of the backend
+
+Suggested classes:
+
+- `UserEntity`
+- `LobbyEntity`
+- `MatchEntity`
+- `MatchSnapshotEntity`
+- `MatchResultEntity`
+- `LeaderboardEntryEntity`
+- `UserRepository`
+- `LobbyRepository`
+- `MatchRepository`
+- `MatchSnapshotRepository`
+- `MatchResultRepository`
+
+Example functionality:
+
+- `LobbyRepository` loads and saves lobby state
+- `MatchRepository` loads the main match metadata
+- `MatchSnapshotRepository` stores the current authoritative match state, potentially as JSON
+- `MatchResultRepository` stores final game outcome data
+
+Important guideline:
+
+Persistence models should be optimized for storage and querying. They do not need to look the same as API DTOs or domain objects.
+
 #### `dto/`
 
-Contains API request and response models, as well as WebSocket payloads.
+Contains request and response shapes for REST and WebSocket communication.
+
+This layer defines the data contract between the backend and the client.
+
+Typical responsibilities:
+
+- define incoming REST request payloads
+- define outgoing REST response payloads
+- define incoming WebSocket message payloads
+- define outgoing WebSocket event payloads
+- keep transport data separate from domain and persistence models
+
+Suggested classes:
+
+- `GuestLoginRequest`
+- `UserResponse`
+- `CreateLobbyRequest`
+- `LobbyResponse`
+- `LobbySettingsResponse`
+- `MatchSummaryResponse`
+- `PublicMatchStateResponse`
+- `PrivateMatchStateResponse`
+- `LeaderboardEntryResponse`
+- `SubmitMoveMessage`
+- `MoveAcceptedEvent`
+- `MoveRejectedEvent`
+- `TurnChangedEvent`
+- `MatchEndedEvent`
+- `TileDto`
+- `BoardGroupDto`
+- `PlayerSummaryDto`
+
+Example functionality:
+
+- `SubmitMoveMessage` carries the proposed final board and rack state from the client
+- `PublicMatchStateResponse` contains the state visible to all players
+- `PrivateMatchStateResponse` contains only the rack and private information for one player
+- `MoveRejectedEvent` returns a stable error contract for invalid actions
+
+Important guideline:
+
+DTOs should be designed for communication clarity, not for internal convenience.
+
+#### `common/`
+
+Contains shared building blocks that can be reused across backend modules.
+
+This layer is useful for cross-cutting utilities and abstractions that do not belong to a single feature area.
+
+Typical responsibilities:
+
+- define shared exceptions
+- provide reusable validation helpers
+- provide common utility functions
+- define shared error models or response wrappers if needed
+- hold constants or helper types that are used across modules
+
+Suggested classes:
+
+- `ApiException`
+- `NotFoundException`
+- `ForbiddenActionException`
+- `ValidationException`
+- `ErrorCode`
+- `ApiErrorResponse`
+- `ClockProvider`
+- `IdGenerator`
+
+Example functionality:
+
+- `ApiException` and subclasses create a standard way to signal business or request errors
+- `ErrorCode` gives stable identifiers for frontend error handling
+- `ClockProvider` makes time-dependent behavior easier to test
+- `IdGenerator` can centralize ID generation strategy for lobbies and matches
+
+Important guideline:
+
+Only place code here if it is truly shared. Avoid turning `common/` into a miscellaneous dump folder.
+
+#### `config/`
+
+Contains Spring configuration classes and technical setup.
+
+This layer wires the backend together and defines infrastructure behavior.
+
+Typical responsibilities:
+
+- configure WebSocket endpoints
+- configure CORS and JSON serialization
+- configure security if authentication is added
+- configure database, environment, and application beans
+- configure message converters or interceptors
+
+Suggested classes:
+
+- `WebSocketConfig`
+- `CorsConfig`
+- `JacksonConfig`
+- `SecurityConfig`
+- `PersistenceConfig`
+- `OpenApiConfig`
+
+Example functionality:
+
+- `WebSocketConfig` registers socket endpoints and message broker behavior
+- `JacksonConfig` configures JSON serialization for Kotlin and domain-specific types
+- `SecurityConfig` can later protect endpoints and associate authenticated users with socket sessions
+- `OpenApiConfig` documents REST APIs automatically
+
+Important guideline:
+
+Configuration classes should focus on wiring and setup, not game rules or business workflows.
+
+#### `mapper/`
+
+Contains mapping logic between persistence models, domain objects, and DTOs when that mapping becomes large enough to deserve a dedicated place.
+
+This layer helps keep controllers and services cleaner when conversion logic grows.
+
+Typical responsibilities:
+
+- map entities to domain objects
+- map domain objects to DTOs
+- map request DTOs into command or domain structures
+- centralize conversion rules so response shapes remain consistent
+
+Suggested classes:
+
+- `LobbyMapper`
+- `MatchMapper`
+- `LeaderboardMapper`
+- `TileMapper`
+- `BoardGroupMapper`
+
+Example functionality:
+
+- `MatchMapper` converts an internal `Match` domain object into `PublicMatchStateResponse` and `PrivateMatchStateResponse`
+- `TileMapper` converts transport tile payloads into domain tile objects
+- `LobbyMapper` converts `LobbyEntity` or domain state into API responses
+
+Important guideline:
+
+Mapping logic should stay mechanical and predictable. Complex rules should remain in services or the rules engine, not inside mappers.
+
+### How these layers work together
+
+A useful way to think about the flow is:
+
+1. `api/` receives a request or socket message
+2. `dto/` defines the payload shape used at the boundary
+3. `service/` coordinates the use case
+4. `persistence/` loads the current stored state
+5. `domain/` and `engine/` represent and validate the game state
+6. `service/` persists the new result and decides what should be broadcast
+7. `mapper/` converts internal objects into response DTOs
+8. `api/` sends the HTTP response or WebSocket event
+
+### Example: move submission flow across layers
+
+For a submitted move, the flow could look like this:
+
+- `MatchSocketHandler` receives `SubmitMoveMessage`
+- `MatchService.submitMove()` loads the current match state
+- `MatchMapper` or a dedicated converter turns DTO payloads into domain structures
+- `RummikubRuleEngine` validates the proposed final turn state
+- if valid, `MatchService` stores the new snapshot through `MatchSnapshotRepository`
+- `MatchBroadcastService` publishes `MatchStateUpdatedEvent` and any private rack updates
+- if invalid, `MoveRejectedEvent` is returned with a stable rejection reason
+
+This example shows why the backend stays easier to understand when each layer has a focused role.
+
+## How to Model Communication
+
+The backend communication for live gameplay should use a clear request-and-authoritative-response pattern.
+
+For this project, the recommended approach is to use **Option B: send the proposed final turn state**.
+
+### Chosen approach: Option B
+
+Instead of sending many small tile movement operations one by one, the client sends the full proposed result of the turn.
+
+That means the client submits:
+
+- the proposed final board state after the player's rearrangement
+- the proposed remaining rack for that player
+- the current match or turn version for concurrency protection
+
+The backend then:
+
+1. loads the current authoritative match state
+2. compares the authoritative state with the proposed client state
+3. checks that the player only moved tiles they are allowed to use
+4. validates that all resulting groups on the table are legal
+5. validates turn-specific rules such as the first meld threshold
+6. either accepts the move and publishes the new state, or rejects it with a reason
+
+### Why Option B is preferred for Rummikub
+
+Rummikub allows players to heavily rearrange tiles that are already on the board. In such a game, reconstructing dozens of single drag operations on the server is more complicated than validating the resulting board as a whole.
+
+Option B has these advantages:
+
+- easier rule validation
+- simpler backend logic for complex rearrangements
+- clearer contract between frontend and backend
+- easier recovery after reconnects because the server always works from complete state snapshots
+
+### Recommended live communication pattern
+
+A typical move submission cycle should look like this:
+
+1. the client renders the current authoritative match state
+2. the player performs local drag-and-drop interactions only on the client
+3. the client builds a proposed final board and rack state
+4. the client sends a `move.submit` message through WebSocket
+5. the server validates the proposal against the current authoritative state
+6. the server either broadcasts the accepted updated state or sends a rejection error
+7. the client updates the UI to the latest authoritative state
+
+### Suggested payload direction
+
+Client to server:
+
+- match identifier
+- player identifier or authenticated session context
+- expected match version
+- proposed board groups
+- proposed remaining rack
+- optional metadata such as whether the player intends to end the turn
+
+Server to client on success:
+
+- updated public match state
+- updated private rack for the acting player if needed
+- next turn information
+- new state version
+
+Server to client on failure:
+
+- error code
+- human-readable reason
+- authoritative state to restore if needed
 
 ---
 
@@ -307,7 +727,7 @@ If the move is invalid, the backend:
 
 ## How Moves Should Be Submitted
 
-There are two common strategies for submitting live game actions.
+There are two common strategies for submitting live game actions, but for this project the chosen approach is **Option B**.
 
 ### Option A: low-level tile operations
 
@@ -325,6 +745,7 @@ Disadvantages:
 
 - harder validation
 - the server must reconstruct the full player intent step by step
+- not ideal for a game with heavy board rearrangement like Rummikub
 
 ### Option B: submit the proposed final turn state
 
@@ -332,30 +753,34 @@ The client sends:
 
 - the proposed final board
 - the proposed remaining rack
+- the expected match version
 
 Advantages:
 
 - much easier to validate for Rummikub
 - well suited for complex rearrangement of existing tiles
 - simpler server-side rule checking
+- easier reconnect handling because complete turn snapshots are exchanged
 
 Disadvantages:
 
 - larger payloads
 
-### Recommendation
+### Final decision
 
-For Rummikub, **Option B** is recommended.
+For Rummikub, **Option B** is the recommended and chosen approach.
 
 Rummikub allows complex manipulation of already placed tiles. In that case, validating the final board and rack state is usually easier and cleaner than replaying many small drag-and-drop operations one by one.
 
-The backend can then:
+The backend should therefore:
 
 1. compare the original state and the proposed state
 2. verify that the player only used allowed tiles
 3. validate that all resulting groups are legal
 4. validate special turn rules such as the first meld threshold
 5. accept or reject the move
+
+This keeps the communication model easier to reason about for both frontend and backend development.
 
 ---
 
@@ -506,38 +931,338 @@ Internal engine classes should not be exposed directly through the API. This kee
 
 ---
 
-## Suggested Initial REST Endpoints
+## Suggested REST Endpoints
+
+The backend should expose REST endpoints mainly for non-live features such as authentication, player profiles, lobby management, match discovery, match history, leaderboard data, and reconnect support.
+
+The endpoints below are split into two groups:
+
+- **initial endpoints** that are realistic and useful for the first version of the project
+- **later optional endpoints** that can be added if the project grows in scope
+
+### Initial REST endpoints
+
+These are the endpoints that are most relevant for the first working version of the backend.
+
+#### Authentication and session
+
+If the project starts with guest access, this area can stay very small at first.
 
 ```text
-POST /api/lobbies
-POST /api/lobbies/{lobbyId}/join
-POST /api/lobbies/{lobbyId}/ready
-POST /api/lobbies/{lobbyId}/start
-GET /api/matches/{matchId}
-GET /api/leaderboard
+POST   /api/auth/guest
+GET    /api/auth/me
+POST   /api/auth/logout
 ```
 
-## Suggested Initial WebSocket Messages
+Purpose:
 
-### Client to server
+- create a guest session for quick game access
+- fetch the currently authenticated user
+- end the current session
 
-- `match.join`
-- `move.submit`
-- `turn.draw`
-- `turn.end`
-- `ping`
+#### User and profile
 
-### Server to client
+```text
+GET    /api/users/{userId}
+PATCH  /api/users/{userId}
+GET    /api/users/{userId}/stats
+GET    /api/users/{userId}/matches
+```
 
-- `match.state.updated`
-- `match.player.private`
-- `match.error`
-- `match.turn.changed`
-- `match.ended`
-- `player.connected`
-- `player.disconnected`
+Purpose:
 
----
+- fetch a user profile
+- update display name or simple profile fields
+- fetch player statistics
+- fetch a player's played matches
+
+#### Lobby management
+
+```text
+POST   /api/lobbies
+GET    /api/lobbies
+GET    /api/lobbies/{lobbyId}
+POST   /api/lobbies/{lobbyId}/join
+POST   /api/lobbies/{lobbyId}/leave
+POST   /api/lobbies/{lobbyId}/ready
+POST   /api/lobbies/{lobbyId}/unready
+PATCH  /api/lobbies/{lobbyId}/settings
+POST   /api/lobbies/{lobbyId}/start
+DELETE /api/lobbies/{lobbyId}
+```
+
+Purpose:
+
+- create a lobby
+- list open or joinable lobbies
+- fetch the current lobby state
+- join a lobby
+- leave a lobby
+- mark a player as ready
+- remove ready status
+- change lobby settings such as player limit or match options
+- start the match from the lobby
+- delete or close a lobby, usually by the host
+
+#### Match metadata, state, and recovery
+
+Even though live gameplay uses WebSocket, REST should still provide reliable state fetch and reconnect support.
+
+```text
+GET    /api/matches/{matchId}
+GET    /api/matches/{matchId}/summary
+GET    /api/matches/{matchId}/players
+GET    /api/matches/{matchId}/state
+GET    /api/matches/{matchId}/private-state
+GET    /api/matches/{matchId}/result
+GET    /api/matches/{matchId}/reconnect
+```
+
+Purpose:
+
+- fetch general match information
+- fetch a summary suitable for match overview screens
+- fetch player participation details
+- fetch the current authoritative public match state
+- fetch the current private state for the requesting player
+- fetch the final result of a finished match
+- recover the latest match snapshot for reconnect scenarios
+
+#### Leaderboard
+
+```text
+GET    /api/leaderboard
+GET    /api/leaderboard/{userId}/position
+```
+
+Purpose:
+
+- fetch the default leaderboard
+- fetch the ranking position for a specific player
+
+#### Development and health
+
+```text
+GET    /api/health
+GET    /api/info
+POST   /api/dev/seed
+POST   /api/dev/reset
+```
+
+Purpose:
+
+- basic backend health check
+- application info endpoint if needed
+- seed development data for easier testing
+- reset development data in non-production environments
+
+### Later optional REST endpoints
+
+These endpoints are not required for the first version, but they are useful if the backend grows in functionality.
+
+#### Full authentication
+
+```text
+POST   /api/auth/register
+POST   /api/auth/login
+POST   /api/auth/refresh
+```
+
+#### Additional profile and progression features
+
+```text
+GET    /api/users/{userId}/achievements
+GET    /api/users/{userId}/friends
+```
+
+#### Invitations and social features
+
+```text
+POST   /api/lobbies/{lobbyId}/invites
+GET    /api/invites
+POST   /api/invites/{inviteId}/accept
+POST   /api/invites/{inviteId}/decline
+GET    /api/friends
+POST   /api/friends/{userId}
+DELETE /api/friends/{userId}
+```
+
+#### Extended match history and replay support
+
+```text
+GET    /api/matches/{matchId}/history
+GET    /api/matches/{matchId}/events
+POST   /api/matches/{matchId}/connect
+POST   /api/matches/{matchId}/disconnect
+```
+
+#### Alternative leaderboard views
+
+```text
+GET    /api/leaderboard/global
+GET    /api/leaderboard/seasonal
+GET    /api/leaderboard/friends
+```
+
+### Core product flow covered by the initial REST endpoints
+
+The initial REST endpoints together cover this rough product flow:
+
+1. enter the app using a guest session
+2. fetch the current user profile
+3. browse or create a lobby
+4. join or leave a lobby
+5. mark ready and change lobby settings
+6. start a match
+7. fetch match metadata and recover state if reconnect is needed
+8. fetch leaderboard and profile statistics
+
+This is enough to support the non-live parts of the first playable version of the game.
+
+## Suggested WebSocket Messages
+
+WebSocket communication should cover the full live match experience.
+
+The messages below are also split into two groups:
+
+- **initial messages** for the first working realtime version
+- **later optional messages** for richer features
+
+### Initial WebSocket messages
+
+These are the most important messages for a first playable multiplayer version.
+
+#### Client to server
+
+```text
+match.connect
+match.disconnect
+match.subscribe
+match.unsubscribe
+move.submit
+turn.draw
+turn.end
+ping
+```
+
+Purpose:
+
+- connect the player to a specific running match
+- disconnect cleanly if needed
+- subscribe to live match updates
+- unsubscribe when leaving the match screen
+- submit the proposed final state of a turn
+- draw a tile when no valid move is played or when required
+- explicitly end a turn if that is modeled separately
+- keep the socket alive or measure latency
+
+#### Server to client
+
+```text
+match.connected
+match.disconnected
+match.subscribed
+match.unsubscribed
+match.state.updated
+match.player.private
+match.turn.changed
+match.move.accepted
+match.move.rejected
+match.tile.drawn
+match.ended
+player.connected
+player.disconnected
+error
+pong
+```
+
+Purpose:
+
+- confirm that a match connection was accepted
+- confirm that the player disconnected
+- confirm that the client subscribed to match updates
+- confirm that the client unsubscribed
+- publish the latest authoritative public match state
+- send updated private rack or private player data
+- notify clients that the active turn changed
+- confirm that a submitted move was accepted
+- reject a move and explain why
+- notify the acting player that a draw was performed
+- notify all players that the match ended
+- notify that another player connected
+- notify that another player disconnected
+- deliver generic socket-level or domain-level errors
+- respond to client ping messages
+
+### Recommended initial live flow
+
+A typical realtime match flow should look like this:
+
+1. the client opens the match screen
+2. the client sends `match.connect`
+3. the client sends `match.subscribe`
+4. the server responds with `match.connected`, `match.subscribed`, and the latest state
+5. the player performs local actions on the client
+6. the client sends `move.submit` with the proposed final turn state
+7. the server validates the move
+8. on success, the server sends `match.move.accepted`, `match.state.updated`, and any needed private updates
+9. on failure, the server sends `match.move.rejected` and, if needed, authoritative state to restore
+10. when the turn changes, the server sends `match.turn.changed`
+11. when the match ends, the server sends `match.ended`
+
+### Example responsibility split for a submitted move
+
+When a player submits a move:
+
+- the client is responsible for sending the proposed final state of the turn
+- the server is responsible for validating whether the move is legal
+- the server is responsible for publishing the accepted new authoritative state
+- the client is responsible for rendering that authoritative state exactly as received
+
+### Later optional WebSocket messages
+
+These messages can be added if the project later supports richer interaction.
+
+#### Client to server
+
+```text
+match.reconnect
+match.request.state
+chat.send
+emote.send
+presence.update
+```
+
+#### Server to client
+
+```text
+match.reconnected
+match.state.snapshot
+chat.received
+emote.received
+presence.updated
+timer.updated
+```
+
+Possible later use cases:
+
+- explicit reconnect commands
+- on-demand state snapshots
+- match chat or reactions
+- richer presence updates
+- separate timer push events
+
+### Important guideline
+
+WebSocket messages should be represented with dedicated DTOs just like REST requests and responses.
+
+That means:
+
+- incoming client messages should map to request-style DTOs
+- outgoing server events should map to event or response DTOs
+- domain objects should not be sent directly over the socket
+
+This keeps the live protocol stable and easier to evolve.
 
 ## Validation Strategy
 
@@ -624,6 +1349,8 @@ This setup offers:
 - fair multiplayer synchronization
 - clean frontend-backend integration
 
+The most important implementation guideline is that the client should never be treated as the final authority for rules or state transitions. The client proposes, but the backend decides.
+
 ---
 
 ## Simple Rule of Thumb
@@ -631,6 +1358,7 @@ This setup offers:
 Use this split throughout the project:
 
 - the client decides what the player wants to do
+- the client sends a proposed final turn state
 - the server decides whether it is allowed
-- the server publishes the new truth
+- the server publishes the new authoritative truth
 - the client renders that truth

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -872,8 +872,9 @@ This also helps with reconnects and duplicate requests.
 
 Handles:
 
-- registration and login if needed
+- registration and login if needed later
 - guest accounts if that is simpler
+- anonymous guest identity with locally stored UUID for the first version
 - player profile
 - display name
 
@@ -920,14 +921,173 @@ Handles:
 
 API payloads should be separated from internal domain models.
 
+### What DTO means
+
+DTO stands for **Data Transfer Object**.
+
+A DTO is a class or data structure that is used only to transfer data between parts of the system, especially:
+
+- between the backend and the Android client
+- between REST controllers and service methods
+- between WebSocket handlers and the rest of the backend
+
+A DTO is not the same thing as a domain model or persistence entity.
+
+### What DTOs are used for
+
+DTOs define the exact shape of data that is sent or received.
+
+They are useful for:
+
+- request bodies coming from the client
+- response bodies sent back to the client
+- WebSocket messages
+- internal transport between layers when needed
+
 Examples:
 
+- `CreateLobbyRequest`
+- `LobbyResponse`
 - `SubmitMoveRequest`
 - `MatchStateResponse`
 - `PlayerPrivateStateResponse`
-- `LobbyResponse`
+- `LeaderboardEntryResponse`
+- `MoveRejectedEvent`
 
-Internal engine classes should not be exposed directly through the API. This keeps the transport format stable even when internal implementation changes.
+### Why DTOs are important
+
+DTOs are important because they create a clean boundary between the API and the internal backend logic.
+
+This helps because:
+
+- the API format stays stable even if internal classes change
+- the backend does not expose internal implementation details by accident
+- request and response validation becomes easier
+- frontend and backend teams have a clear contract to work against
+- sensitive or unnecessary fields can be excluded from API responses
+
+### DTOs versus domain models
+
+A **domain model** represents the actual business concepts and rules inside the application.
+
+Examples:
+
+- `Match`
+- `Player`
+- `Tile`
+- `BoardGroup`
+
+A **DTO** represents how data is exchanged with the outside world.
+
+For example:
+
+- the internal `Match` domain model may contain technical fields, helper methods, and rule-related state
+- the external `MatchStateResponse` DTO should only contain the data the client actually needs to render the current state
+
+That means a DTO should be designed for communication, while a domain model should be designed for business logic.
+
+### DTOs versus persistence entities
+
+A persistence entity is designed for database storage.
+
+For example, a database entity might include:
+
+- primary keys
+- foreign keys
+- timestamps
+- persistence annotations
+- internal storage-specific structure
+
+Those details should usually not be sent directly to the client.
+
+DTOs prevent the API from becoming tightly coupled to the database design.
+
+### Practical DTO usage in this project
+
+For this Rummikub backend, DTOs should be used in at least these places:
+
+#### REST request DTOs
+
+Used for data coming into the backend.
+
+Examples:
+
+- `CreateLobbyRequest`
+- `UpdateLobbySettingsRequest`
+- `GuestLoginRequest`
+
+#### REST response DTOs
+
+Used for data returned to the Android app.
+
+Examples:
+
+- `LobbyResponse`
+- `MatchSummaryResponse`
+- `LeaderboardResponse`
+
+#### WebSocket incoming message DTOs
+
+Used for live messages sent by the client.
+
+Examples:
+
+- `JoinMatchMessage`
+- `SubmitMoveMessage`
+- `EndTurnMessage`
+
+#### WebSocket outgoing message DTOs
+
+Used for live messages sent by the backend.
+
+Examples:
+
+- `MatchStateUpdatedEvent`
+- `PrivateRackUpdatedEvent`
+- `MoveRejectedEvent`
+- `TurnChangedEvent`
+
+### Example
+
+A client might send a move using a DTO like this:
+
+```kotlin
+data class SubmitMoveRequest(
+    val matchId: String,
+    val expectedVersion: Long,
+    val proposedBoardGroups: List<BoardGroupDto>,
+    val proposedRackTiles: List<TileDto>,
+    val endTurn: Boolean
+)
+```
+
+The backend may then convert that DTO into internal domain objects and pass them into the game engine.
+
+After validation, the backend might send back a DTO like:
+
+```kotlin
+data class MatchStateResponse(
+    val matchId: String,
+    val version: Long,
+    val currentPlayerId: String,
+    val boardGroups: List<BoardGroupDto>,
+    val players: List<PlayerSummaryDto>,
+    val gameStatus: String
+)
+```
+
+### Important guideline
+
+Internal engine classes should not be exposed directly through the API.
+
+The recommended flow is:
+
+- controllers or WebSocket handlers receive DTOs
+- services map DTOs into domain objects
+- the game engine works with domain objects
+- the backend maps results back into DTOs before returning them
+
+This keeps the transport format stable even when internal implementation changes.
 
 ---
 
@@ -946,7 +1106,7 @@ These are the endpoints that are most relevant for the first working version of 
 
 #### Authentication and session
 
-If the project starts with guest access, this area can stay very small at first.
+For the first version of the project, the recommended approach is **anonymous guest users with a generated UUID stored locally on the device**. This keeps player identities simple without requiring passwords or a complex authentication flow.
 
 ```text
 POST   /api/auth/guest
@@ -959,6 +1119,16 @@ Purpose:
 - create a guest session for quick game access
 - fetch the currently authenticated user
 - end the current session
+
+Recommended first-version identity model:
+
+- create a guest user on first app launch
+- generate a stable unique user ID for that player
+- store the ID locally on the device
+- let the player choose a display name
+- use that guest identity for lobbies, matches, leaderboard entries, and player statistics
+
+This gives the project lightweight player identities without introducing password management, email verification, or full account recovery complexity.
 
 #### User and profile
 
@@ -1341,6 +1511,7 @@ Responsible for:
 - pure Rummikub rules engine
 - persistence with PostgreSQL
 - JSON snapshots for current match state
+- simple guest-user identity support without password-based authentication
 
 This setup offers:
 
@@ -1354,6 +1525,8 @@ The most important implementation guideline is that the client should never be t
 ---
 
 ## Simple Rule of Thumb
+
+For the first version of the game, player identity should be lightweight: create a guest player once, store their generated ID locally, and reuse it across sessions on the same device.
 
 Use this split throughout the project:
 

--- a/docs/lobby-architecture-proposal.md
+++ b/docs/lobby-architecture-proposal.md
@@ -26,12 +26,12 @@ A mock design or wireframe for the lobby feature can be placed here for visual r
 <table>
   <tr>
     <td align="center">
-<img width="728" height="1564" alt="image" src="https://github.com/user-attachments/assets/846b8647-fc81-453b-a85f-94568d3a7e72" />
+<img width="702" height="1616" alt="image" src="https://github.com/user-attachments/assets/c92a5e14-181d-48fe-99a4-4d3e79b91a75" />
       <sub>Lobby screen</sub>
     </td>
     <td align="center">
-<img width="706" height="1572" alt="image" src="https://github.com/user-attachments/assets/cc9a440c-8917-432b-b364-c02abd51ecc8" />
-      <sub>Match screen</sub>
+<img width="674" height="1546" alt="image" src="https://github.com/user-attachments/assets/7d2c5a9f-a5d0-4a97-a66e-9d5c313deb71" />
+      <sub>Lobby list screen</sub>
     </td>
   </tr>
 </table>

--- a/docs/lobby-architecture-proposal.md
+++ b/docs/lobby-architecture-proposal.md
@@ -23,9 +23,10 @@ The goal is to keep the lobby simple, reliable, and easy to extend.
 
 A mock design or wireframe for the lobby feature can be placed here for visual reference during implementation.
 
-![Lobby Mock Design](./images/lobby-mock-design.png)
+<img width="728" height="1564" alt="image" src="https://github.com/user-attachments/assets/846b8647-fc81-453b-a85f-94568d3a7e72" />
 
-> Replace the image path above with the correct file path once the mock design asset is added to the repository.
+<img width="706" height="1572" alt="image" src="https://github.com/user-attachments/assets/cc9a440c-8917-432b-b364-c02abd51ecc8" />
+
 
 This section should help align backend and frontend implementation with the intended user flow and screen structure.
 
@@ -44,8 +45,8 @@ It should support at least these actions:
 - leave a lobby
 - mark a player as ready
 - mark a player as unready
-- update lobby settings
-- start a match
+- update lobby settings - only for host
+- start a match - only for host
 - broadcast lobby changes to connected clients
 
 The lobby should **not** contain actual game logic for Rummikub turns, board validation, or scoring. Once a game starts, responsibility moves to the match or game module.
@@ -54,6 +55,8 @@ A useful rule of thumb is:
 
 - **Lobby = waiting room**
 - **Match = actual game**
+
+_note: perhaps dont distinguish between lobby and match - use the same for everything -> lobby = match_
 
 ---
 
@@ -90,6 +93,129 @@ lobby/
 ```
 
 This keeps the lobby feature separated from the match feature and makes it easier to evolve later.
+
+---
+
+### Suggested frontend feature structure
+
+The Android app should mirror the same separation conceptually, even if the exact package structure differs.
+
+A clean frontend structure for the lobby feature could look like this:
+
+```text
+apps/android/.../lobby/
+├── api/
+│   ├── LobbyApiService.kt
+│   ├── dto/
+│   │   ├── CreateLobbyRequestDto.kt
+│   │   ├── JoinLobbyRequestDto.kt
+│   │   ├── UpdateLobbySettingsRequestDto.kt
+│   │   ├── LobbyResponseDto.kt
+│   │   ├── LobbyListItemResponseDto.kt
+│   │   └── LobbyEventDto.kt
+├── data/
+│   ├── LobbyRepository.kt
+│   ├── LobbyRepositoryImpl.kt
+│   └── mapper/
+├── model/
+│   ├── LobbyUiModel.kt
+│   ├── LobbyPlayerUiModel.kt
+│   ├── LobbySettingsUiModel.kt
+│   └── LobbyStatusUiModel.kt
+├── websocket/
+│   ├── LobbySocketClient.kt
+│   └── LobbyEventHandler.kt
+├── presentation/
+│   ├── LobbyListViewModel.kt
+│   ├── LobbyDetailViewModel.kt
+│   ├── CreateLobbyViewModel.kt
+│   ├── LobbyListScreen.kt
+│   ├── LobbyDetailScreen.kt
+│   ├── CreateLobbyScreen.kt
+│   └── components/
+└── navigation/
+    └── LobbyNavigation.kt
+```
+
+### Frontend responsibilities by layer
+
+#### `api/`
+
+Contains the HTTP service definitions and network DTOs used to communicate with the backend.
+
+Responsibilities:
+
+- define Retrofit or HTTP endpoints for lobby actions
+- define request and response DTOs matching the backend contract
+- keep transport models separate from UI models
+
+#### `data/`
+
+Contains the repository and mapping logic that coordinates REST calls and WebSocket events.
+
+Responsibilities:
+
+- call lobby REST endpoints
+- subscribe to lobby WebSocket events
+- map API DTOs into frontend models
+- expose a clean interface to ViewModels
+
+#### `model/`
+
+Contains the models that the UI actually consumes.
+
+Responsibilities:
+
+- represent lobby state in a frontend-friendly shape
+- keep UI concerns separate from raw network payloads
+- hold data used directly by screens and state containers
+
+#### `websocket/`
+
+Contains the socket client and event handling logic for live lobby updates.
+
+Responsibilities:
+
+- connect and subscribe to lobby topics
+- parse lobby event payloads
+- notify repository or ViewModels about updates
+- handle reconnect and resubscribe behavior
+
+#### `presentation/`
+
+Contains ViewModels, screens, and reusable UI components.
+
+Responsibilities:
+
+- manage screen state
+- call repository methods for user actions
+- expose loading, error, and content state to the UI
+- render lobby list, create lobby, and lobby detail flows
+
+#### `navigation/`
+
+Contains the routes and navigation wiring for the lobby flow.
+
+Responsibilities:
+
+- define lobby-related destinations
+- pass required arguments such as `lobbyId`
+- connect lobby screens to the rest of the app flow
+
+### Frontend data model guidance
+
+Even in a shared monorepo, the frontend should **not** directly reuse backend persistence entities.
+
+Recommended separation:
+
+- backend entities -> database and persistence only
+- backend DTOs -> API contract
+- frontend DTOs -> network transport models
+- frontend UI models -> screen and ViewModel state
+
+If duplication later becomes annoying, a small shared **API contract** module can be introduced for request and response shapes only. However, backend JPA entities and internal backend domain models should not be shared with the Android app.
+
+This keeps the frontend decoupled from backend persistence concerns and makes both sides easier to evolve independently.
 
 ---
 
@@ -155,6 +281,8 @@ data class LobbyPlayer(
 )
 ```
 
+_note: only arbitrary settings for now - discuss what settings would be useful_
+
 ### `LobbySettings`
 
 ```kotlin
@@ -189,6 +317,9 @@ data class Lobby(
 ## DTOs
 
 DTOs define the API contract between the backend and the client.
+
+For this project, DTOs should still exist even though the backend and frontend live in the same monorepo. The frontend should not directly depend on backend persistence entities or backend-internal domain models. At most, only stable API contract models should ever be shared, while JPA entities and backend implementation models should remain backend-only.
+
 
 ### Requests
 
@@ -637,7 +768,8 @@ class LobbyService(
 ) {
 
     fun createLobby(hostUserId: String, request: CreateLobbyRequest): Lobby {
-        require(request.maxPlayers >= 2) { "maxPlayers must be at least 2" }
+        // evtl. falsch
+        //require(request.maxPlayers >= 2) { "maxPlayers must be at least 2" }
 
         val lobby = Lobby(
             lobbyId = UUID.randomUUID().toString(),
@@ -952,6 +1084,25 @@ Possible event types:
 
 This is enough for a first version. You do not need many more event types unless the feature becomes more advanced.
 
+### Disconnect and reconnect behavior
+
+If a client disconnects from the lobby WebSocket subscription, this should **not** automatically remove the player from the lobby.
+
+For the first version, lobby membership should only change through explicit REST endpoints such as:
+
+- `POST /api/lobbies/{lobbyId}/leave`
+- `DELETE /api/lobbies/{lobbyId}`
+
+A temporary socket disconnect should be treated as a lost live connection, not as a lobby leave.
+
+When the client reconnects, it should:
+
+1. reconnect the WebSocket connection
+2. resubscribe to `/topic/lobbies/{lobbyId}`
+3. refetch `GET /api/lobbies/{lobbyId}` once to restore the latest authoritative state
+
+This keeps the first-version lobby behavior simple and avoids incorrectly removing players because of short network interruptions.
+
 ---
 
 ## Error handling recommendations
@@ -1085,7 +1236,7 @@ The backend lobby feature should be implemented in a layered order so that plann
 
 ### Best implementation order
 
-#### Phase 0: Planning
+#### Phase 0: Planning (Can be split up and assigned to other phases when actually needed)
 
 1. `docs(backend)(lobby): plan lobby architecture and implementation`
 
@@ -1155,16 +1306,7 @@ These issues verify service rules, REST integration, and live update behavior.
 
 This issue should be completed last so the documentation reflects the final implementation and not just the planned structure.
 
-### Why this order is recommended
-
-This order minimizes rework and follows the real dependency structure of the backend:
-
-- planning should happen first so the implementation has a clear direction
-- domain models, DTOs, and mappers should exist before persistence and service work
-- persistence should exist before service logic depends on it
-- service logic should be complete before exposing the REST controller
-- live updates should come after the underlying state transitions already work
-- error handling, match handoff, testing, and final documentation are most effective once the feature is largely stable
+---
 
 ### Simple dependency chain
 

--- a/docs/lobby-architecture-proposal.md
+++ b/docs/lobby-architecture-proposal.md
@@ -23,9 +23,20 @@ The goal is to keep the lobby simple, reliable, and easy to extend.
 
 A mock design or wireframe for the lobby feature can be placed here for visual reference during implementation.
 
+<table>
+  <tr>
+    <td align="center">
 <img width="728" height="1564" alt="image" src="https://github.com/user-attachments/assets/846b8647-fc81-453b-a85f-94568d3a7e72" />
-
+      <sub>Lobby screen</sub>
+    </td>
+    <td align="center">
 <img width="706" height="1572" alt="image" src="https://github.com/user-attachments/assets/cc9a440c-8917-432b-b364-c02abd51ecc8" />
+      <sub>Match screen</sub>
+    </td>
+  </tr>
+</table>
+
+
 
 
 This section should help align backend and frontend implementation with the intended user flow and screen structure.

--- a/docs/lobby-architecture-proposal.md
+++ b/docs/lobby-architecture-proposal.md
@@ -1,0 +1,1335 @@
+# Lobby Architecture and Implementation Plan
+
+## Purpose
+
+This document describes the full lobby architecture for the Rummikub backend and gives a practical implementation plan from start to finish. It includes:
+
+- the role of the lobby in the overall system
+- recommended backend structure
+- domain model and rules
+- REST endpoints
+- WebSocket events for live lobby updates
+- DTOs
+- persistence design
+- service responsibilities
+- code examples for a first implementation
+- the recommended next steps for turning the first version into a cleaner architecture
+
+The goal is to keep the lobby simple, reliable, and easy to extend.
+
+---
+
+## Mock Design Reference
+
+A mock design or wireframe for the lobby feature can be placed here for visual reference during implementation.
+
+![Lobby Mock Design](./images/lobby-mock-design.png)
+
+> Replace the image path above with the correct file path once the mock design asset is added to the repository.
+
+This section should help align backend and frontend implementation with the intended user flow and screen structure.
+
+---
+
+## What the lobby is responsible for
+
+The lobby is the waiting room before a match starts.
+
+It should support at least these actions:
+
+- create a lobby
+- fetch a lobby by ID
+- list open lobbies
+- join a lobby
+- leave a lobby
+- mark a player as ready
+- mark a player as unready
+- update lobby settings
+- start a match
+- broadcast lobby changes to connected clients
+
+The lobby should **not** contain actual game logic for Rummikub turns, board validation, or scoring. Once a game starts, responsibility moves to the match or game module.
+
+A useful rule of thumb is:
+
+- **Lobby = waiting room**
+- **Match = actual game**
+
+---
+
+## High-level architecture
+
+A clean first version can use these backend parts:
+
+```text
+lobby/
+├── api/
+│   └── LobbyController.kt
+├── service/
+│   ├── LobbyService.kt
+│   └── LobbyBroadcastService.kt
+├── domain/
+│   ├── Lobby.kt
+│   ├── LobbyPlayer.kt
+│   ├── LobbySettings.kt
+│   └── LobbyStatus.kt
+├── dto/
+│   ├── CreateLobbyRequest.kt
+│   ├── JoinLobbyRequest.kt
+│   ├── UpdateLobbySettingsRequest.kt
+│   ├── LobbyResponse.kt
+│   ├── LobbyPlayerResponse.kt
+│   ├── LobbyListItemResponse.kt
+│   └── LobbyEvent.kt
+├── persistence/
+│   ├── LobbyEntity.kt
+│   ├── LobbyPlayerEmbeddable.kt
+│   └── LobbyRepository.kt
+└── mapper/
+    └── LobbyMapper.kt
+```
+
+This keeps the lobby feature separated from the match feature and makes it easier to evolve later.
+
+---
+
+## Main lobby rules
+
+The service layer should enforce these rules.
+
+### General rules
+
+- a lobby can only be joined when its status is `OPEN`
+- a lobby cannot exceed its maximum player count
+- the same player cannot join the same lobby twice
+- only players inside the lobby can ready or unready themselves
+- only the host can update settings
+- only the host can start the match
+- a match can only start if enough players joined
+- a match can only start if all players are ready
+
+### Suggested first-version rules
+
+These are practical defaults for the first version:
+
+- minimum players to start: `2`
+- maximum players: configurable, default `4`
+- lobby status values:
+    - `OPEN`
+    - `IN_GAME`
+    - `CLOSED`
+- all players must be ready before the host can start
+- if the host leaves, host ownership transfers to the oldest remaining player
+- if the last player leaves, the lobby is deleted or marked closed
+
+---
+
+## Domain model
+
+The domain model should describe the lobby clearly.
+
+### `LobbyStatus`
+
+```kotlin
+package at.se2group.backend.lobby.domain
+
+enum class LobbyStatus {
+    OPEN,
+    IN_GAME,
+    CLOSED
+}
+```
+
+### `LobbyPlayer`
+
+```kotlin
+package at.se2group.backend.lobby.domain
+
+import java.time.Instant
+
+data class LobbyPlayer(
+    val userId: String,
+    val displayName: String,
+    val isReady: Boolean = false,
+    val joinedAt: Instant = Instant.now()
+)
+```
+
+### `LobbySettings`
+
+```kotlin
+package at.se2group.backend.lobby.domain
+
+data class LobbySettings(
+    val maxPlayers: Int = 4,
+    val isPrivate: Boolean = false,
+    val allowGuests: Boolean = true
+)
+```
+
+### `Lobby`
+
+```kotlin
+package at.se2group.backend.lobby.domain
+
+import java.time.Instant
+
+data class Lobby(
+    val lobbyId: String,
+    val hostUserId: String,
+    val players: List<LobbyPlayer>,
+    val status: LobbyStatus = LobbyStatus.OPEN,
+    val settings: LobbySettings = LobbySettings(),
+    val createdAt: Instant = Instant.now()
+)
+```
+
+---
+
+## DTOs
+
+DTOs define the API contract between the backend and the client.
+
+### Requests
+
+```kotlin
+package at.se2group.backend.lobby.dto
+
+data class CreateLobbyRequest(
+    val displayName: String,
+    val maxPlayers: Int = 4,
+    val isPrivate: Boolean = false,
+    val allowGuests: Boolean = true
+)
+
+data class JoinLobbyRequest(
+    val userId: String,
+    val displayName: String
+)
+
+data class UpdateLobbySettingsRequest(
+    val maxPlayers: Int,
+    val isPrivate: Boolean,
+    val allowGuests: Boolean
+)
+```
+
+### Responses
+
+```kotlin
+package at.se2group.backend.lobby.dto
+
+data class LobbyPlayerResponse(
+    val userId: String,
+    val displayName: String,
+    val isReady: Boolean
+)
+
+data class LobbyResponse(
+    val lobbyId: String,
+    val hostUserId: String,
+    val status: String,
+    val maxPlayers: Int,
+    val isPrivate: Boolean,
+    val allowGuests: Boolean,
+    val players: List<LobbyPlayerResponse>
+)
+
+data class LobbyListItemResponse(
+    val lobbyId: String,
+    val hostUserId: String,
+    val status: String,
+    val currentPlayerCount: Int,
+    val maxPlayers: Int,
+    val isPrivate: Boolean
+)
+```
+
+### WebSocket event payloads
+
+```kotlin
+package at.se2group.backend.lobby.dto
+
+data class LobbyUpdatedEvent(
+    val type: String = "lobby.updated",
+    val lobby: LobbyResponse
+)
+
+data class LobbyDeletedEvent(
+    val type: String = "lobby.deleted",
+    val lobbyId: String
+)
+
+data class LobbyStartedEvent(
+    val type: String = "lobby.started",
+    val lobbyId: String,
+    val matchId: String
+)
+```
+
+---
+
+## Mapper helpers
+
+It is useful to convert domain objects into response DTOs in one place.
+
+```kotlin
+package at.se2group.backend.lobby.mapper
+
+import at.se2group.backend.lobby.domain.Lobby
+import at.se2group.backend.lobby.dto.LobbyListItemResponse
+import at.se2group.backend.lobby.dto.LobbyPlayerResponse
+import at.se2group.backend.lobby.dto.LobbyResponse
+
+fun Lobby.toResponse(): LobbyResponse =
+    LobbyResponse(
+        lobbyId = lobbyId,
+        hostUserId = hostUserId,
+        status = status.name,
+        maxPlayers = settings.maxPlayers,
+        isPrivate = settings.isPrivate,
+        allowGuests = settings.allowGuests,
+        players = players.map {
+            LobbyPlayerResponse(
+                userId = it.userId,
+                displayName = it.displayName,
+                isReady = it.isReady
+            )
+        }
+    )
+
+fun Lobby.toListItemResponse(): LobbyListItemResponse =
+    LobbyListItemResponse(
+        lobbyId = lobbyId,
+        hostUserId = hostUserId,
+        status = status.name,
+        currentPlayerCount = players.size,
+        maxPlayers = settings.maxPlayers,
+        isPrivate = settings.isPrivate
+    )
+```
+
+---
+
+## REST API design
+
+The lobby should mainly use REST for lobby mutations and retrieval.
+
+### Recommended endpoints
+
+```text
+POST   /api/lobbies
+GET    /api/lobbies
+GET    /api/lobbies/{lobbyId}
+POST   /api/lobbies/{lobbyId}/join
+POST   /api/lobbies/{lobbyId}/leave
+POST   /api/lobbies/{lobbyId}/ready
+POST   /api/lobbies/{lobbyId}/unready
+PATCH  /api/lobbies/{lobbyId}/settings
+POST   /api/lobbies/{lobbyId}/start
+DELETE /api/lobbies/{lobbyId}
+```
+
+### Responsibility of each endpoint
+
+- `POST /api/lobbies` creates a new lobby and adds the host as the first player
+- `GET /api/lobbies` lists open lobbies for browse or join screens
+- `GET /api/lobbies/{lobbyId}` fetches a specific lobby state
+- `POST /api/lobbies/{lobbyId}/join` adds a player to the lobby
+- `POST /api/lobbies/{lobbyId}/leave` removes a player from the lobby
+- `POST /api/lobbies/{lobbyId}/ready` marks the calling player as ready
+- `POST /api/lobbies/{lobbyId}/unready` removes ready state
+- `PATCH /api/lobbies/{lobbyId}/settings` updates lobby settings, host only
+- `POST /api/lobbies/{lobbyId}/start` starts the match, host only
+- `DELETE /api/lobbies/{lobbyId}` closes the lobby, host only
+
+---
+
+## Persistence design
+
+The first sample implementation used an in-memory `ConcurrentHashMap`. That is fine for a prototype, but the next step should be a repository-backed implementation.
+
+### Suggested persistence approach
+
+A practical first database design is:
+
+- one `LobbyEntity`
+- embedded or child player rows for `LobbyPlayer`
+- columns for host, status, and settings
+
+You can keep this fairly simple.
+
+### Example JPA persistence classes
+
+#### `LobbyPlayerEmbeddable`
+
+```kotlin
+package at.se2group.backend.lobby.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.time.Instant
+
+@Embeddable
+data class LobbyPlayerEmbeddable(
+    @Column(name = "user_id")
+    var userId: String = "",
+
+    @Column(name = "display_name")
+    var displayName: String = "",
+
+    @Column(name = "is_ready")
+    var isReady: Boolean = false,
+
+    @Column(name = "joined_at")
+    var joinedAt: Instant = Instant.now()
+)
+```
+
+#### `LobbyEntity`
+
+```kotlin
+package at.se2group.backend.lobby.persistence
+
+import at.se2group.backend.lobby.domain.LobbyStatus
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "lobbies")
+class LobbyEntity(
+    @Id
+    @Column(name = "lobby_id")
+    var lobbyId: String = "",
+
+    @Column(name = "host_user_id", nullable = false)
+    var hostUserId: String = "",
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: LobbyStatus = LobbyStatus.OPEN,
+
+    @Column(name = "max_players", nullable = false)
+    var maxPlayers: Int = 4,
+
+    @Column(name = "is_private", nullable = false)
+    var isPrivate: Boolean = false,
+
+    @Column(name = "allow_guests", nullable = false)
+    var allowGuests: Boolean = true,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+
+    @ElementCollection
+    @CollectionTable(name = "lobby_players", joinColumns = [JoinColumn(name = "lobby_id")])
+    var players: MutableList<LobbyPlayerEmbeddable> = mutableListOf()
+)
+```
+
+#### `LobbyRepository`
+
+```kotlin
+package at.se2group.backend.lobby.persistence
+
+import at.se2group.backend.lobby.domain.LobbyStatus
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LobbyRepository : JpaRepository<LobbyEntity, String> {
+    fun findAllByStatus(status: LobbyStatus): List<LobbyEntity>
+}
+```
+
+---
+
+## Entity-domain mapping
+
+Because entities and domain objects serve different purposes, it is better to map between them.
+
+```kotlin
+package at.se2group.backend.lobby.mapper
+
+import at.se2group.backend.lobby.domain.Lobby
+import at.se2group.backend.lobby.domain.LobbyPlayer
+import at.se2group.backend.lobby.domain.LobbySettings
+import at.se2group.backend.lobby.persistence.LobbyEntity
+import at.se2group.backend.lobby.persistence.LobbyPlayerEmbeddable
+
+fun LobbyEntity.toDomain(): Lobby =
+    Lobby(
+        lobbyId = lobbyId,
+        hostUserId = hostUserId,
+        players = players.map {
+            LobbyPlayer(
+                userId = it.userId,
+                displayName = it.displayName,
+                isReady = it.isReady,
+                joinedAt = it.joinedAt
+            )
+        },
+        status = status,
+        settings = LobbySettings(
+            maxPlayers = maxPlayers,
+            isPrivate = isPrivate,
+            allowGuests = allowGuests
+        ),
+        createdAt = createdAt
+    )
+
+fun Lobby.toEntity(): LobbyEntity =
+    LobbyEntity(
+        lobbyId = lobbyId,
+        hostUserId = hostUserId,
+        status = status,
+        maxPlayers = settings.maxPlayers,
+        isPrivate = settings.isPrivate,
+        allowGuests = settings.allowGuests,
+        createdAt = createdAt,
+        players = players.map {
+            LobbyPlayerEmbeddable(
+                userId = it.userId,
+                displayName = it.displayName,
+                isReady = it.isReady,
+                joinedAt = it.joinedAt
+            )
+        }.toMutableList()
+    )
+```
+
+---
+
+## Lobby service responsibilities
+
+The `LobbyService` should contain the main business logic for the lobby.
+
+### Service responsibilities
+
+- create lobby
+- fetch lobby by ID
+- list open lobbies
+- join lobby
+- leave lobby
+- mark ready
+- mark unready
+- update settings
+- start match
+- delete lobby
+- call broadcast service when state changes
+
+### Important checks
+
+The service should enforce:
+
+- status must be `OPEN` before joining or settings updates
+- player cannot join twice
+- lobby must not be full
+- only host can update settings
+- only host can start the match
+- all players must be ready before start
+- at least 2 players before start
+
+---
+
+## LobbyBroadcastService for live updates
+
+Even if lobby actions use REST, it is useful to notify all connected lobby screens about changes through WebSocket.
+
+### What it should broadcast
+
+- player joined
+- player left
+- ready state changed
+- settings changed
+- lobby deleted
+- lobby started
+
+### Example implementation
+
+```kotlin
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.lobby.dto.LobbyDeletedEvent
+import at.se2group.backend.lobby.dto.LobbyStartedEvent
+import at.se2group.backend.lobby.dto.LobbyUpdatedEvent
+import at.se2group.backend.lobby.mapper.toResponse
+import at.se2group.backend.lobby.domain.Lobby
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class LobbyBroadcastService(
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+
+    fun broadcastLobbyUpdated(lobby: Lobby) {
+        messagingTemplate.convertAndSend(
+            "/topic/lobbies/${lobby.lobbyId}",
+            LobbyUpdatedEvent(lobby = lobby.toResponse())
+        )
+    }
+
+    fun broadcastLobbyDeleted(lobbyId: String) {
+        messagingTemplate.convertAndSend(
+            "/topic/lobbies/$lobbyId",
+            LobbyDeletedEvent(lobbyId = lobbyId)
+        )
+    }
+
+    fun broadcastLobbyStarted(lobbyId: String, matchId: String) {
+        messagingTemplate.convertAndSend(
+            "/topic/lobbies/$lobbyId",
+            LobbyStartedEvent(lobbyId = lobbyId, matchId = matchId)
+        )
+    }
+}
+```
+
+Clients can subscribe to:
+
+```text
+/topic/lobbies/{lobbyId}
+```
+
+That allows lobby screens to update live without polling.
+
+---
+
+## Full example service implementation
+
+This version replaces the original `ConcurrentHashMap` with a repository-backed service and includes:
+
+- unready
+- updateSettings
+- list endpoint support
+- LobbyBroadcastService integration
+
+```kotlin
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.lobby.domain.Lobby
+import at.se2group.backend.lobby.domain.LobbyPlayer
+import at.se2group.backend.lobby.domain.LobbySettings
+import at.se2group.backend.lobby.domain.LobbyStatus
+import at.se2group.backend.lobby.dto.CreateLobbyRequest
+import at.se2group.backend.lobby.dto.JoinLobbyRequest
+import at.se2group.backend.lobby.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.lobby.mapper.toDomain
+import at.se2group.backend.lobby.mapper.toEntity
+import at.se2group.backend.lobby.persistence.LobbyRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Service
+@Transactional
+class LobbyService(
+    private val lobbyRepository: LobbyRepository,
+    private val lobbyBroadcastService: LobbyBroadcastService
+) {
+
+    fun createLobby(hostUserId: String, request: CreateLobbyRequest): Lobby {
+        require(request.maxPlayers >= 2) { "maxPlayers must be at least 2" }
+
+        val lobby = Lobby(
+            lobbyId = UUID.randomUUID().toString(),
+            hostUserId = hostUserId,
+            players = listOf(
+                LobbyPlayer(
+                    userId = hostUserId,
+                    displayName = request.displayName,
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            ),
+            settings = LobbySettings(
+                maxPlayers = request.maxPlayers,
+                isPrivate = request.isPrivate,
+                allowGuests = request.allowGuests
+            )
+        )
+
+        val saved = lobbyRepository.save(lobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    @Transactional(readOnly = true)
+    fun getLobby(lobbyId: String): Lobby {
+        return lobbyRepository.findById(lobbyId)
+            .orElseThrow { IllegalArgumentException("Lobby not found") }
+            .toDomain()
+    }
+
+    @Transactional(readOnly = true)
+    fun listOpenLobbies(): List<Lobby> {
+        return lobbyRepository.findAllByStatus(LobbyStatus.OPEN)
+            .map { it.toDomain() }
+    }
+
+    fun joinLobby(lobbyId: String, request: JoinLobbyRequest): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        require(lobby.status == LobbyStatus.OPEN) { "Lobby is not open" }
+        require(lobby.players.none { it.userId == request.userId }) { "Player already in lobby" }
+        require(lobby.players.size < lobby.settings.maxPlayers) { "Lobby is full" }
+
+        val updated = lobby.copy(
+            players = lobby.players + LobbyPlayer(
+                userId = request.userId,
+                displayName = request.displayName,
+                isReady = false,
+                joinedAt = Instant.now()
+            )
+        )
+
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    fun leaveLobby(lobbyId: String, userId: String): Lobby? {
+        val lobby = getLobby(lobbyId)
+        val remainingPlayers = lobby.players.filterNot { it.userId == userId }
+
+        if (remainingPlayers.size == lobby.players.size) {
+            throw IllegalArgumentException("Player is not in lobby")
+        }
+
+        if (remainingPlayers.isEmpty()) {
+            lobbyRepository.deleteById(lobbyId)
+            lobbyBroadcastService.broadcastLobbyDeleted(lobbyId)
+            return null
+        }
+
+        val newHostUserId = if (lobby.hostUserId == userId) {
+            remainingPlayers.minBy { it.joinedAt }.userId
+        } else {
+            lobby.hostUserId
+        }
+
+        val updated = lobby.copy(
+            hostUserId = newHostUserId,
+            players = remainingPlayers
+        )
+
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    fun markReady(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+        val updated = lobby.copy(
+            players = lobby.players.map {
+                if (it.userId == userId) it.copy(isReady = true) else it
+            }
+        )
+
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    fun markUnready(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+        val updated = lobby.copy(
+            players = lobby.players.map {
+                if (it.userId == userId) it.copy(isReady = false) else it
+            }
+        )
+
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    fun updateSettings(lobbyId: String, userId: String, request: UpdateLobbySettingsRequest): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        require(lobby.hostUserId == userId) { "Only host can update settings" }
+        require(lobby.status == LobbyStatus.OPEN) { "Lobby is not open" }
+        require(request.maxPlayers >= lobby.players.size) { "maxPlayers cannot be smaller than current player count" }
+        require(request.maxPlayers >= 2) { "maxPlayers must be at least 2" }
+
+        val updated = lobby.copy(
+            settings = LobbySettings(
+                maxPlayers = request.maxPlayers,
+                isPrivate = request.isPrivate,
+                allowGuests = request.allowGuests
+            )
+        )
+
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
+
+    fun startMatch(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        require(lobby.hostUserId == userId) { "Only host can start" }
+        require(lobby.players.size >= 2) { "At least 2 players required" }
+        require(lobby.players.all { it.isReady }) { "All players must be ready" }
+        require(lobby.status == LobbyStatus.OPEN) { "Lobby is not open" }
+
+        val updated = lobby.copy(status = LobbyStatus.IN_GAME)
+        val saved = lobbyRepository.save(updated.toEntity()).toDomain()
+
+        val matchId = UUID.randomUUID().toString()
+        lobbyBroadcastService.broadcastLobbyStarted(lobbyId, matchId)
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+
+        return saved
+    }
+
+    fun deleteLobby(lobbyId: String, userId: String) {
+        val lobby = getLobby(lobbyId)
+        require(lobby.hostUserId == userId) { "Only host can delete lobby" }
+
+        lobbyRepository.deleteById(lobbyId)
+        lobbyBroadcastService.broadcastLobbyDeleted(lobbyId)
+    }
+}
+```
+
+---
+
+## Controller implementation
+
+This controller exposes all core lobby endpoints.
+
+```kotlin
+package at.se2group.backend.lobby.api
+
+import at.se2group.backend.lobby.dto.CreateLobbyRequest
+import at.se2group.backend.lobby.dto.JoinLobbyRequest
+import at.se2group.backend.lobby.dto.LobbyListItemResponse
+import at.se2group.backend.lobby.dto.LobbyResponse
+import at.se2group.backend.lobby.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.lobby.mapper.toListItemResponse
+import at.se2group.backend.lobby.mapper.toResponse
+import at.se2group.backend.lobby.service.LobbyService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/lobbies")
+class LobbyController(
+    private val lobbyService: LobbyService
+) {
+
+    @PostMapping
+    fun createLobby(
+        @RequestHeader("X-User-Id") userId: String,
+        @RequestBody request: CreateLobbyRequest
+    ): LobbyResponse {
+        return lobbyService.createLobby(userId, request).toResponse()
+    }
+
+    @GetMapping
+    fun listLobbies(): List<LobbyListItemResponse> {
+        return lobbyService.listOpenLobbies().map { it.toListItemResponse() }
+    }
+
+    @GetMapping("/{lobbyId}")
+    fun getLobby(@PathVariable lobbyId: String): LobbyResponse {
+        return lobbyService.getLobby(lobbyId).toResponse()
+    }
+
+    @PostMapping("/{lobbyId}/join")
+    fun joinLobby(
+        @PathVariable lobbyId: String,
+        @RequestBody request: JoinLobbyRequest
+    ): LobbyResponse {
+        return lobbyService.joinLobby(lobbyId, request).toResponse()
+    }
+
+    @PostMapping("/{lobbyId}/leave")
+    fun leaveLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): ResponseEntity<Any> {
+        val lobby = lobbyService.leaveLobby(lobbyId, userId)
+        return if (lobby == null) {
+            ResponseEntity.noContent().build()
+        } else {
+            ResponseEntity.ok(lobby.toResponse())
+        }
+    }
+
+    @PostMapping("/{lobbyId}/ready")
+    fun markReady(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): LobbyResponse {
+        return lobbyService.markReady(lobbyId, userId).toResponse()
+    }
+
+    @PostMapping("/{lobbyId}/unready")
+    fun markUnready(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): LobbyResponse {
+        return lobbyService.markUnready(lobbyId, userId).toResponse()
+    }
+
+    @PatchMapping("/{lobbyId}/settings")
+    fun updateSettings(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String,
+        @RequestBody request: UpdateLobbySettingsRequest
+    ): LobbyResponse {
+        return lobbyService.updateSettings(lobbyId, userId, request).toResponse()
+    }
+
+    @PostMapping("/{lobbyId}/start")
+    fun startMatch(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): LobbyResponse {
+        return lobbyService.startMatch(lobbyId, userId).toResponse()
+    }
+
+    @DeleteMapping("/{lobbyId}")
+    fun deleteLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): ResponseEntity<Void> {
+        lobbyService.deleteLobby(lobbyId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}
+```
+
+---
+
+## Live lobby update flow
+
+The REST API performs the mutation, and the broadcast service pushes the change.
+
+### Example flow: player joins lobby
+
+1. client calls `POST /api/lobbies/{lobbyId}/join`
+2. `LobbyController` forwards request to `LobbyService`
+3. `LobbyService` validates lobby state and adds the player
+4. updated lobby is saved through `LobbyRepository`
+5. `LobbyBroadcastService` publishes `lobby.updated`
+6. all clients subscribed to `/topic/lobbies/{lobbyId}` receive the new state
+
+### Example flow: host starts match
+
+1. client calls `POST /api/lobbies/{lobbyId}/start`
+2. `LobbyService` checks host ownership, readiness, and minimum players
+3. lobby status becomes `IN_GAME`
+4. match creation is triggered or delegated to the match module
+5. `LobbyBroadcastService` publishes `lobby.started`
+6. clients navigate from lobby screen to match screen
+
+---
+
+## Suggested WebSocket subscription pattern
+
+For live lobby updates, clients can subscribe to:
+
+```text
+/topic/lobbies/{lobbyId}
+```
+
+Possible event types:
+
+- `lobby.updated`
+- `lobby.deleted`
+- `lobby.started`
+
+This is enough for a first version. You do not need many more event types unless the feature becomes more advanced.
+
+---
+
+## Error handling recommendations
+
+The lobby service should throw stable exceptions or use a common error model.
+
+Example failure cases:
+
+- lobby not found
+- lobby full
+- lobby not open
+- player already joined
+- only host can update settings
+- only host can start match
+- all players must be ready
+- minimum player count not met
+
+A shared exception structure can later map these into clean API responses such as:
+
+```json
+{
+    "code": "LOBBY_FULL",
+    "message": "Lobby is full"
+}
+```
+
+---
+
+## Recommended implementation order
+
+This is a practical step-by-step implementation plan.
+
+### Phase 1: domain and DTOs
+
+Implement:
+
+- `LobbyStatus`
+- `LobbyPlayer`
+- `LobbySettings`
+- `Lobby`
+- request and response DTOs
+- mapper helpers
+
+### Phase 2: persistence
+
+Implement:
+
+- `LobbyEntity`
+- `LobbyPlayerEmbeddable`
+- `LobbyRepository`
+- entity-domain mapping
+
+### Phase 3: service logic
+
+Implement:
+
+- `createLobby`
+- `getLobby`
+- `listOpenLobbies`
+- `joinLobby`
+- `leaveLobby`
+- `markReady`
+- `markUnready`
+- `updateSettings`
+- `startMatch`
+- `deleteLobby`
+
+### Phase 4: REST controller
+
+Implement all endpoints in `LobbyController`.
+
+### Phase 5: live updates
+
+Implement:
+
+- `LobbyBroadcastService`
+- topic naming convention
+- event DTOs
+- frontend subscription handling
+
+### Phase 6: match handoff
+
+When start is called:
+
+- create a match from the lobby players and settings
+- return or publish the new `matchId`
+- move users from lobby screen to match screen
+
+---
+
+## Good next steps after the first complete version
+
+Once the above is working, good follow-up improvements are:
+
+- add validation annotations on request DTOs
+- replace header-based identity with the project-wide guest-user identity mechanism
+- add dedicated error codes and exception handlers
+- add host transfer tests
+- add service unit tests for lobby rules
+- add integration tests for REST endpoints
+- add pagination or filters for lobby listing if needed
+- optionally add invite codes for private lobbies later
+
+---
+
+## Minimum complete first version checklist
+
+A good complete first version of lobby functionality should include all of these:
+
+- [ ] create lobby
+- [ ] fetch lobby by ID
+- [ ] list open lobbies
+- [ ] join lobby
+- [ ] leave lobby
+- [ ] ready
+- [ ] unready
+- [ ] update settings
+- [ ] host transfer on leave
+- [ ] start match
+- [ ] delete lobby
+- [ ] repository-backed persistence
+- [ ] DTO mapping
+- [ ] live lobby updates via `LobbyBroadcastService`
+- [ ] basic error handling
+
+---
+
+## Recommended Backend Lobby Issue Order
+
+The backend lobby feature should be implemented in a layered order so that planning and core models come first, service logic is built on top of stable persistence and DTO structures, and live updates, testing, and documentation are added afterward.
+
+### Best implementation order
+
+#### Phase 0: Planning
+
+1. `docs(backend)(lobby): plan lobby architecture and implementation`
+
+This issue defines the technical structure, rules, responsibilities, persistence approach, API design, and overall implementation strategy for the backend lobby feature.
+
+#### Phase 1: Core Models and Contracts
+
+2. `feat(backend)(lobby): add lobby domain models and status enums`
+3. `feat(backend)(lobby): add lobby request and response DTOs`
+4. `feat(backend)(lobby): add lobby domain and response mappers`
+
+These issues define the core domain layer, transport contracts, and mapping layer that the rest of the backend depends on.
+
+#### Phase 2: Persistence Layer
+
+5. `feat(backend)(lobby): add lobby persistence entities`
+6. `feat(backend)(lobby): add lobby repository for database access`
+
+These issues add the storage model and repository access needed by the service layer.
+
+#### Phase 3: Core Service Logic
+
+7. `feat(backend)(lobby): implement create lobby service logic`
+8. `feat(backend)(lobby): implement get lobby by id use case`
+9. `feat(backend)(lobby): implement open lobby listing`
+10. `feat(backend)(lobby): implement join lobby use case`
+11. `feat(backend)(lobby): implement leave lobby and host transfer logic`
+12. `feat(backend)(lobby): implement mark player as ready`
+13. `feat(backend)(lobby): implement mark player as unready`
+14. `feat(backend)(lobby): implement lobby settings update for host`
+15. `feat(backend)(lobby): implement lobby start match validation and state transition`
+16. `feat(backend)(lobby): implement delete lobby use case`
+
+This phase builds the complete backend lobby behavior in the service layer, including all main rules and state transitions.
+
+#### Phase 4: REST API
+
+17. `feat(backend)(lobby): add lobby REST controller endpoints`
+
+This issue exposes the completed lobby service logic through HTTP endpoints for create, list, fetch, join, leave, ready, unready, settings update, start, and delete operations.
+
+#### Phase 5: Live Lobby Updates
+
+18. `feat(backend)(lobby): add websocket lobby broadcast service`
+19. `feat(backend)(lobby): add lobby websocket event payloads`
+
+These issues add live update support so connected clients can receive lobby changes without polling.
+
+#### Phase 6: Error Handling and Match Handoff
+
+20. `feat(backend)(lobby): add lobby-specific error handling and validation responses`
+21. `feat(backend)(lobby): add handoff from lobby start to match creation`
+
+These issues improve backend robustness and connect the lobby flow to the actual match lifecycle.
+
+#### Phase 7: Testing
+
+22. `test(backend)(lobby): add unit tests for lobby service rules`
+23. `test(backend)(lobby): add integration tests for lobby REST endpoints`
+24. `test(backend)(lobby): add tests for lobby websocket broadcast behavior`
+
+These issues verify service rules, REST integration, and live update behavior.
+
+#### Phase 8: Documentation
+
+25. `docs(backend)(lobby): document lobby architecture and implementation flow`
+
+This issue should be completed last so the documentation reflects the final implementation and not just the planned structure.
+
+### Why this order is recommended
+
+This order minimizes rework and follows the real dependency structure of the backend:
+
+- planning should happen first so the implementation has a clear direction
+- domain models, DTOs, and mappers should exist before persistence and service work
+- persistence should exist before service logic depends on it
+- service logic should be complete before exposing the REST controller
+- live updates should come after the underlying state transitions already work
+- error handling, match handoff, testing, and final documentation are most effective once the feature is largely stable
+
+### Simple dependency chain
+
+```text
+Planning
+-> Domain / DTOs / Mappers
+-> Persistence
+-> Service Logic
+-> REST Controller
+-> WebSocket Updates
+-> Error Handling + Match Handoff
+-> Tests
+-> Documentation
+```
+
+This backend order should be followed based on implementation dependency, not raw GitHub issue number order.
+
+## Recommended Frontend Lobby Issue Order
+
+The Android lobby feature should be implemented in a layered order so that the technical foundations come first, the core REST-based flow works next, and live updates, polish, testing, and documentation are added afterward.
+
+### Best implementation order
+
+#### Phase 1: Foundation
+
+1. `feat(android)(lobby): add lobby domain and UI models`
+2. `feat(android)(lobby): add lobby API DTOs and mapping`
+3. `feat(android)(lobby): add lobby API service definitions`
+4. `feat(android)(lobby): add lobby websocket event models`
+5. `feat(android)(lobby): add lobby repository`
+
+These issues define the core data models, networking contracts, and repository layer that the rest of the frontend depends on.
+
+#### Phase 2: Navigation and State Management
+
+6. `feat(android)(lobby): add lobby navigation routes`
+7. `feat(android)(lobby): add lobby viewmodel for list screen`
+8. `feat(android)(lobby): add lobby viewmodel for detail screen`
+
+These issues prepare the screen flow and state handling for the actual lobby UI.
+
+#### Phase 3: Core UI
+
+9. `feat(android)(lobby): implement lobby list screen UI`
+10. `feat(android)(lobby): implement create lobby screen UI`
+11. `feat(android)(lobby): implement lobby detail screen UI`
+12. `feat(android)(lobby): implement lobby player list component`
+13. `feat(android)(lobby): implement lobby settings section UI`
+
+These issues build the visible interface on top of the prepared models and ViewModels.
+
+#### Phase 4: Core Lobby Flows
+
+14. `feat(android)(lobby): load open lobbies from backend`
+15. `feat(android)(lobby): implement fetch lobby by id flow`
+16. `feat(android)(lobby): implement create lobby action flow`
+17. `feat(android)(lobby): implement join lobby action flow`
+18. `feat(android)(lobby): implement leave lobby action flow`
+19. `feat(android)(lobby): implement mark ready action flow`
+20. `feat(android)(lobby): implement mark unready action flow`
+21. `feat(android)(lobby): implement host-only settings update flow`
+22. `feat(android)(lobby): implement host-only start match flow`
+23. `feat(android)(lobby): implement delete lobby flow`
+
+This phase completes the main REST-based lobby feature from browsing through match start or deletion.
+
+#### Phase 5: Realtime Updates
+
+24. `feat(android)(lobby): add websocket subscription for live lobby updates`
+25. `feat(android)(lobby): handle lobby started event and navigate to match`
+26. `feat(android)(lobby): handle lobby deleted event in UI`
+
+These issues add live synchronization and event-driven transitions.
+
+#### Phase 6: UX Polish
+
+27. `feat(android)(lobby): add loading and error states for lobby screens`
+28. `feat(android)(lobby): add host and permission-based UI states`
+
+These issues improve usability and make the lobby behavior clearer for players and hosts.
+
+#### Phase 7: Testing
+
+29. `test(android)(lobby): add unit tests for lobby viewmodels`
+30. `test(android)(lobby): add ui tests for lobby screens`
+31. `test(android)(lobby): add integration tests for lobby repository`
+
+These issues verify ViewModel behavior, screen flows, and backend integration logic.
+
+#### Phase 8: Documentation
+
+32. `docs(android)(lobby): document lobby frontend architecture and flow` `#103`
+
+This issue should be completed after the main implementation is stable so the documentation reflects the actual frontend structure and flow.
+
+### Why this order is recommended
+
+This order minimizes rework and follows the real dependency structure of the Android app:
+
+- models, DTOs, and API service definitions should exist before repository work
+- repository and navigation should exist before complete ViewModels and screen flows
+- screens should exist before wiring all user actions
+- the REST-based flow should work before adding WebSocket updates
+- testing and documentation are most useful once the feature is largely stable
+
+### Simple dependency chain
+
+```text
+Models / DTOs / Events
+-> API Service
+-> Repository
+-> Navigation + ViewModels
+-> Screens
+-> Action Flows
+-> WebSocket Updates
+-> UX Polish
+-> Tests
+-> Documentation
+```
+
+This frontend order should be followed based on implementation dependency, not raw GitHub issue number order.
+
+## Summary
+
+The recommended lobby implementation is:
+
+- **REST for lobby actions**
+- **WebSocket for live lobby updates**
+- **repository-backed persistence instead of `ConcurrentHashMap`**
+- **clear domain model for lobby, players, settings, and status**
+- **service layer for lobby rules**
+- **broadcast service for realtime UI updates**
+
+This gives you a clean and realistic first version that is simple enough for a student project but structured enough to scale into the full multiplayer flow.
+
+---
+
+## Frontend and Backend Alignment
+
+The backend and frontend lobby issue orders should be treated as two connected implementation tracks rather than two completely separate efforts.
+
+A good coordination rule is:
+
+- the backend should implement and stabilize the domain model, DTOs, REST endpoints, and basic lobby service behavior first
+- the frontend should build its models, DTO mapping, repository, navigation, and UI against those stable backend contracts
+- once the REST-based lobby flow works end to end, both sides can implement WebSocket-based live lobby updates
+- testing and final documentation on both sides should happen after the main feature flow is stable
+
+### Recommended cross-team implementation sequence
+
+1. backend planning, models, DTOs, persistence, and service logic
+2. backend REST controller endpoints
+3. frontend models, API DTO mapping, API service definitions, and repository
+4. frontend lobby screens and action flows against the finished REST endpoints
+5. backend lobby broadcast service and websocket event payloads
+6. frontend websocket subscription and live event handling
+7. backend and frontend testing
+8. backend and frontend documentation cleanup and final alignment
+
+### Practical takeaway
+
+The safest implementation path is:
+
+- **backend first for contracts and core behavior**
+- **frontend next for screen flow and REST integration**
+- **then realtime updates on both sides**
+
+This reduces blocking, avoids repeated contract changes, and makes it easier for both parts of the project to progress in parallel with clear handoff points.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,9 +20,19 @@ junit = "4.13.2"
 androidxJunit = "1.3.0"
 espresso = "3.7.0"
 
+
+# Websocket + STOMP
+krossbowStompCore = "9.3.0"
+krossbowWebsocketBuiltin = "9.3.0"
+krossbowWebsocketOkhttp = "9.3.0"
+
+# HTTP-Client
+ktor="2.3.10"
+
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
@@ -43,6 +53,16 @@ spring-boot-starter-actuator = { group = "org.springframework.boot", name = "spr
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test" }
 jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
+
+krossbow-stomp-core = { module = "org.hildan.krossbow:krossbow-stomp-core", version.ref = "krossbowStompCore" }
+krossbow-websocket-builtin = { module = "org.hildan.krossbow:krossbow-websocket-builtin", version.ref = "krossbowWebsocketBuiltin" }
+krossbow-websocket-okhttp = { module = "org.hildan.krossbow:krossbow-websocket-okhttp", version.ref = "krossbowWebsocketOkhttp" }
+
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-jackson = { group = "io.ktor", name = "ktor-serialization-jackson", version.ref = "ktor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,9 @@ jvmTarget = "11"
 
 agp = "8.13.2"
 kotlin = "2.3.10"
+springBoot = "3.5.13"
+springDependencyManagement = "1.1.7"
+
 composeBom = "2026.03.00"
 composeCompiler = "1.5.14"
 
@@ -20,32 +23,33 @@ espresso = "3.7.0"
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
-
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 
-# Compose BOM
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-
-# Compose UI (no versions because BOM handles it)
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-
-# Material3
 material3 = { group = "androidx.compose.material3", name = "material3" }
 
-# Testing
 junit4 = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
-
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-
-# Debug
 compose-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+
+spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web" }
+spring-boot-starter-actuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator" }
+spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "36"
 minSdk = "26"
 targetSdk = "36"
-jvmTarget = "11"
+jvmTarget = "17"
 
 agp = "8.13.2"
 kotlin = "2.3.10"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,8 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(":apps:android:app")
 include(":apps:backend")
+include(":apps:shared")
 
 project(":apps:android:app").projectDir = file("apps/android/app")
 project(":apps:backend").projectDir = file("apps/backend")
+project(":apps:shared").projectDir = file("apps/shared")


### PR DESCRIPTION
## Summary

This PR initializes the backend inside `apps/backend` as a Spring Boot Kotlin module within the monorepo and adds a first sample API endpoint for frontend integration.

## Changes

- add Spring Boot backend module setup in `apps/backend`
- add backend Gradle configuration using the shared root Gradle setup
- extend `libs.versions.toml` with backend plugins and dependencies
- add the backend application entrypoint and application configuration
- add a sample `GET /api/leaderboard` endpoint returning mocked leaderboard data
- add an initial backend context load test
- document the leaderboard endpoint in `docs/api.md`

## Purpose

This creates the initial backend foundation for the project and provides a simple mock API the Android frontend can use for early integration and UI testing.

## Testing

- backend module builds successfully via Gradle
- Spring Boot application starts successfully
- `GET /api/leaderboard` returns mocked JSON leaderboard data
- backend test suite runs successfully

## Notes

- the leaderboard response currently returns mocked sample data
- this endpoint is intended as an initial integration example and will later be replaced or extended with real game logic and persistence

## Issues

Closes #6 
Closes #44 
Closes #43 
Closes #43 
Closes #41 

Related to #45 
Related to #40 
Related to #39 