### PR TITLE
feat(backend)(lobby): add REST API endpoints for core lobby flows (part 3)

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -75,7 +75,7 @@ class LobbyController(
         return lobbyService.leaveLobby(lobbyId, userId).toResponse()
     }
 
-    @PostMapping("/{lobbyid}/ready")
+    @PostMapping("/{lobbyId}/ready")
     fun readyLobby(
         @PathVariable lobbyId: String,
         @RequestHeader("X-User-Id") userId: String,
@@ -83,7 +83,7 @@ class LobbyController(
         return lobbyService.readyLobby(lobbyId, userId).toResponse()
     }
 
-    @PostMapping("/{lobbyid}/unready")
+    @PostMapping("/{lobbyId}/unready")
     fun unreadyLobby(
         @PathVariable lobbyId: String,
         @RequestHeader("X-User-Id") userId: String

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -74,4 +74,12 @@ class LobbyController(
         ): LobbyResponse {
         return lobbyService.leaveLobby(lobbyId, userId).toResponse()
     }
+
+    @PostMapping("/{lobbyid}/ready")
+    fun readyLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String,
+    ): LobbyResponse {
+        return lobbyService.readyLobby(lobbyId, userId).toResponse()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -82,4 +82,12 @@ class LobbyController(
     ): LobbyResponse {
         return lobbyService.readyLobby(lobbyId, userId).toResponse()
     }
+
+    @PostMapping("/{lobbyid}/unready")
+    fun unreadyLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String
+     ): LobbyResponse {
+        return lobbyService.unreadyLobby(lobbyId, userId).toResponse()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -66,4 +66,12 @@ class LobbyController(
         ): LobbyResponse {
         return lobbyService.startLobby(lobbyId, userId).toResponse()
     }
+
+    @PostMapping("/{lobbyId}/leave")
+    fun leaveLobby(
+        @PathVariable lobbyId: String,
+        @RequestHeader("X-User-Id") userId: String,
+        ): LobbyResponse {
+        return lobbyService.leaveLobby(lobbyId, userId).toResponse()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -173,4 +173,25 @@ class LobbyService(
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
+
+    @Transactional
+    fun readyLobby(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        if(lobby.status != LobbyStatus.OPEN) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "While lobby is not open you cannot change the ready status")
+        }
+
+        if(lobby.players.none { it.userId == userId}) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player was found in this lobby")
+        }
+
+        val updatedLobby = lobby.copy(
+            players = lobby.players.map {
+                if (it.userId == userId) it.copy(isReady = true) else it
+            }
+        )
+
+        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -194,4 +194,24 @@ class LobbyService(
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
+
+     @Transactional
+     fun unreadyLobby(lobbyId: String, userId: String): Lobby {
+         val lobby = getLobby(lobbyId)
+
+         if(lobby.status != LobbyStatus.OPEN) {
+             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot change the ready status, while lobby is not open")
+         }
+
+         if(lobby.players.none {it.userId == userId}) {
+             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player found in this lobby")
+         }
+
+         val updatedLobby = lobby.copy(
+             players = lobby.players.map {
+                 if (it.userId == userId) it.copy(isReady = false) else it
+             }
+         )
+         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -154,4 +154,23 @@ class LobbyService(
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
+
+    @Transactional
+    fun leaveLobby(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+
+        if(lobby.status != LobbyStatus.OPEN) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot leave an unopen lobby")
+        }
+
+        if (lobby.players.none { it.userId == userId }) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player found in this lobby")
+        }
+
+        val updatedLobby = lobby.copy(
+            players = lobby.players.filter { it.userId == userId }
+        )
+
+        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -167,7 +167,21 @@ class LobbyService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player found in this lobby")
         }
 
+        val remainingPlayers = lobby.players.filter { it.userId != userId }
+
+        if(remainingPlayers.isEmpty()) {
+            lobbyRepository.deleteById(lobbyId)
+            throw ResponseStatusException(HttpStatus.NO_CONTENT, "Lobby deleted as there are no players left")
+        }
+
+        val nextHostId = if (lobby.hostUserId == userId) {
+            remainingPlayers.first().userId
+        } else {
+            lobby.hostUserId
+        }
+
         val updatedLobby = lobby.copy(
+            hostUserId = nextHostId,
             players = lobby.players.filter { it.userId != userId }
         )
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -168,7 +168,7 @@ class LobbyService(
         }
 
         val updatedLobby = lobby.copy(
-            players = lobby.players.filter { it.userId == userId }
+            players = lobby.players.filter { it.userId != userId }
         )
 
         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
@@ -179,7 +179,7 @@ class LobbyService(
         val lobby = getLobby(lobbyId)
 
         if(lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "While lobby is not open you cannot change the ready status")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot change the ready status, while lobby is not open")
         }
 
         if(lobby.players.none { it.userId == userId}) {


### PR DESCRIPTION
## Summary

This PR implements the next set of lobby REST API endpoints for the backend.

It extends the earlier lobby REST API work by adding the remaining player-state lobby actions needed after creation, fetching, listing, joining, and host-controlled management are already available.

The goal of this change is to complete the next core step of the lobby flow so the frontend can leave a lobby and update player readiness through stable HTTP endpoints defined in `docs/lobby.md`.

## Endpoints / Operations included

- `POST /api/lobbies/{lobbyId}/leave`
- `POST /api/lobbies/{lobbyId}/ready`
- `POST /api/lobbies/{lobbyId}/unready`

## What this PR does

### Adds the remaining player-state lobby REST endpoints
Implements the documented lobby actions for leaving a lobby, marking a player as ready, and marking a player as unready.  [oai_citation:0‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/blob/feature/lobby/docs/lobby.md)

### Extends the lobby controller
Exposes the new endpoints in `LobbyController` and connects them to the existing service layer.  [oai_citation:1‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/130/changes)

### Extends the lobby service logic
Adds the required business rules for:
- leaving a lobby
- validating that the player is part of the lobby
- changing ready state only while the lobby is open
- persisting the updated lobby state after each operation  [oai_citation:2‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/130/changes)

### Uses the existing DTO and mapper structure
Keeps the implementation aligned with the existing response mapping and lobby REST API structure already introduced in the earlier PRs.  [oai_citation:3‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/130/changes)

## Scope

This PR is intended as **part 3** of the lobby REST API implementation.

It focuses only on:
- leave lobby
- mark ready
- mark unready

The following lobby operations are already handled in earlier or separate PRs:
- `POST /api/lobbies`
- `GET /api/lobbies`
- `GET /api/lobbies/{lobbyId}`
- `POST /api/lobbies/{lobbyId}/join`
- `PATCH /api/lobbies/{lobbyId}/settings`
- `POST /api/lobbies/{lobbyId}/start`
- `DELETE /api/lobbies/{lobbyId}`  [oai_citation:4‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/blob/feature/lobby/docs/lobby.md)

## Files / areas affected

Typical affected areas include:

- `lobby/api/`
- `lobby/service/`
- `docs/lobby.md`

## Related issues

**Backend:**
- Closes #109
- Closes #110
- Closes #111

---

- Related to #68 - unit testing
- Related to #69 - integration testing
- Related to #70 - web socket tests

**Related backend work:**
- Related to #63  
- Related to #66  
- Related to #68  
- Related to #69  
- Related to #48
- Related to #49 
- Related to #50 
- Related to #51 
- Related to #52

---

- Related to #66 
- Related to #68 
- Related to #69 
- Related to #71 

**Frontend:**
- Related to #86 
- Related to #86 
- Related to #87 
- Related to #83 
- Related to #79 
- Related to #88
- Related to #89 
- Related to #91 

## Testing / verification

Please verify at least the following:

- leaving a lobby updates the returned lobby state correctly
- a player cannot leave a lobby they are not part of
- ready is only allowed while the lobby is open
- unready is only allowed while the lobby is open
- ready updates the correct player state
- unready updates the correct player state
- endpoint responses match the documented API contract in `docs/lobby.md`

## Checklist

- [ ] `POST /api/lobbies/{lobbyId}/leave` implemented
- [ ] `POST /api/lobbies/{lobbyId}/ready` implemented
- [ ] `POST /api/lobbies/{lobbyId}/unready` implemented
- [ ] Endpoints wired to `LobbyService`
- [ ] Player membership is validated before leave / ready / unready operations
- [ ] Ready-state changes are only allowed while lobby status is `OPEN`
- [ ] Controller methods remain thin and delegate to the service layer
- [ ] Response mapping stays consistent with the existing lobby REST API
- [ ] Endpoint behavior matches `docs/lobby.md`