### PR TITLE
feat(backend)(websocket)(lobby): broadcast lobby updated event to web…

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyDeletedEvent.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyDeletedEvent.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.dto
+
+data class LobbyDeletedEvent(
+    val type: String = "lobby.deleted",
+    val lobbyId: String
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyStartedEvent.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyStartedEvent.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.dto
+
+data class LobbyStartedEvent(
+    val type: String = "lobby.started",
+    val lobbyId: String,
+    val matchId: String
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
@@ -1,6 +1,8 @@
 package at.se2group.backend.service
 
 import at.se2group.backend.domain.Lobby
+import at.se2group.backend.dto.LobbyDeletedEvent
+import at.se2group.backend.dto.LobbyStartedEvent
 import at.se2group.backend.dto.LobbyUpdatedEvent
 import at.se2group.backend.mapper.toResponse
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -15,6 +17,23 @@ class LobbyBroadcastService(
         messagingTemplate.convertAndSend(
             "/topic/lobbies/${lobby.lobbyId}",
             LobbyUpdatedEvent(lobby = lobby.toResponse())
+        )
+    }
+
+    fun broadcastLobbyDeleted(lobbyId: String) {
+        messagingTemplate.convertAndSend(
+            "/topic/lobbies/$lobbyId",
+            LobbyDeletedEvent(lobbyId = lobbyId)
+        )
+    }
+
+    fun broadcastLobbyStarted(lobbyId: String, matchId: String) {
+        messagingTemplate.convertAndSend(
+            "/topic/lobbies/$lobbyId",
+            LobbyStartedEvent(
+                lobbyId = lobbyId,
+                matchId = matchId
+            )
         )
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -19,8 +19,7 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class LobbyService(
     private val lobbyRepository: LobbyRepository,
-    private val lobbyBroadcastService: LobbyBroadcastService)
-{
+    private val lobbyBroadcastService: LobbyBroadcastService) {
 
     companion object {
         const val MAX_PLAYERS = 4

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -58,7 +58,9 @@ class LobbyService(
             createdAt = Instant.now()
         )
 
-        return lobbyRepository.save(lobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(lobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
     }
 
     fun getLobby(lobbyId: String): Lobby {
@@ -94,7 +96,9 @@ class LobbyService(
             )
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
     }
 
     @Transactional
@@ -121,10 +125,9 @@ class LobbyService(
             )
         )
 
-        val saved = lobbyRepository.save(lobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
         lobbyBroadcastService.broadcastLobbyUpdated(saved)
-
-        return saved;
+        return saved
     }
 
     @Transactional
@@ -184,7 +187,9 @@ class LobbyService(
             players = lobby.players.filter { it.userId != userId }
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
     }
 
     @Transactional
@@ -205,7 +210,9 @@ class LobbyService(
             }
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
     }
 
      @Transactional
@@ -225,7 +232,9 @@ class LobbyService(
                  if (it.userId == userId) it.copy(isReady = false) else it
              }
          )
-         return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+         lobbyBroadcastService.broadcastLobbyUpdated(saved)
+         return saved
      }
 
     fun deleteLobby(lobbyId: String, userId: String) {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -154,7 +154,9 @@ class LobbyService(
             status = LobbyStatus.IN_GAME
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, saved.lobbyId)
+        return saved
     }
 
     @Transactional
@@ -171,8 +173,9 @@ class LobbyService(
 
         val remainingPlayers = lobby.players.filter { it.userId != userId }
 
-        if(remainingPlayers.isEmpty()) {
+        if (remainingPlayers.isEmpty()) {
             lobbyRepository.deleteById(lobbyId)
+            lobbyBroadcastService.broadcastLobbyDeleted(lobbyId)
             return null
         }
 
@@ -245,5 +248,6 @@ class LobbyService(
         }
 
         lobbyRepository.deleteById(lobbyId)
+        lobbyBroadcastService.broadcastLobbyDeleted(lobbyId)
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -18,8 +18,9 @@ import java.util.UUID
 @Service
 @Transactional(readOnly = true)
 class LobbyService(
-    private val lobbyRepository: LobbyRepository
-) {
+    private val lobbyRepository: LobbyRepository,
+    private val lobbyBroadcastService: LobbyBroadcastService)
+{
 
     companion object {
         const val MAX_PLAYERS = 4
@@ -120,7 +121,10 @@ class LobbyService(
             )
         )
 
-        return lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        val saved = lobbyRepository.save(lobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+
+        return saved;
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

This PR completes the backend websocket integration for the lobby feature by adding event broadcasting for all relevant lobby state changes.

The goal of this change is to ensure that connected clients receive real-time lobby updates whenever the lobby state changes through the REST API. This allows the frontend to keep the lobby screen synchronized without polling.

This PR builds on the previously added websocket foundation and now wires the actual event emissions into the lobby service flow.

## What this PR includes

### Adds websocket event broadcasting in `LobbyService`
This PR integrates websocket broadcasts into the lobby service after relevant lobby state changes.

### Emits lobby events for all important lobby actions
The backend now broadcasts websocket events for the following cases:

- lobby created
- player joined lobby
- player left lobby
- player marked ready
- player marked unready
- lobby settings updated
- lobby started
- lobby deleted

### Uses the existing broadcast service
All websocket emissions are routed through the existing `LobbyBroadcastService` so the send logic remains centralized and consistent.

### Uses the documented lobby websocket event types
This PR emits the documented lobby websocket events:

- `lobby.updated`
- `lobby.deleted`
- `lobby.started`

## Event behavior

### `lobby.updated`
This event is emitted whenever the current lobby state changes and clients should refresh the shown lobby state.

Typical triggers in this PR:
- create lobby
- join lobby
- leave lobby
- ready
- unready
- update settings

### `lobby.deleted`
This event is emitted when a lobby is deleted.

Typical triggers in this PR:
- host deletes lobby
- optional: lobby is removed after the last player leaves, depending on current implementation

### `lobby.started`
This event is emitted when the lobby successfully starts a match.

This event should allow the frontend to transition from the lobby screen to the game screen.

## Why this PR is needed

The websocket infrastructure and event DTOs already exist, but without actual event broadcasting inside the service layer, connected clients still do not receive live updates.

This PR is needed to connect the lobby business logic to the websocket layer so that all players in the same lobby stay synchronized in real time.

## Files / areas affected

Typical affected areas include:

- `apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyUpdatedEvent.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyDeletedEvent.kt`
- `apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyStartedEvent.kt`

## Expected result

After this PR:

- clients subscribed to `/topic/lobbies/{lobbyId}` receive live lobby updates
- the frontend can react to lobby deletion in real time
- the frontend can react to match start in real time
- lobby state changes no longer require polling to become visible to other players

## Testing / verification

Please verify at least the following:

- creating a lobby emits `lobby.updated`
- joining a lobby emits `lobby.updated`
- leaving a lobby emits `lobby.updated`
- ready emits `lobby.updated`
- unready emits `lobby.updated`
- updating settings emits `lobby.updated`
- deleting a lobby emits `lobby.deleted`
- starting a lobby emits `lobby.started`
- events are sent to `/topic/lobbies/{lobbyId}`
- payloads match the documented websocket event structure

## Related issues

- Closes #115 
- Closes #116 
- Closes #117
- Closes #123
- Closes #124
- Closes #125
- Closes #126
- Closes #127

## Checklist

- [ ] `lobby.updated` emitted after create lobby
- [ ] `lobby.updated` emitted after join lobby
- [ ] `lobby.updated` emitted after leave lobby
- [ ] `lobby.updated` emitted after ready
- [ ] `lobby.updated` emitted after unready
- [ ] `lobby.updated` emitted after settings update
- [ ] `lobby.deleted` emitted after lobby deletion
- [ ] `lobby.started` emitted after successful lobby start
- [ ] all event emissions go through `LobbyBroadcastService`
- [ ] websocket topic path uses `/topic/lobbies/{lobbyId}`
- [ ] emitted payloads match the documented event DTOs