### PR TITLE
feat(backend)(lobby): add REST API endpoints for core lobby flows (part 2)

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -4,8 +4,9 @@ import at.se2group.backend.dto.LobbyListItemResponse
 import at.se2group.backend.mapper.toListItemResponse
 import at.se2group.backend.service.LobbyService
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import at.se2group.backend.dto.CreateLobbyRequest
 import at.se2group.backend.dto.LobbyResponse
 import at.se2group.backend.mapper.toResponse
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.PathVariable
 import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
 
 @RestController
 @RequestMapping("/api/lobbies")
@@ -46,5 +48,14 @@ class LobbyController(
         @RequestBody request: JoinLobbyRequest
     ): LobbyResponse {
         return lobbyService.joinLobby(lobbyId, request).toResponse()
+    }
+
+    @PatchMapping("/{lobbyId}/settings")
+    fun updateLobbySettings(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String,
+        @RequestBody request: UpdateLobbySettingsRequest
+    ): LobbyResponse {
+        return lobbyService.updateLobbySettings(lobbyId, userId, request).toResponse()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -58,4 +58,12 @@ class LobbyController(
     ): LobbyResponse {
         return lobbyService.updateLobbySettings(lobbyId, userId, request).toResponse()
     }
+
+    @PostMapping("/{lobbyId}/start")
+    fun startLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String,
+        ): LobbyResponse {
+        return lobbyService.startLobby(lobbyId, userId).toResponse()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.PathVariable
 import at.se2group.backend.dto.JoinLobbyRequest
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 
 @RestController
 @RequestMapping("/api/lobbies")
@@ -62,8 +64,17 @@ class LobbyController(
     @PostMapping("/{lobbyId}/start")
     fun startLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String,
-        ): LobbyResponse {
+        @RequestHeader("X-User-Id") userId: String
+    ): LobbyResponse {
         return lobbyService.startLobby(lobbyId, userId).toResponse()
+    }
+
+    @DeleteMapping("/{lobbyId}")
+    fun deleteLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): ResponseEntity<Void> {
+        lobbyService.deleteLobby(lobbyId, userId)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/UpdateLobbySettingsRequest.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/UpdateLobbySettingsRequest.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.dto
+
+data class UpdateLobbySettingsRequest(
+    val maxPlayers: Int,
+    val isPrivate: Boolean,
+    val allowGuests: Boolean
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -117,7 +117,7 @@ class LobbyService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}")
         }
 
-        val updated_lobby = lobby.copy(
+        val updatedLobby = lobby.copy(
             settings = LobbySettings(
                 maxPlayers = request.maxPlayers,
                 isPrivate = request.isPrivate,
@@ -125,7 +125,7 @@ class LobbyService(
             )
         )
 
-        return lobbyRepository.save(updated_lobby.toEntity()).toDomain()
+        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
 
     @Transactional

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -24,7 +24,7 @@ class LobbyService(
 ) {
 
     companion object {
-        const val MAX_PLAYERS = 8
+        const val MAX_PLAYERS = 4
         const val MIN_PLAYERS = 2
     }
 
@@ -35,10 +35,10 @@ class LobbyService(
 
     @Transactional
     fun createLobby(userId: String, request: CreateLobbyRequest): Lobby {
-        if (request.maxPlayers < 0 || request.maxPlayers >= MAX_PLAYERS) {
+        if (request.maxPlayers < MIN_PLAYERS || request.maxPlayers > MAX_PLAYERS) {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
-                "maxPlayers must be between 0 and ${MAX_PLAYERS - 1}"
+                "maxPlayers must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}"
             )
         }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -127,4 +127,31 @@ class LobbyService(
 
         return lobbyRepository.save(updated_lobby.toEntity()).toDomain()
     }
+
+    @Transactional
+    fun startLobby(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        if (lobby.hostUserId != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can start the match")
+        }
+
+        if (lobby.status != LobbyStatus.OPEN) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Match can only be started while the lobby is open")
+        }
+
+        if (lobby.players.size < MIN_PLAYERS) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "At least ${MIN_PLAYERS} players are required to start the match")
+        }
+
+        if (lobby.players.any { !it.isReady }) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "All players must be ready to start the match")
+        }
+
+        val updatedLobby = lobby.copy(
+            status = LobbyStatus.IN_GAME
+        )
+
+        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -117,6 +117,10 @@ class LobbyService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}")
         }
 
