### PR TITLE
test(backend)(lobby): add lobby service unit tests - delete lobby & set players ready / unready 

### DIFF
--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Instant
 import java.util.Optional
@@ -51,8 +52,10 @@ class LobbyServiceDeleteTest {
 
         lobbyService.deleteLobby("lobby-1", "host-1")
 
+        verify(lobbyRepository).findById("lobby-1")
         verify(lobbyRepository).deleteById("lobby-1")
         verify(lobbyBroadcastService).broadcastLobbyDeleted("lobby-1")
+        verifyNoMoreInteractions(lobbyRepository, lobbyBroadcastService)
     }
 
     @Test
@@ -78,6 +81,7 @@ class LobbyServiceDeleteTest {
         }
 
         assertEquals("Only the host can delete the lobby", exception.message)
+        verify(lobbyRepository).findById("lobby-1")
         verify(lobbyRepository, never()).deleteById("lobby-1")
         verifyNoInteractions(lobbyBroadcastService)
     }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
@@ -1,15 +1,28 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceDeleteTest {
+
     @Mock
     lateinit var lobbyRepository: LobbyRepository
 
@@ -18,4 +31,54 @@ class LobbyServiceDeleteTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `deleteLobby allows host to delete lobby successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        lobbyService.deleteLobby("lobby-1", "host-1")
+
+        verify(lobbyRepository).deleteById("lobby-1")
+        verify(lobbyBroadcastService).broadcastLobbyDeleted("lobby-1")
+    }
+
+    @Test
+    fun `deleteLobby rejects if non host tries to delete lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Bob", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<SecurityException> {
+            lobbyService.deleteLobby("lobby-1", "player-2")
+        }
+
+        assertEquals("Only the host can delete the lobby", exception.message)
+        verify(lobbyRepository, never()).deleteById("lobby-1")
+        verifyNoInteractions(lobbyBroadcastService)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
@@ -1,15 +1,32 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceReadyTest {
+
     @Mock
     lateinit var lobbyRepository: LobbyRepository
 
@@ -18,4 +35,94 @@ class LobbyServiceReadyTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `readyLobby marks player as ready successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Bob", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        val result = lobbyService.readyLobby("lobby-1", "player-2")
+
+        val player = result.players.first { it.userId == "player-2" }
+        assertTrue(player.isReady)
+
+        val otherPlayer = result.players.first { it.userId == "host-1" }
+        assertFalse(otherPlayer.isReady)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+        val saved = captor.value
+
+        assertTrue(saved.players.first { it.userId == "player-2" }.isReady)
+        assertFalse(saved.players.first { it.userId == "host-1" }.isReady)
+
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
+    }
+
+    @Test
+    fun `readyLobby rejects if lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.CLOSED,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("player-2", "Bob", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.readyLobby("lobby-1", "player-2")
+        }
+
+        assertEquals("You cannot change the ready status, while lobby is not open", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `readyLobby rejects if player is not in lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            lobbyService.readyLobby("lobby-1", "missing-player")
+        }
+
+        assertEquals("No player was found in this lobby", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
@@ -57,6 +57,13 @@ class LobbyServiceReadyTest {
             .thenAnswer { it.arguments[0] as LobbyEntity }
 
         val result = lobbyService.readyLobby("lobby-1", "player-2")
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(4, result.settings.maxPlayers)
+        assertFalse(result.settings.isPrivate)
+        assertTrue(result.settings.allowGuests)
+        assertEquals(2, result.players.size)
 
         val player = result.players.first { it.userId == "player-2" }
         assertTrue(player.isReady)
@@ -66,7 +73,15 @@ class LobbyServiceReadyTest {
 
         val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
         verify(lobbyRepository).save(captor.capture())
+
         val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+        assertEquals(2, saved.players.size)
 
         assertTrue(saved.players.first { it.userId == "player-2" }.isReady)
         assertFalse(saved.players.first { it.userId == "host-1" }.isReady)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
@@ -1,15 +1,32 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceUnreadyTest {
+
     @Mock
     lateinit var lobbyRepository: LobbyRepository
 
@@ -18,4 +35,94 @@ class LobbyServiceUnreadyTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `unreadyLobby marks player as unready successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Bob", true, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        val result = lobbyService.unreadyLobby("lobby-1", "player-2")
+
+        val player = result.players.first { it.userId == "player-2" }
+        assertFalse(player.isReady)
+
+        val otherPlayer = result.players.first { it.userId == "host-1" }
+        assertTrue(otherPlayer.isReady)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+        val saved = captor.value
+
+        assertFalse(saved.players.first { it.userId == "player-2" }.isReady)
+        assertTrue(saved.players.first { it.userId == "host-1" }.isReady)
+
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
+    }
+
+    @Test
+    fun `unreadyLobby rejects if lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.IN_GAME,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("player-2", "Bob", true, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.unreadyLobby("lobby-1", "player-2")
+        }
+
+        assertEquals("You cannot change the ready status, while lobby is not open", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `unreadyLobby rejects if player is not in lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Alice", true, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            lobbyService.unreadyLobby("lobby-1", "missing-player")
+        }
+
+        assertEquals("No player found in this lobby", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
@@ -57,6 +57,13 @@ class LobbyServiceUnreadyTest {
             .thenAnswer { it.arguments[0] as LobbyEntity }
 
         val result = lobbyService.unreadyLobby("lobby-1", "player-2")
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(4, result.settings.maxPlayers)
+        assertFalse(result.settings.isPrivate)
+        assertTrue(result.settings.allowGuests)
+        assertEquals(2, result.players.size)
 
         val player = result.players.first { it.userId == "player-2" }
         assertFalse(player.isReady)
@@ -66,7 +73,15 @@ class LobbyServiceUnreadyTest {
 
         val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
         verify(lobbyRepository).save(captor.capture())
+
         val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(LobbyStatus.OPEN, saved.status)
+        assertEquals(4, saved.maxPlayers)
+        assertFalse(saved.isPrivate)
+        assertTrue(saved.allowGuests)
+        assertEquals(2, saved.players.size)
 
         assertFalse(saved.players.first { it.userId == "player-2" }.isReady)
         assertTrue(saved.players.first { it.userId == "host-1" }.isReady)


### PR DESCRIPTION
```bash
# run tests
./gradlew :apps:backend:test
```

---

## Description

Add unit tests for the core `LobbyService` methods that cover the main lobby lifecycle and player interaction flows.

The goal of this issue is to create a solid service-layer test foundation for the lobby feature. The tests should verify both valid behavior and important invalid cases for all main lobby operations.

These tests should focus only on `LobbyService`. The repository and broadcast service should be mocked, and the tests should verify service logic independently from the controller/web layer.

## Issues

#### In this PR was done
- Related to (parent issue) #141 
- Closes #146 
- Closes #152 
- Closes #153 

---


- Does **not** cover #150 
- Does **not** cover #151 
- Does **not** cover #154 
- Does **not** cover #155 
- Does **not** cover #144 
- Does **not** cover #147 


## Scope

This PR should include tests for:
- `deleteLobby`
- `readyLobby`
- `unreadyLobby`

This PR should **not** include tests for:


- `updateLobbySettings`
- `startLobby`
- `leaveLobby`
- `createLobby`
- `getLobby`
- `listOpenLobbies`
- `joinLobby`


# Mockito Quick Guide **(please use mockito in the unit tests!!!)**

Use Mockito to fake dependencies like repositories and services in tests.

## Basic setup

```kotlin
@ExtendWith(MockitoExtension::class)
class LobbyServiceTest {

    @Mock lateinit var lobbyRepository: LobbyRepository
    @Mock lateinit var lobbyBroadcastService: LobbyBroadcastService

    @InjectMocks lateinit var lobbyService: LobbyService
}
```

## Most useful examples

### Return a value

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))
```

### Test exception case

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.empty())

assertThrows<NoSuchElementException> {
    lobbyService.getLobby("1")
}
```

### Verify a method call

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyRepository).findById("1")
```

### Verify something was not called

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyBroadcastService, never()).broadcastLobbyUpdated(any())
```

### Verify call count

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

verify(lobbyRepository, times(1)).save(any())
```

### Use `any()` for generic arguments

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)
```

### Return the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenAnswer { it.arguments[0] }
```

### Capture the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

val captor = argumentCaptor<LobbyEntity>()
verify(lobbyRepository).save(captor.capture())

assertEquals("lobby-1", captor.firstValue.lobbyId)
```

## Simple rule

- mock dependencies
- test the real service
- verify important interactions

Example:

- mock `LobbyRepository`
- mock `LobbyBroadcastService`
- test real `LobbyService`