### PR TITLE
feat(android)(lobby): add REST API communication to android client

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation(libs.material3)
     implementation(libs.activity.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.runtime)
 
     // Unit tests
     testImplementation(libs.junit4)
@@ -95,4 +96,3 @@ dependencies {
     implementation(libs.moshi)
     implementation(libs.moshi.kotlin)
 }
-

--- a/apps/android/app/src/main/java/at/aau/serg/android/data/lobby/mapper/LobbyMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/data/lobby/mapper/LobbyMapper.kt
@@ -6,14 +6,12 @@ import shared.models.lobby.domain.LobbySettings
 import shared.models.lobby.domain.LobbyStatus
 import shared.models.lobby.response.LobbyPlayerResponse
 import shared.models.lobby.response.LobbyResponse
-import java.time.Instant
 
 fun LobbyPlayerResponse.toDomain(): LobbyPlayer {
     return LobbyPlayer(
         userId = userId,
         displayName = displayName,
-        isReady = isReady,
-        joinedAt = Instant.now()
+        isReady = isReady
     )
 }
 
@@ -27,7 +25,6 @@ fun LobbyResponse.toDomain(): Lobby {
             maxPlayers = maxPlayers,
             isPrivate = isPrivate,
             allowGuests = allowGuests
-        ),
-        createdAt = Instant.now()
+        )
     )
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/data/lobby/mapper/LobbyMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/data/lobby/mapper/LobbyMapper.kt
@@ -1,0 +1,33 @@
+package at.aau.serg.android.data.lobby.mapper
+
+import shared.models.lobby.domain.Lobby
+import shared.models.lobby.domain.LobbyPlayer
+import shared.models.lobby.domain.LobbySettings
+import shared.models.lobby.domain.LobbyStatus
+import shared.models.lobby.response.LobbyPlayerResponse
+import shared.models.lobby.response.LobbyResponse
+import java.time.Instant
+
+fun LobbyPlayerResponse.toDomain(): LobbyPlayer {
+    return LobbyPlayer(
+        userId = userId,
+        displayName = displayName,
+        isReady = isReady,
+        joinedAt = Instant.now()
+    )
+}
+
+fun LobbyResponse.toDomain(): Lobby {
+    return Lobby(
+        lobbyId = lobbyId,
+        hostUserId = hostUserId,
+        players = players.map { it.toDomain() },
+        status = LobbyStatus.valueOf(status),
+        settings = LobbySettings(
+            maxPlayers = maxPlayers,
+            isPrivate = isPrivate,
+            allowGuests = allowGuests
+        ),
+        createdAt = Instant.now()
+    )
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -3,10 +3,7 @@ package at.aau.serg.android.navigation
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -16,6 +13,8 @@ import androidx.navigation.compose.composable
 import at.aau.serg.android.ui.screens.home.HomeScreen
 import at.aau.serg.android.ui.screens.leaderboard.LeaderboardScreen
 import at.aau.serg.android.ui.screens.leaderboard.LeaderboardViewModel
+import at.aau.serg.android.ui.screens.lobby.LobbyScreen
+import at.aau.serg.android.ui.screens.lobby.LobbyViewModel
 
 @Composable
 fun AppNavHost(
@@ -34,12 +33,22 @@ fun AppNavHost(
             val parentEntry = remember(navController.currentBackStackEntry) {
                 navController.getBackStackEntry("root")
             }
+
             val leaderboardVM: LeaderboardViewModel = viewModel(parentEntry)
+            val lobbyVM: LobbyViewModel = viewModel(parentEntry)
             val state by leaderboardVM.loadState.collectAsState()
 
             HomeScreen(
                 state = state,
-                onCreateLobby = { navController.navigate("createLobby") },
+                onCreateLobby = {
+                    lobbyVM.createLobby(
+                        onSuccess = { lobby ->
+                            // Navigate with ONLY the lobbyId
+                            navController.navigate("lobby/${lobby.lobbyId}")
+                        },
+                        onError = { /* show error */ }
+                    )
+                },
                 onBrowseLobbies = { navController.navigate("browseLobbies") },
                 onShowLeaderboard = {
                     leaderboardVM.loadLeaderboard(
@@ -65,7 +74,19 @@ fun AppNavHost(
             )
         }
 
-        composable("createLobby") { Text("TODO: Create Lobby Screen") }
+        // LOBBY SCREEN — loads lobby inside the screen
+        composable("lobby/{lobbyId}") { backStackEntry ->
+            val lobbyId = backStackEntry.arguments?.getString("lobbyId")!!
+            val vm: LobbyViewModel = viewModel()
+
+            LobbyScreen(
+                navController = navController,
+                viewModel = vm,
+                lobbyId = lobbyId
+            )
+        }
+
+        // PLACEHOLDER SCREENS
         composable("browseLobbies") { Text("TODO: Browse Lobbies Screen") }
         composable("settings") { Text("TODO: Settings Screen") }
     }

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
@@ -10,12 +10,20 @@ class LobbyAPI(
         return service.getLobbies()
     }
 
+    suspend fun getLobby(lobbyId: String) : LobbyResponse {
+        return service.getLobby(lobbyId)
+    }
+
+    suspend fun createLobby(userId: String, lobbyRequest: CreateLobbyRequest) : LobbyResponse {
+        return service.createLobby(userId, lobbyRequest)
+    }
+
     suspend fun joinLobby(lobbyId: String): LobbyResponse {
         return service.joinLobby(lobbyId)
     }
 
-    suspend fun leaveLobby(lobbyId: String): Boolean {
-        val response = service.leaveLobby(lobbyId)
+    suspend fun leaveLobby(userId: String, lobbyId: String): Boolean {
+        val response = service.leaveLobby(userId, lobbyId)
         return response.isSuccessful
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
@@ -18,8 +18,8 @@ class LobbyAPI(
         return service.createLobby(userId, lobbyRequest)
     }
 
-    suspend fun joinLobby(lobbyId: String): LobbyResponse {
-        return service.joinLobby(lobbyId)
+    suspend fun joinLobby(lobbyId: String, request: JoinLobbyRequest): LobbyResponse {
+        return service.joinLobby(lobbyId, request)
     }
 
     suspend fun leaveLobby(userId: String, lobbyId: String): Boolean {

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
@@ -1,0 +1,21 @@
+package at.aau.serg.android.network.lobby
+
+import shared.models.lobby.response.*
+import shared.models.lobby.request.*
+
+class LobbyAPI(
+    private val service: LobbyService
+) {
+    suspend fun getLobbies(): List<LobbyListItemResponse> {
+        return service.getLobbies()
+    }
+
+    suspend fun joinLobby(lobbyId: String): LobbyResponse {
+        return service.joinLobby(lobbyId)
+    }
+
+    suspend fun leaveLobby(lobbyId: String): Boolean {
+        val response = service.leaveLobby(lobbyId)
+        return response.isSuccessful
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
@@ -1,0 +1,23 @@
+package at.aau.serg.android.network.lobby
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import shared.models.lobby.request.*
+import shared.models.lobby.response.*
+
+interface LobbyService {
+    @GET("lobbies")
+    suspend fun getLobbies(): List<LobbyListItemResponse>
+
+    @POST("lobbies/{lobbyId}/join")
+    suspend fun joinLobby(
+        @Path("lobbyId") lobbyId: String
+    ): LobbyResponse
+
+    @POST("lobbies/{lobbyId}/leave")
+    suspend fun leaveLobby(
+        @Path("lobbyId")lobbyId: String
+    ): Response<Unit>
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
@@ -1,7 +1,9 @@
 package at.aau.serg.android.network.lobby
 
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import shared.models.lobby.request.*
@@ -11,6 +13,17 @@ interface LobbyService {
     @GET("lobbies")
     suspend fun getLobbies(): List<LobbyListItemResponse>
 
+    @POST("lobbies")
+    suspend fun createLobby(
+        @Header("X-User-Id") userId: String,
+        @Body request: CreateLobbyRequest
+    ): LobbyResponse
+
+    @GET("lobbies/{lobbyId}")
+    suspend fun getLobby(
+        @Path("lobbyId") lobbyId: String
+    ): LobbyResponse
+
     @POST("lobbies/{lobbyId}/join")
     suspend fun joinLobby(
         @Path("lobbyId") lobbyId: String
@@ -18,6 +31,7 @@ interface LobbyService {
 
     @POST("lobbies/{lobbyId}/leave")
     suspend fun leaveLobby(
-        @Path("lobbyId")lobbyId: String
+        @Header("X-User-Id") userId: String,
+        @Path("lobbyId") lobbyId: String
     ): Response<Unit>
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
@@ -26,7 +26,8 @@ interface LobbyService {
 
     @POST("lobbies/{lobbyId}/join")
     suspend fun joinLobby(
-        @Path("lobbyId") lobbyId: String
+        @Path("lobbyId") lobbyId: String,
+        @Body request: JoinLobbyRequest
     ): LobbyResponse
 
     @POST("lobbies/{lobbyId}/leave")

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/leaderboard/LeaderboardLoadState.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/leaderboard/LeaderboardLoadState.kt
@@ -1,8 +1,0 @@
-package at.aau.serg.android.ui.screens.leaderboard
-
-sealed interface LeaderboardLoadState {
-    object Idle : LeaderboardLoadState
-    object Loading : LeaderboardLoadState
-    data class Error(val message: String) : LeaderboardLoadState
-    object Success : LeaderboardLoadState
-}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyScreen.kt
@@ -1,0 +1,50 @@
+package at.aau.serg.android.ui.screens.lobby
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+
+@Composable
+fun LobbyScreen(
+    navController: NavHostController,
+    viewModel: LobbyViewModel,
+    lobbyId: String
+) {
+    val lobbyState by viewModel.lobby.collectAsState()
+
+    LaunchedEffect(lobbyId) {
+        viewModel.loadLobby(lobbyId)
+    }
+
+    when (val lobby = lobbyState) {
+        null -> Text("Loading lobby...")
+        else -> {
+            Column(Modifier.fillMaxSize()) {
+                Text("Lobby ID: ${lobby.lobbyId}")
+
+                Button(
+                    onClick = {
+                        viewModel.leaveLobby(
+                            lobbyId = lobby.lobbyId,
+                            onSuccess = {
+                                navController.navigate("home") {
+                                    popUpTo("home") { inclusive = true }
+                                }
+                            }
+                        )
+                    }
+                ) {
+                    Text("Leave Lobby")
+                }
+            }
+        }
+    }
+}
+

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
@@ -1,0 +1,67 @@
+package at.aau.serg.android.ui.screens.lobby
+
+import at.aau.serg.android.data.lobby.mapper.toDomain
+import at.aau.serg.android.network.RetrofitProvider
+import at.aau.serg.android.network.lobby.LobbyAPI
+import at.aau.serg.android.network.lobby.LobbyService
+import at.aau.serg.android.util.DefaultDispatcherProvider
+import at.aau.serg.android.util.DispatcherProvider
+import at.aau.serg.android.viewmodel.BaseViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import shared.models.lobby.domain.Lobby
+import shared.models.lobby.request.CreateLobbyRequest
+
+class LobbyViewModel(
+    private val api: LobbyAPI = LobbyAPI(
+        RetrofitProvider.retrofit.create(LobbyService::class.java)
+    ),
+    dispatchers: DispatcherProvider = DefaultDispatcherProvider
+) : BaseViewModel(dispatchers) {
+
+    private val _lobby = MutableStateFlow<Lobby?>(null)
+    val lobby = _lobby.asStateFlow()
+
+    fun loadLobby(lobbyId: String) {
+        launchRequest(
+            request = { api.getLobby(lobbyId).toDomain() },
+            onSuccess = { loaded -> _lobby.value = loaded },
+            onError = {}
+        )
+    }
+
+    fun createLobby(
+        onSuccess: (Lobby) -> Unit = {},
+        onError: () -> Unit = {}
+    ) {
+        launchRequest(
+            request = {
+                api.createLobby(
+                    "test",
+                    CreateLobbyRequest(
+                        displayName = "tester",
+                        maxPlayers = 4,
+                        isPrivate = false,
+                        allowGuests = true
+                    )
+                ).toDomain()
+            },
+            onSuccess = { lobby -> onSuccess(lobby) },
+            onError = { onError() }
+        )
+    }
+
+    fun leaveLobby(
+        lobbyId: String,
+        onSuccess: () -> Unit = {},
+        onError: () -> Unit = {}
+    ) {
+        launchRequest(
+            request = { api.leaveLobby("test", lobbyId) },
+            onSuccess = { success ->
+                if (success) onSuccess() else onError()
+            },
+            onError = { onError() }
+        )
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/util/LocalContextProvider.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/util/LocalContextProvider.kt
@@ -1,0 +1,19 @@
+package at.aau.serg.android.util
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
+
+val LocalContextProvider = staticCompositionLocalOf<Context> {
+    error("No context provided")
+}
+
+@Composable
+fun ProvideLocalContext(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    androidx.compose.runtime.CompositionLocalProvider(
+        LocalContextProvider provides context,
+        content = content
+    )
+}

--- a/apps/shared/build.gradle.kts
+++ b/apps/shared/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.serialization)
 }
 
 java {
@@ -25,5 +24,4 @@ kotlin {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(libs.kotlinx.serialization.json)
 }

--- a/apps/shared/src/main/kotlin/shared/models/LeaderboardEntry.kt
+++ b/apps/shared/src/main/kotlin/shared/models/LeaderboardEntry.kt
@@ -1,8 +1,6 @@
 package shared.models
 
-import kotlinx.serialization.Serializable
 
-@Serializable
 data class LeaderboardEntry(
     val rank: Int,
     val playerName: String,

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/Lobby.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/Lobby.kt
@@ -1,0 +1,12 @@
+package shared.models.lobby.domain
+
+import java.time.Instant
+
+data class Lobby(
+    val lobbyId: String,
+    val hostUserId: String,
+    val players: List<LobbyPlayer>,
+    val status: LobbyStatus,
+    val settings: LobbySettings,
+    val createdAt: Instant? = null
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/Lobby.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/Lobby.kt
@@ -7,6 +7,5 @@ data class Lobby(
     val hostUserId: String,
     val players: List<LobbyPlayer>,
     val status: LobbyStatus,
-    val settings: LobbySettings,
-    val createdAt: Instant? = null
+    val settings: LobbySettings
 )

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyPlayer.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyPlayer.kt
@@ -1,0 +1,10 @@
+package shared.models.lobby.domain
+
+import java.time.Instant
+
+data class LobbyPlayer(
+    val userId: String,
+    val displayName: String,
+    val isReady: Boolean = false,
+    val joinedAt: Instant? = Instant.now()
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyPlayer.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyPlayer.kt
@@ -5,6 +5,5 @@ import java.time.Instant
 data class LobbyPlayer(
     val userId: String,
     val displayName: String,
-    val isReady: Boolean = false,
-    val joinedAt: Instant? = Instant.now()
+    val isReady: Boolean = false
 )

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbySettings.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbySettings.kt
@@ -1,0 +1,7 @@
+package shared.models.lobby.domain
+
+data class LobbySettings(
+    val maxPlayers: Int = 4,
+    val isPrivate: Boolean = false,
+    val allowGuests: Boolean = true
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyStatus.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbyStatus.kt
@@ -1,0 +1,7 @@
+package shared.models.lobby.domain
+
+enum class LobbyStatus {
+    OPEN,
+    IN_GAME,
+    CLOSED
+}

--- a/apps/shared/src/main/kotlin/shared/models/lobby/request/CreateLobbyRequest.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/request/CreateLobbyRequest.kt
@@ -1,0 +1,8 @@
+package shared.models.lobby.request
+
+data class CreateLobbyRequest(
+    val displayName: String,
+    val maxPlayers: Int = 4,
+    val isPrivate: Boolean = false,
+    val allowGuests: Boolean = true
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/request/JoinLobbyRequest.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/request/JoinLobbyRequest.kt
@@ -1,0 +1,6 @@
+package shared.models.lobby.request
+
+data class JoinLobbyRequest(
+    val userId: String,
+    val displayName: String
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyListItemResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyListItemResponse.kt
@@ -1,0 +1,10 @@
+package shared.models.lobby.response
+
+data class LobbyListItemResponse(
+    val lobbyId: String,
+    val hostUserId: String,
+    val status: String,
+    val currentPlayerCount: Int,
+    val maxPlayers: Int,
+    val isPrivate: Boolean
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyPlayerResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyPlayerResponse.kt
@@ -1,0 +1,7 @@
+package shared.models.lobby.response
+
+data class LobbyPlayerResponse(
+    val userId: String,
+    val displayName: String,
+    val isReady: Boolean
+)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyResponse.kt
@@ -1,0 +1,11 @@
+package shared.models.lobby.response
+
+data class LobbyResponse(
+    val lobbyId: String,
+    val hostUserId: String,
+    val status: String,
+    val players: List<LobbyPlayerResponse>,
+    val maxPlayers: Int,
+    val isPrivate: Boolean,
+    val allowGuests: Boolean
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ krossbowWebsocketOkhttp = "9.3.0"
 retrofit = "2.11.0"
 moshi = "1.15.1"
 navigationCompose = "2.9.7"
+runtime = "1.10.6"
 
 
 [libraries]
@@ -105,6 +106,7 @@ retrofit-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", v
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "runtime" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary

Add the first Android-side REST API integration for the lobby feature.

This PR introduces the initial frontend communication layer for the lobby flow, including lobby REST calls, mapping of backend responses into Android models, ViewModel wiring, and a first basic lobby screen flow for loading and leaving a lobby. It also adds shared lobby request/response/domain models in the shared module so the Android client can consume the backend lobby API more consistently.  [oai_citation:0‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)

## Related Issue

- Related to #72 
- Related to #73 
- Related to #74 
- Related to #76 
- Related to #77 
- Related to #78 
- Related to #79 
- Related to #80 
- Related to #83
- Related to #84 
- Closed to #87


## What Was Done

- added shared lobby request, response, and domain models in `apps/shared`:
  - `CreateLobbyRequest`
  - `JoinLobbyRequest`
  - `LobbyResponse`
  - `LobbyListItemResponse`
  - `LobbyPlayerResponse`
  - `Lobby`
  - `LobbyPlayer`
  - `LobbySettings`
  - `LobbyStatus`  [oai_citation:1‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)
- added Android lobby mapping logic in `LobbyMapper.kt` to convert backend lobby responses into Android domain models  [oai_citation:2‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- added Android lobby REST service and API wrapper:
  - `LobbyService.kt`
  - `LobbyAPI.kt`  [oai_citation:3‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- implemented initial REST support for:
  - `GET /api/lobbies`
  - `GET /api/lobbies/{lobbyId}`
  - `POST /api/lobbies`
  - `POST /api/lobbies/{lobbyId}/join`
  - `POST /api/lobbies/{lobbyId}/leave`  [oai_citation:4‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)
- updated `LobbyViewModel` to:
  - load a lobby by ID
  - create a lobby
  - leave a lobby
  - use the new lobby API layer  [oai_citation:5‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- added a first basic `LobbyScreen` flow that supports loading and leaving a lobby through the ViewModel  [oai_citation:6‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- updated navigation so the lobby screen can be reached through the app navigation flow  [oai_citation:7‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- added Android build/dependency updates needed for the new REST-related setup  [oai_citation:8‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)

## Scope of This PR

This PR focuses on the **initial REST-based lobby communication layer** on Android.

It includes:
- shared models
- Android mapping
- API/service integration
- ViewModel integration
- initial lobby screen support for loading, creating, and leaving

It does **not** aim to fully complete the final lobby UI or realtime WebSocket behavior yet. The current lobby screen support is a first functional baseline for REST integration.  [oai_citation:9‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)

## How to Test

1. Build the project and make sure the Android app compiles successfully.
2. Start the backend locally.
3. Run the Android app.
4. Navigate to the lobby screen.
5. Verify that loading a lobby by ID works.
6. Verify that creating a lobby works.
7. Verify that leaving a lobby returns success and navigates away correctly.
8. Verify that lobby response data is mapped correctly into the Android lobby model.  [oai_citation:10‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)

## Notes

- this PR introduces shared lobby models in `apps/shared` for easier frontend/backend contract reuse  [oai_citation:11‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)
- the current implementation uses a basic hardcoded user ID in the Android leave flow, so identity handling should be improved later as part of the broader lobby/frontend flow  [oai_citation:12‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156/files)
- WebSocket/live lobby updates are not the focus of this PR and should be handled in follow-up work based on the lobby architecture plan  [oai_citation:13‡GitHub](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/pull/156)

## Checklist

- [ ] I linked the related issues
- [x] The project builds locally
- [x] I tested my changes
- [ ] I updated documentation if needed
- [x] I kept the PR focused and reasonably small