### PR TITLE
test(backend)(lobby): add lobby service unit tests - list, create, delete & leave lobby

### DIFF
--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -6,6 +6,8 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import at.se2group.backend.service.LobbyService.Companion.MAX_PLAYERS
+import at.se2group.backend.service.LobbyService.Companion.MIN_PLAYERS
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -21,6 +23,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import kotlin.IllegalArgumentException
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceCreateTest {
@@ -75,6 +78,12 @@ class LobbyServiceCreateTest {
             lobbyService.createLobby("host alice", request)
         }
 
+        val exception = assertThrows<IllegalArgumentException> {
+            lobbyService.createLobby("host alice", request)
+        }
+
+        assertEquals("maxPlayers must be between 2 and 4", exception.message)
+
         verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
         verifyNoInteractions(lobbyBroadcastService)
     }
@@ -88,9 +97,11 @@ class LobbyServiceCreateTest {
             allowGuests = true
         )
 
-        assertThrows<IllegalArgumentException> {
+        val exception = assertThrows<IllegalArgumentException> {
             lobbyService.createLobby("host alice", request)
         }
+
+        assertEquals("maxPlayers must be between 2 and 4", exception.message)
 
         verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
         verifyNoInteractions(lobbyBroadcastService)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -6,8 +6,6 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
-import at.se2group.backend.service.LobbyService.Companion.MAX_PLAYERS
-import at.se2group.backend.service.LobbyService.Companion.MIN_PLAYERS
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -1,11 +1,26 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.dto.CreateLobbyRequest
+import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
 
 @ExtendWith(MockitoExtension::class)
@@ -19,4 +34,95 @@ class LobbyServiceCreateTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `createLobby creates a valid open lobby with host as first player`() {
+        val request = CreateLobbyRequest(
+            displayName = "Alice",
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true
+        )
+
+        Mockito.`when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        val result = lobbyService.createLobby("host alice", request)
+
+        assertEquals("host alice", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(4, result.settings.maxPlayers)
+        assertFalse(result.settings.isPrivate)
+        assertTrue(result.settings.allowGuests)
+        assertEquals(1, result.players.size)
+        assertEquals("host alice", result.players.first().userId)
+        assertEquals("Alice", result.players.first().displayName)
+        assertFalse(result.players.first().isReady)
+
+        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
+    }
+
+    @Test
+    fun `createLobby rejects maxPlayers below minimum`() {
+        val request = CreateLobbyRequest(
+            displayName = "Alice",
+            maxPlayers = 1,
+            isPrivate = false,
+            allowGuests = true
+        )
+
+        assertThrows<IllegalArgumentException> {
+            lobbyService.createLobby("host alice", request)
+        }
+
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `createLobby rejects maxPlayers above maximum`() {
+        val request = CreateLobbyRequest(
+            displayName = "Alice",
+            maxPlayers = 99,
+            isPrivate = false,
+            allowGuests = true
+        )
+
+        assertThrows<IllegalArgumentException> {
+            lobbyService.createLobby("host alice", request)
+        }
+
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `createLobby persists created lobby`() {
+        val request = CreateLobbyRequest(
+            displayName = "Alice",
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true
+        )
+
+        Mockito.`when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        lobbyService.createLobby("host alice", request)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+
+        val saved = captor.value
+        assertEquals("host alice", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+        assertEquals(1, saved.players.size)
+        assertEquals("host alice", saved.players.first().userId)
+        assertEquals("Alice", saved.players.first().displayName)
+        assertFalse(saved.players.first().isReady)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -59,7 +59,20 @@ class LobbyServiceCreateTest {
         assertEquals("Alice", result.players.first().displayName)
         assertFalse(result.players.first().isReady)
 
-        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        val saveCaptor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(saveCaptor.capture())
+
+        val saved = saveCaptor.value
+        assertEquals("host alice", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+        assertEquals(1, saved.players.size)
+        assertEquals("host alice", saved.players.first().userId)
+        assertEquals("Alice", saved.players.first().displayName)
+        assertFalse(saved.players.first().isReady)
+
         verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
     }
 
@@ -71,10 +84,6 @@ class LobbyServiceCreateTest {
             isPrivate = false,
             allowGuests = true
         )
-
-        assertThrows<IllegalArgumentException> {
-            lobbyService.createLobby("host alice", request)
-        }
 
         val exception = assertThrows<IllegalArgumentException> {
             lobbyService.createLobby("host alice", request)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -1,6 +1,5 @@
 package at.se2group.backend.lobby.service
 
-import at.se2group.backend.domain.Lobby
 import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.dto.CreateLobbyRequest
 import at.se2group.backend.persistence.LobbyEntity

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -1,0 +1,22 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceCreateTest {
+
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
@@ -78,9 +78,11 @@ class LobbyServiceGetTest {
         Mockito.`when`(lobbyRepository.findById("missing-lobby"))
             .thenReturn(Optional.empty())
 
-        assertThrows<NoSuchElementException> {
+        val exception = assertThrows<NoSuchElementException> {
             lobbyService.getLobby("missing-lobby")
         }
+
+        assertEquals("Lobby not found", exception.message)
 
         verify(lobbyRepository).findById("missing-lobby")
         verifyNoInteractions(lobbyBroadcastService)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
@@ -1,0 +1,88 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceGetTest {
+
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `getLobby returns existing lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+
+        val result = lobbyService.getLobby("lobby-1")
+
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(4, result.settings.maxPlayers)
+        assertFalse(result.settings.isPrivate)
+        assertTrue(result.settings.allowGuests)
+        assertEquals(1, result.players.size)
+        assertEquals("host-1", result.players.first().userId)
+        assertEquals("Alice", result.players.first().displayName)
+        assertFalse(result.players.first().isReady)
+
+        verify(lobbyRepository).findById("lobby-1")
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `getLobby throws NoSuchElementException when lobby does not exist`() {
+        Mockito.`when`(lobbyRepository.findById("missing-lobby"))
+            .thenReturn(Optional.empty())
+
+        assertThrows<NoSuchElementException> {
+            lobbyService.getLobby("missing-lobby")
+        }
+
+        verify(lobbyRepository).findById("missing-lobby")
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -1,12 +1,28 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceJoinTest {
@@ -19,4 +35,223 @@ class LobbyServiceJoinTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `joinLobby allows a player to join an open lobby successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        val request = JoinLobbyRequest(
+            userId = "player-2",
+            displayName = "Bob"
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+        Mockito.`when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        val result = lobbyService.joinLobby("lobby-1", request)
+
+        assertEquals(2, result.players.size)
+        assertEquals("player-2", result.players.last().userId)
+        assertEquals("Bob", result.players.last().displayName)
+        assertFalse(result.players.last().isReady)
+
+        verify(lobbyRepository).findById("lobby-1")
+        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
+    }
+
+    @Test
+    fun `joinLobby rejects joining when lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.IN_GAME,
+            maxPlayers = 2,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                ),
+                LobbyPlayerEmbeddable(
+                    userId = "player-2",
+                    displayName = "Bob",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        val request = JoinLobbyRequest(
+            userId = "player-3",
+            displayName = "Charlie"
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.joinLobby("lobby-1", request)
+        }
+
+        assertEquals("Lobby is not open", exception.message)
+
+        verify(lobbyRepository).findById("lobby-1")
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `joinLobby rejects joining when lobby is full`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 2,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                ),
+                LobbyPlayerEmbeddable(
+                    userId = "player-2",
+                    displayName = "Bob",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        val request = JoinLobbyRequest(
+            userId = "player-3",
+            displayName = "Charlie"
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.joinLobby("lobby-1", request)
+        }
+
+        assertEquals("Lobby is full", exception.message)
+
+        verify(lobbyRepository).findById("lobby-1")
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `joinLobby rejects joining when player is already in lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                ),
+                LobbyPlayerEmbeddable(
+                    userId = "player-2",
+                    displayName = "Bob",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        val request = JoinLobbyRequest(
+            userId = "player-2",
+            displayName = "Bob"
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.joinLobby("lobby-1", request)
+        }
+
+        assertEquals("Player already in lobby", exception.message)
+
+        verify(lobbyRepository).findById("lobby-1")
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `joinLobby persists updated lobby through repository`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                    joinedAt = Instant.now()
+                )
+            )
+        )
+
+        val request = JoinLobbyRequest(
+            userId = "player-2",
+            displayName = "Bob"
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+        Mockito.`when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        lobbyService.joinLobby("lobby-1", request)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+
+        val saved = captor.value
+        assertEquals(2, saved.players.size)
+        assertEquals("player-2", saved.players.last().userId)
+        assertEquals("Bob", saved.players.last().displayName)
+        assertFalse(saved.players.last().isReady)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -9,6 +9,7 @@ import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -68,13 +69,43 @@ class LobbyServiceJoinTest {
 
         val result = lobbyService.joinLobby("lobby-1", request)
 
-        assertEquals(2, result.players.size)
-        assertEquals("player-2", result.players.last().userId)
-        assertEquals("Bob", result.players.last().displayName)
-        assertFalse(result.players.last().isReady)
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(4, result.settings.maxPlayers)
+        assertFalse(result.settings.isPrivate)
+        assertTrue(result.settings.allowGuests)
 
-        verify(lobbyRepository).findById("lobby-1")
-        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        assertEquals(2, result.players.size)
+
+        val originalPlayer = result.players.first()
+        assertEquals("host-1", originalPlayer.userId)
+        assertEquals("Alice", originalPlayer.displayName)
+        assertFalse(originalPlayer.isReady)
+
+        val joinedPlayer = result.players.last()
+        assertEquals("player-2", joinedPlayer.userId)
+        assertEquals("Bob", joinedPlayer.displayName)
+        assertFalse(joinedPlayer.isReady)
+
+        val saveCaptor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(saveCaptor.capture())
+
+        val saved = saveCaptor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+        assertEquals(2, saved.players.size)
+        assertEquals("host-1", saved.players.first().userId)
+        assertEquals("Alice", saved.players.first().displayName)
+        assertFalse(saved.players.first().isReady)
+        assertEquals("player-2", saved.players.last().userId)
+        assertEquals("Bob", saved.players.last().displayName)
+        assertFalse(saved.players.last().isReady)
+
         verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
     }
 
@@ -249,9 +280,23 @@ class LobbyServiceJoinTest {
         verify(lobbyRepository).save(captor.capture())
 
         val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+
         assertEquals(2, saved.players.size)
-        assertEquals("player-2", saved.players.last().userId)
-        assertEquals("Bob", saved.players.last().displayName)
-        assertFalse(saved.players.last().isReady)
+
+        val originalPlayer = saved.players.first()
+        assertEquals("host-1", originalPlayer.userId)
+        assertEquals("Alice", originalPlayer.displayName)
+        assertFalse(originalPlayer.isReady)
+
+        val joinedPlayer = saved.players.last()
+        assertEquals("player-2", joinedPlayer.userId)
+        assertEquals("Bob", joinedPlayer.displayName)
+        assertFalse(joinedPlayer.isReady)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -1,0 +1,22 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceJoinTest {
+
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
@@ -1,0 +1,22 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceLeaveTest {
+
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
@@ -6,6 +6,7 @@ import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -61,10 +62,16 @@ class LobbyServiceListOpenTest {
         assertEquals("lobby-1", result[0].lobbyId)
         assertEquals("host-1", result[0].hostUserId)
         assertEquals(LobbyStatus.OPEN, result[0].status)
+        assertEquals(4, result[0].settings.maxPlayers)
+        assertFalse(result[0].settings.isPrivate)
+        assertTrue(result[0].settings.allowGuests)
 
         assertEquals("lobby-2", result[1].lobbyId)
         assertEquals("host-2", result[1].hostUserId)
         assertEquals(LobbyStatus.OPEN, result[1].status)
+        assertEquals(3, result[1].settings.maxPlayers)
+        assertTrue(result[1].settings.isPrivate)
+        assertFalse(result[1].settings.allowGuests)
 
         verify(lobbyRepository).findAllByStatus(LobbyStatus.OPEN)
         verifyNoInteractions(lobbyBroadcastService)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
@@ -1,0 +1,85 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceListOpenTest {
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `listOpenLobbies returns open lobbies`() {
+        val entity1 = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf()
+        )
+
+        val entity2 = LobbyEntity(
+            lobbyId = "lobby-2",
+            hostUserId = "host-2",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 3,
+            isPrivate = true,
+            allowGuests = false,
+            createdAt = Instant.now(),
+            players = mutableListOf()
+        )
+
+        Mockito.`when`(lobbyRepository.findAllByStatus(LobbyStatus.OPEN))
+            .thenReturn(listOf(entity1, entity2))
+
+        val result = lobbyService.listOpenLobbies()
+
+        assertEquals(2, result.size)
+        assertEquals("lobby-1", result[0].lobbyId)
+        assertEquals("host-1", result[0].hostUserId)
+        assertEquals(LobbyStatus.OPEN, result[0].status)
+
+        assertEquals("lobby-2", result[1].lobbyId)
+        assertEquals("host-2", result[1].hostUserId)
+        assertEquals(LobbyStatus.OPEN, result[1].status)
+
+        verify(lobbyRepository).findAllByStatus(LobbyStatus.OPEN)
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `listOpenLobbies returns empty list when no open lobbies exist`() {
+        Mockito.`when`(lobbyRepository.findAllByStatus(LobbyStatus.OPEN))
+            .thenReturn(emptyList())
+
+        val result = lobbyService.listOpenLobbies()
+
+        assertTrue(result.isEmpty())
+
+        verify(lobbyRepository).findAllByStatus(LobbyStatus.OPEN)
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceSettingsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceSettingsTest.kt
@@ -1,0 +1,22 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class LobbyServiceSettingsTest {
+
+    @Mock
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Mock
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @InjectMocks
+    lateinit var lobbyService: LobbyService
+}


### PR DESCRIPTION
```bash
# run tests
./gradlew :apps:backend:test
```

---

## Description

Add unit tests for the core `LobbyService` methods that cover the main lobby lifecycle and player interaction flows.

The goal of this issue is to create a solid service-layer test foundation for the lobby feature. The tests should verify both valid behavior and important invalid cases for all main lobby operations.

These tests should focus only on `LobbyService`. The repository and broadcast service should be mocked, and the tests should verify service logic independently from the controller/web layer.

## Issues

#### In this PR was done
- Related to (parent issue) #141 
- Closes #144 
- Closes #147 
- Closes #154 
- Closes #155 

---

- Does **not** cover #150 
- Does **not** cover #151 
- Does **not** cover #152 
- Does **not** cover #153 
- Does **not** cover #154 
- Does **not** cover #155 


## Scope

This PR should include tests for:

- `createLobby`
- `getLobby`
- `listOpenLobbies`
- `joinLobby`

This PR should **not** include tests for:

- `readyLobby`
- `unreadyLobby`
- `updateLobbySettings`
- `startLobby`
- `leaveLobby`
- `deleteLobby`
- shared test fixtures
- exception behavior consistency as a dedicated concern

## What should be tested

### `createLobby`

- creates a valid lobby successfully
- adds the host as the first player
- sets the host to `isReady = false`
- sets the lobby status to `OPEN`
- rejects invalid `maxPlayers` values
- persists the created lobby through the repository
- triggers websocket broadcast if part of the current implementation

### `getLobby`

- returns an existing lobby correctly
- throws `NoSuchElementException` when the lobby does not exist

### `listOpenLobbies`

- returns open lobbies correctly
- returns an empty list when no open lobbies exist

### `joinLobby`

- allows a player to join an open lobby successfully
- adds the joined player with `isReady = false`
- rejects joining when the lobby is full
- rejects joining when the lobby is not open
- rejects joining when the player is already in the lobby
- persists the updated lobby through the repository
- triggers websocket broadcast if part of the current implementation

## Acceptance Criteria

- unit tests exist for the selected core `LobbyService` methods in this PR
- successful cases are covered
- important invalid cases are covered for the included methods
- repository interactions are verified where appropriate
- broadcast interactions are verified where appropriate
- tests are readable and consistent with the current backend test style
- service-layer behavior is tested independently from controller/web-layer behavior
- `readyLobby`, `unreadyLobby`, `updateLobbySettings`, and `startLobby` are left for issue `#142`
- `leaveLobby`, `deleteLobby`, shared fixtures, and dedicated exception consistency coverage are left for issue `#143`

## Notes

- use mocked dependencies for `LobbyRepository`
- mock `LobbyBroadcastService` where needed
- keep the tests focused on service logic, not HTTP responses
- follow the current package and naming conventions used in the backend module

# Mockito Quick Guide **(please use mockito in the unit tests!!!)**

Use Mockito to fake dependencies like repositories and services in tests.

## Basic setup

```kotlin
@ExtendWith(MockitoExtension::class)
class LobbyServiceTest {

    @Mock lateinit var lobbyRepository: LobbyRepository
    @Mock lateinit var lobbyBroadcastService: LobbyBroadcastService

    @InjectMocks lateinit var lobbyService: LobbyService
}
```

## Most useful examples

### Return a value

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))
```

### Test exception case

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.empty())

assertThrows<NoSuchElementException> {
    lobbyService.getLobby("1")
}
```

### Verify a method call

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyRepository).findById("1")
```

### Verify something was not called

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyBroadcastService, never()).broadcastLobbyUpdated(any())
```

### Verify call count

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

verify(lobbyRepository, times(1)).save(any())
```

### Use `any()` for generic arguments

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)
```

### Return the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenAnswer { it.arguments[0] }
```

### Capture the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

val captor = argumentCaptor<LobbyEntity>()
verify(lobbyRepository).save(captor.capture())

assertEquals("lobby-1", captor.firstValue.lobbyId)
```

## Simple rule

- mock dependencies
- test the real service
- verify important interactions

Example:

- mock `LobbyRepository`
- mock `LobbyBroadcastService`
- test real `LobbyService`