### PR TITLE
test(backend)(lobby): add global error handling for API

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -14,8 +14,8 @@ class GlobalExceptionHandler {
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(
                 ApiErrorResponse(
-                    errorCode = "INTERNAL_SERVICE_ERROR",
-                    errorMessage = "An unexpected error occured"
+                    errorCode = "INTERNAL_SERVER_ERROR",
+                    errorMessage = "An unexpected error occurred"
                 )
             )
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -1,0 +1,70 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.dto.ApiErrorResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(Exception::class)
+    fun handleGeneric(ex: Exception): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "INTERNAL_SERVICE_ERROR",
+                    errorMessage = "An unexpected error occured"
+                )
+            )
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "BAD_REQUEST",
+                    errorMessage = ex.message ?: "Invalid request"
+                )
+            )
+    }
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNoSuchElement(ex: NoSuchElementException): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "NOT_FOUND",
+                    errorMessage = ex.message ?: "Resource not found"
+                )
+            )
+    }
+
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleIllegalState(ex: IllegalStateException): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "CONFLICT",
+                    errorMessage = ex.message ?: "Invalid state"
+                )
+            )
+    }
+
+    @ExceptionHandler(SecurityException::class)
+    fun handleSecurity(ex: SecurityException): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "FORBIDDEN",
+                    errorMessage = ex.message ?: "Access denied"
+                )
+            )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -73,9 +73,14 @@ class LobbyController(
     fun leaveLobby(
         @PathVariable lobbyId: String,
         @RequestHeader("X-User-Id") userId: String,
-        ): ResponseEntity<Void> {
-        lobbyService.leaveLobby(lobbyId, userId)
-        return ResponseEntity.noContent().build()
+        ): ResponseEntity<Any> {
+        val updatedLobby = lobbyService.leaveLobby(lobbyId, userId)
+
+        return if (updatedLobby == null) {
+            ResponseEntity.noContent().build()
+        } else {
+            ResponseEntity.ok(updatedLobby.toResponse())
+        }
     }
 
     @PostMapping("/{lobbyId}/ready")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -73,8 +73,9 @@ class LobbyController(
     fun leaveLobby(
         @PathVariable lobbyId: String,
         @RequestHeader("X-User-Id") userId: String,
-        ): LobbyResponse {
-        return lobbyService.leaveLobby(lobbyId, userId).toResponse()
+        ): ResponseEntity<Void> {
+        lobbyService.leaveLobby(lobbyId, userId)
+        return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/{lobbyId}/ready")
@@ -92,7 +93,7 @@ class LobbyController(
      ): LobbyResponse {
         return lobbyService.unreadyLobby(lobbyId, userId).toResponse()
     }
-    
+
     @DeleteMapping("/{lobbyId}")
     fun deleteLobby(
         @PathVariable lobbyId: String,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/ApiErrorResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/ApiErrorResponse.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.dto
+
+data class ApiErrorResponse(
+    val errorCode: String,
+    val errorMessage: String
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -151,7 +151,7 @@ class LobbyService(
     }
 
     @Transactional
-    fun leaveLobby(lobbyId: String, userId: String) {
+    fun leaveLobby(lobbyId: String, userId: String): Lobby? {
         val lobby = getLobby(lobbyId)
 
         if(lobby.status != LobbyStatus.OPEN) {
@@ -166,7 +166,7 @@ class LobbyService(
 
         if(remainingPlayers.isEmpty()) {
             lobbyRepository.deleteById(lobbyId)
-            return
+            return null
         }
 
         val nextHostId = if (lobby.hostUserId == userId) {
@@ -180,7 +180,7 @@ class LobbyService(
             players = lobby.players.filter { it.userId != userId }
         )
 
-        lobbyRepository.save(updatedLobby.toEntity())
+        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
     }
 
     @Transactional

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -10,10 +10,8 @@ import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.mapper.toDomain
 import at.se2group.backend.mapper.toEntity
 import at.se2group.backend.persistence.LobbyRepository
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.server.ResponseStatusException
 import java.time.Instant
 import java.util.UUID
 
@@ -36,10 +34,7 @@ class LobbyService(
     @Transactional
     fun createLobby(userId: String, request: CreateLobbyRequest): Lobby {
         if (request.maxPlayers < MIN_PLAYERS || request.maxPlayers > MAX_PLAYERS) {
-            throw ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                "maxPlayers must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}"
-            )
+            throw IllegalArgumentException("maxPlayers must be between ${MIN_PLAYERS} and ${MAX_PLAYERS}")
         }
 
         val lobby = Lobby(
@@ -68,7 +63,7 @@ class LobbyService(
     fun getLobby(lobbyId: String): Lobby {
         return lobbyRepository.findById(lobbyId)
             .orElseThrow {
-                ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby not found")
+                NoSuchElementException("Lobby not found")
             }
             .toDomain()
     }
@@ -78,15 +73,15 @@ class LobbyService(
         val lobby = getLobby(lobbyId)
 
         if (lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lobby is not open")
+            throw IllegalStateException("Lobby is not open")
         }
 
         if (lobby.players.size >= lobby.settings.maxPlayers) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lobby is full")
+            throw IllegalStateException("Lobby is full")
         }
 
         if (lobby.players.any { it.userId == request.userId }) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Player already in lobby")
+            throw IllegalStateException("Player already in lobby")
         }
 
         val updatedLobby = lobby.copy(
@@ -106,15 +101,15 @@ class LobbyService(
         val lobby = getLobby(lobbyId)
 
         if (lobby.hostUserId != userId) {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can update lobby settings")
+            throw SecurityException("Only the host can update lobby settings")
         }
 
         if (lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Lobby settings can only be changed while the lobby is open")
+            throw IllegalStateException("Lobby settings can only be changed while the lobby is open")
         }
 
         if (request.maxPlayers !in maxOf(MIN_PLAYERS, lobby.players.size)..MAX_PLAYERS) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Maximum players must be between ${maxOf(MIN_PLAYERS, lobby.players.size)} and ${MAX_PLAYERS}")
+            throw IllegalArgumentException("Maximum players must be between ${maxOf(MIN_PLAYERS, lobby.players.size)} and ${MAX_PLAYERS}")
         }
 
         val updatedLobby = lobby.copy(
@@ -133,19 +128,19 @@ class LobbyService(
         val lobby = getLobby(lobbyId)
 
         if (lobby.hostUserId != userId) {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can start the match")
+            throw SecurityException("Only the host can start the match")
         }
 
         if (lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Match can only be started while the lobby is open")
+            throw IllegalStateException("Match can only be started while the lobby is open")
         }
 
         if (lobby.players.size < MIN_PLAYERS) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "At least ${MIN_PLAYERS} players are required to start the match")
+            throw IllegalStateException("At least ${MIN_PLAYERS} players are required to start the match")
         }
 
         if (lobby.players.any { !it.isReady }) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "All players must be ready to start the match")
+            throw IllegalStateException("All players must be ready to start the match")
         }
 
         val updatedLobby = lobby.copy(
@@ -156,22 +151,22 @@ class LobbyService(
     }
 
     @Transactional
-    fun leaveLobby(lobbyId: String, userId: String): Lobby {
+    fun leaveLobby(lobbyId: String, userId: String) {
         val lobby = getLobby(lobbyId)
 
         if(lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot leave an unopen lobby")
+            throw IllegalStateException("Cannot leave an unopen lobby")
         }
 
         if (lobby.players.none { it.userId == userId }) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player found in this lobby")
+            throw IllegalArgumentException("No player found in this lobby")
         }
 
         val remainingPlayers = lobby.players.filter { it.userId != userId }
 
         if(remainingPlayers.isEmpty()) {
             lobbyRepository.deleteById(lobbyId)
-            throw ResponseStatusException(HttpStatus.NO_CONTENT, "Lobby deleted as there are no players left")
+            return
         }
 
         val nextHostId = if (lobby.hostUserId == userId) {
@@ -185,7 +180,7 @@ class LobbyService(
             players = lobby.players.filter { it.userId != userId }
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyRepository.save(updatedLobby.toEntity())
     }
 
     @Transactional
@@ -193,11 +188,11 @@ class LobbyService(
         val lobby = getLobby(lobbyId)
 
         if(lobby.status != LobbyStatus.OPEN) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot change the ready status, while lobby is not open")
+            throw IllegalStateException("You cannot change the ready status, while lobby is not open")
         }
 
         if(lobby.players.none { it.userId == userId}) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player was found in this lobby")
+            throw IllegalArgumentException("No player was found in this lobby")
         }
 
         val updatedLobby = lobby.copy(
@@ -214,11 +209,11 @@ class LobbyService(
          val lobby = getLobby(lobbyId)
 
          if(lobby.status != LobbyStatus.OPEN) {
-             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot change the ready status, while lobby is not open")
+             throw IllegalStateException("You cannot change the ready status, while lobby is not open")
          }
 
          if(lobby.players.none {it.userId == userId}) {
-             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "No player found in this lobby")
+             throw IllegalArgumentException("No player found in this lobby")
          }
 
          val updatedLobby = lobby.copy(
@@ -228,12 +223,12 @@ class LobbyService(
          )
          return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
      }
-     
+
     fun deleteLobby(lobbyId: String, userId: String) {
         val lobby = getLobby(lobbyId)
 
         if (lobby.hostUserId != userId) {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can delete the lobby")
+            throw SecurityException("Only the host can delete the lobby")
         }
 
         lobbyRepository.deleteById(lobbyId)


### PR DESCRIPTION
## Summary

This PR adds centralized error handling for the backend lobby REST API.

The goal of this change is to remove HTTP-specific exception handling from `LobbyService` and handle API errors in one shared place instead. This keeps the service layer cleaner and makes REST error responses more consistent.  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## What this PR includes

- adds a global exception handler in `GlobalExceptionHandler.kt`
- adds a reusable API error DTO in `ApiErrorResponse.kt`
- refactors lobby service logic to stop using `ResponseStatusException`
- updates the lobby REST flow to rely on global exception mapping instead of per-method HTTP exception handling  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Why this PR is needed

Before this PR, lobby-related errors were handled too close to the service logic. This mixes business logic with HTTP concerns and makes error handling harder to keep consistent across the API.

This PR introduces one central place for REST error mapping so the controller and service flow stay simpler and easier to extend later.  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Implementation details

### Global exception handling
A new `GlobalExceptionHandler` was added to map backend exceptions to HTTP responses.

### Reusable error response DTO
A reusable `ApiErrorResponse` was added so error payloads follow a shared JSON structure.

### Service-layer cleanup
`LobbyService` was refactored to throw general exceptions instead of `ResponseStatusException`, so the service layer stays HTTP-agnostic.

### Controller integration
`LobbyController` now relies on the global handler for error responses instead of handling these cases manually.  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Files / areas affected

- `apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/dto/ApiErrorResponse.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt`  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Expected result

After this PR:

- lobby API errors are returned in a consistent JSON format
- service logic is cleaner and less coupled to Spring HTTP classes
- controllers remain thin
- future backend features can reuse the same error handling pattern  [see this PR](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Testing / verification

Please verify at least the following:

- invalid requests return structured JSON errors
- missing lobby resources return the expected error response
- invalid lobby state operations return the expected error response
- lobby endpoints still behave correctly for valid requests
- `LobbyService` no longer depends on `ResponseStatusException`  [see these changes](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/137/changes)

## Checklist

- [ ] `GlobalExceptionHandler` added
- [ ] `ApiErrorResponse` added
- [ ] `LobbyService` refactored away from `ResponseStatusException`
- [ ] lobby API errors return consistent JSON responses
- [ ] controller/service separation is improved

## Issues

- Closes #43 
- Closes #121  