+        if (request.maxPlayers < lobby.players.size) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players cannot be smaller than the current player count")
+        }
+
         val updatedLobby = lobby.copy(
             settings = LobbySettings(
                 maxPlayers = request.maxPlayers,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -154,4 +154,15 @@ class LobbyService(
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
+
+    @Transactional
+    fun deleteLobby(lobbyId: String, userId: String) {
+        val lobby = getLobby(lobbyId)
+
+        if (lobby.hostUserId != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can delete the lobby")
+        }
+
+        lobbyRepository.deleteById(lobbyId)
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -6,6 +6,7 @@ import at.se2group.backend.domain.LobbySettings
 import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.dto.CreateLobbyRequest
 import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.mapper.toDomain
 import at.se2group.backend.mapper.toEntity
 import at.se2group.backend.persistence.LobbyRepository
@@ -24,6 +25,7 @@ class LobbyService(
 
     companion object {
         const val MAX_PLAYERS = 8
+        const val MIN_PLAYERS = 2
     }
 
     fun listOpenLobbies(): List<Lobby> {
@@ -97,5 +99,32 @@ class LobbyService(
         )
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+    }
+
+    @Transactional
+    fun updateLobbySettings(lobbyId: String, userId: String, request: UpdateLobbySettingsRequest): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        if (lobby.hostUserId != userId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can update lobby settings")
+        }
+
+        if (lobby.status != LobbyStatus.OPEN) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lobby settings can only be changed while the lobby is open")
+        }
+
+        if (request.maxPlayers < MIN_PLAYERS || request.maxPlayers > MAX_PLAYERS) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}")
+        }
+
+        val updated_lobby = lobby.copy(
+            settings = LobbySettings(
+                maxPlayers = request.maxPlayers,
+                isPrivate = request.isPrivate,
+                allowGuests = request.allowGuests
+            )
+        )
+
+        return lobbyRepository.save(updated_lobby.toEntity()).toDomain()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -113,12 +113,8 @@ class LobbyService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lobby settings can only be changed while the lobby is open")
         }
 
-        if (request.maxPlayers < MIN_PLAYERS || request.maxPlayers > MAX_PLAYERS) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}")
-        }
-
-        if (request.maxPlayers < lobby.players.size) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players cannot be smaller than the current player count")
+        if (request.maxPlayers !in maxOf(MIN_PLAYERS, lobby.players.size)..MAX_PLAYERS) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${maxOf(MIN_PLAYERS, lobby.players.size)} and ${MAX_PLAYERS}")
         }
 
         val updatedLobby = lobby.copy(


### PR DESCRIPTION
## Summary

This PR implements the next set of lobby REST API endpoints for the backend.

It extends the first lobby REST API PR by adding the remaining host-controlled lobby actions needed to manage lobby state after creation and joining.

The goal of this change is to complete the next core step of the lobby flow so the frontend can update lobby settings, start a match from the lobby, and delete a lobby through stable HTTP endpoints.

## Endpoints / Operations included

- `PATCH /api/lobbies/{lobbyId}/settings` - #112  
- `POST /api/lobbies/{lobbyId}/start` - #113  
- `DELETE /api/lobbies/{lobbyId}` - #114

## Not included in this PR

The following lobby REST endpoints are part of the overall lobby plan, but are intentionally out of scope for this PR:

- `POST /api/lobbies/{lobbyId}/leave` - #109  
- `POST /api/lobbies/{lobbyId}/ready` - #110  
- `POST /api/lobbies/{lobbyId}/unready` - #111  
  

## What this PR does

### Adds the remaining host-controlled lobby REST endpoints
Implements the documented lobby actions for updating settings, starting a match, and deleting a lobby.

### Extends the lobby controller
Exposes the new endpoints in `LobbyController` and connects them to the existing service layer.

### Extends the lobby service logic
Adds the required business rules for:
- updating lobby settings
- validating player count limits
- starting a match only when allowed
- deleting a lobby as host

### Uses existing DTO and mapper structure
Keeps the implementation aligned with the existing request/response DTOs and mapper-based response conversion already introduced in the earlier REST API PR.

## Scope

This PR is intended as **part 2** of the lobby REST API implementation.

It focuses only on:
- settings update
- match start
- lobby deletion

The following lobby operations are still out of scope for this PR if not already implemented elsewhere:

- `POST /api/lobbies/{lobbyId}/leave`
- `POST /api/lobbies/{lobbyId}/ready`
- `POST /api/lobbies/{lobbyId}/unready`

## Files / areas affected

Typical affected areas include:

- `lobby/api/`
- `lobby/service/`
- `lobby/dto/`
- `lobby/mapper/`
- `docs/lobby.md`

## Related issues

**Backend:**
- Closes #112  
- Closes #113  
- Closes #114 
- Related to #63 
- Related to #68 - unit testing
- Related to #69 - integration testing
- Related to #70 - web socket tests

**Related backend work:**
- Related to #63  
- Related to #66  
- Related to #68  
- Related to #69  
- Related to #48
- Related to #49 
- Related to #50 
- Related to #51 
- Related to #52

---

- Related to #66 
- Related to #68 
- Related to #69 
- Related to #71 

**Frontend:**
- Related to #86 
- Related to #86 
- Related to #87 
- Related to #83 
- Related to #79 
- Related to #88
- Related to #89 
- Related to #91 

## Testing / verification

Please verify at least the following:

- updating lobby settings returns an updated `LobbyResponse`
- only the host can update lobby settings
- invalid `maxPlayers` values are rejected
- starting a lobby is restricted to the host
- starting a lobby requires valid lobby state and required start conditions
- deleting a lobby is restricted to the host
- deleting a lobby removes it successfully
- endpoint responses match the documented API contract in `docs/lobby.md`

## Checklist

- [ ] `PATCH /api/lobbies/{lobbyId}/settings` implemented
- [ ] `POST /api/lobbies/{lobbyId}/start` implemented
- [ ] `DELETE /api/lobbies/{lobbyId}` implemented
- [ ] Endpoints wired to `LobbyService`
- [ ] Host-only restrictions enforced where required
- [ ] Validation rules for player count and lobby state are enforced
- [ ] Controller methods remain thin and delegate to the service layer
- [ ] Response mapping uses existing mapper helpers
- [ ] Endpoint behavior matches `docs/lobby.md`