### PR TITLE
design(android)(lobby): added main landing / home screen ui design

### DIFF
--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.aau.serg.android.ui.state.LoadState
+import at.aau.serg.android.ui.theme.ThemeState
 
 @Composable
 fun HomeScreen(
@@ -44,13 +45,51 @@ fun HomeScreen(
     onSettings: () -> Unit,
     onWaitingRoom: () -> Unit
 ) {
+    val darkMode = ThemeState.isDarkMode.value
+
     val backgroundGradient = Brush.verticalGradient(
         colors = listOf(
-            Color(0xFF090F22),
-            Color(0xFF121A31),
-            Color(0xFF0E1429)
+            if (darkMode) MaterialTheme.colorScheme.background else Color(0xFFF6F8FD),
+            if (darkMode) Color(0xFF121A31) else Color(0xFFEFF3FF),
+            if (darkMode) Color(0xFF0E1429) else Color(0xFFE7ECFA)
         )
     )
+
+    val titleColor = if (darkMode) {
+        Color(0xFFEAEFFF)
+    } else {
+        Color(0xFF1D2750)
+    }
+
+    val subtitleColor = if (darkMode) {
+        Color.White.copy(alpha = 0.78f)
+    } else {
+        Color(0xFF4D5A78)
+    }
+
+    val errorColor = if (darkMode) {
+        Color(0xFFFF8F8F)
+    } else {
+        Color(0xFFC74141)
+    }
+
+    val settingsBrush = Brush.horizontalGradient(
+        colors = if (darkMode) {
+            listOf(Color(0xFF2D3951), Color(0xFF253046))
+        } else {
+            listOf(Color(0xFFD7DEEA), Color(0xFFC9D2E2))
+        }
+    )
+
+    val leaderboardBrush = Brush.horizontalGradient(
+        colors = if (darkMode) {
+            listOf(Color(0xFF33435B), Color(0xFF273347))
+        } else {
+            listOf(Color(0xFFDCE3EF), Color(0xFFCED7E7))
+        }
+    )
+
+    val neutralButtonContentColor = if (darkMode) Color.White else Color(0xFF23314C)
 
     Column(
         modifier = modifier
@@ -89,26 +128,26 @@ fun HomeScreen(
             text = "RUMMIKUB",
             style = MaterialTheme.typography.displaySmall,
             fontWeight = FontWeight.Black,
-            color = Color(0xFFEAEFFF)
+            color = titleColor
         )
 
         Text(
             text = "Classic Tile Game",
             style = MaterialTheme.typography.bodyLarge,
-            color = Color.White.copy(alpha = 0.78f)
+            color = subtitleColor
         )
 
         Spacer(modifier = Modifier.height(28.dp))
 
         if (state is LoadState.Loading) {
-            CircularProgressIndicator(color = Color.White)
+            CircularProgressIndicator(color = if (darkMode) Color.White else Color(0xFF456EFF))
             Spacer(modifier = Modifier.height(14.dp))
         }
 
         if (state is LoadState.Error) {
             Text(
                 text = state.message,
-                color = Color(0xFFFF8F8F),
+                color = errorColor,
                 style = MaterialTheme.typography.bodyMedium
             )
             Spacer(modifier = Modifier.height(14.dp))
@@ -117,11 +156,11 @@ fun HomeScreen(
         HomeActionButton(
             text = "Create Lobby",
             onClick = onCreateLobby,
-            icon = {
+            icon = { tint ->
                 Icon(
                     imageVector = Icons.Filled.Person,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = tint,
                     modifier = Modifier.size(24.dp)
                 )
             },
@@ -130,16 +169,16 @@ fun HomeScreen(
             )
         )
 
-        Spacer(modifier = Modifier.height(2.dp))
+        Spacer(modifier = Modifier.height(4.dp))
 
         HomeActionButton(
             text = "Browse Lobbies",
             onClick = onBrowseLobbies,
-            icon = {
+            icon = { tint ->
                 Icon(
                     imageVector = Icons.Filled.Groups,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = tint,
                     modifier = Modifier.size(24.dp)
                 )
             },
@@ -148,16 +187,16 @@ fun HomeScreen(
             )
         )
 
-        Spacer(modifier = Modifier.height(2.dp))
+        Spacer(modifier = Modifier.height(4.dp))
 
         HomeActionButton(
             text = "Waiting Room",
             onClick = onWaitingRoom,
-            icon = {
+            icon = { tint ->
                 Icon(
                     imageVector = Icons.Filled.ViewInAr,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = tint,
                     modifier = Modifier.size(24.dp)
                 )
             },
@@ -171,35 +210,33 @@ fun HomeScreen(
         HomeActionButton(
             text = "Settings",
             onClick = onSettings,
-            icon = {
+            icon = { tint ->
                 Icon(
                     imageVector = Icons.Filled.Settings,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = tint,
                     modifier = Modifier.size(22.dp)
                 )
             },
-            containerBrush = Brush.horizontalGradient(
-                colors = listOf(Color(0xFF2D3951), Color(0xFF253046))
-            )
+            containerBrush = settingsBrush,
+            contentColor = neutralButtonContentColor
         )
 
-        Spacer(modifier = Modifier.height(2.dp))
+        Spacer(modifier = Modifier.height(4.dp))
 
         HomeActionButton(
             text = "Leaderboard",
             onClick = onShowLeaderboard,
-            icon = {
+            icon = { tint ->
                 Icon(
                     imageVector = Icons.Filled.EmojiEvents,
                     contentDescription = null,
-                    tint = Color.White,
+                    tint = tint,
                     modifier = Modifier.size(22.dp)
                 )
             },
-            containerBrush = Brush.horizontalGradient(
-                colors = listOf(Color(0xFF33435B), Color(0xFF273347))
-            )
+            containerBrush = leaderboardBrush,
+            contentColor = neutralButtonContentColor
         )
     }
 }
@@ -208,20 +245,27 @@ fun HomeScreen(
 private fun HomeActionButton(
     text: String,
     onClick: () -> Unit,
-    icon: @Composable () -> Unit,
-    containerBrush: Brush
+    icon: @Composable (Color) -> Unit,
+    containerBrush: Brush,
+    contentColor: Color = Color.White
 ) {
     Button(
         onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .height(62.dp),
+            .height(56.dp),
         shape = RoundedCornerShape(16.dp),
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
             contentColor = Color.White
         ),
-        contentPadding = ButtonDefaults.ContentPadding
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+        elevation = ButtonDefaults.buttonElevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+            focusedElevation = 0.dp,
+            hoveredElevation = 0.dp
+        )
     ) {
         Box(
             modifier = Modifier
@@ -234,13 +278,13 @@ private fun HomeActionButton(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                icon()
+                icon(contentColor)
                 Spacer(modifier = Modifier.size(12.dp))
                 Text(
                     text = text,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = Color.White
+                    color = contentColor
                 )
             }
         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -1,21 +1,42 @@
 package at.aau.serg.android.ui.screens.home
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ViewInAr
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import at.aau.serg.android.util.findActivity
-import at.aau.serg.android.ui.state.LoadState   // ← NEW IMPORT
+import at.aau.serg.android.ui.state.LoadState
 
 @Composable
 fun HomeScreen(
-    state: LoadState,   // ← UPDATED TYPE
+    state: LoadState,
     modifier: Modifier = Modifier,
     onCreateLobby: () -> Unit,
     onBrowseLobbies: () -> Unit,
@@ -23,65 +44,205 @@ fun HomeScreen(
     onSettings: () -> Unit,
     onWaitingRoom: () -> Unit
 ) {
-    val activity = LocalContext.current.findActivity()
+    val backgroundGradient = Brush.verticalGradient(
+        colors = listOf(
+            Color(0xFF090F22),
+            Color(0xFF121A31),
+            Color(0xFF0E1429)
+        )
+    )
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Center
+            .background(backgroundGradient)
+            .padding(horizontal = 28.dp, vertical = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        // Loading indicator
-        if (state is LoadState.Loading) {
-            CircularProgressIndicator()
-            Spacer(Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(RoundedCornerShape(28.dp))
+                .background(
+                    Brush.linearGradient(
+                        colors = listOf(
+                            Color(0xFF4F8DFF),
+                            Color(0xFF9B42FF)
+                        )
+                    )
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ViewInAr,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(60.dp)
+            )
         }
 
-        // Error message
+        Spacer(modifier = Modifier.height(22.dp))
+
+        Text(
+            text = "RUMMIKUB",
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.Black,
+            color = Color(0xFFEAEFFF)
+        )
+
+        Text(
+            text = "Classic Tile Game",
+            style = MaterialTheme.typography.bodyLarge,
+            color = Color.White.copy(alpha = 0.78f)
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        if (state is LoadState.Loading) {
+            CircularProgressIndicator(color = Color.White)
+            Spacer(modifier = Modifier.height(14.dp))
+        }
+
         if (state is LoadState.Error) {
             Text(
                 text = state.message,
-                color = Color.Red,
-                style = MaterialTheme.typography.bodyLarge
+                color = Color(0xFFFF8F8F),
+                style = MaterialTheme.typography.bodyMedium
             )
-            Spacer(Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(14.dp))
         }
 
-        Button(onClick = onCreateLobby) {
-            Text("Create Lobby")
-        }
+        HomeActionButton(
+            text = "Create Lobby",
+            onClick = onCreateLobby,
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            containerBrush = Brush.horizontalGradient(
+                colors = listOf(Color(0xFF4B68FF), Color(0xFF4B3FD4))
+            )
+        )
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(2.dp))
 
-        Button(onClick = onBrowseLobbies) {
-            Text("Browse Lobbies")
-        }
+        HomeActionButton(
+            text = "Browse Lobbies",
+            onClick = onBrowseLobbies,
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.Groups,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            containerBrush = Brush.horizontalGradient(
+                colors = listOf(Color(0xFF9D3CFF), Color(0xFF7D23D7))
+            )
+        )
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(2.dp))
 
-        Button(onClick = onWaitingRoom) {
-            Text("Waiting Room")
-        }
+        HomeActionButton(
+            text = "Waiting Room",
+            onClick = onWaitingRoom,
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.ViewInAr,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp)
+                )
+            },
+            containerBrush = Brush.horizontalGradient(
+                colors = listOf(Color(0xFF4C59E8), Color(0xFF3154C8))
+            )
+        )
 
-        Spacer(Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
-        /*Button(
+        HomeActionButton(
+            text = "Settings",
+            onClick = onSettings,
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(22.dp)
+                )
+            },
+            containerBrush = Brush.horizontalGradient(
+                colors = listOf(Color(0xFF2D3951), Color(0xFF253046))
+            )
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        HomeActionButton(
+            text = "Leaderboard",
             onClick = onShowLeaderboard,
-            enabled = state !is LoadState.Loading   // ← UPDATED
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.EmojiEvents,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(22.dp)
+                )
+            },
+            containerBrush = Brush.horizontalGradient(
+                colors = listOf(Color(0xFF33435B), Color(0xFF273347))
+            )
+        )
+    }
+}
+
+@Composable
+private fun HomeActionButton(
+    text: String,
+    onClick: () -> Unit,
+    icon: @Composable () -> Unit,
+    containerBrush: Brush
+) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(62.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = Color.White
+        ),
+        contentPadding = ButtonDefaults.ContentPadding
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(16.dp))
+                .background(containerBrush),
+            contentAlignment = Alignment.Center
         ) {
-            Text("Leaderboard")
-        }
-
-        Spacer(Modifier.height(12.dp)) */
-
-        Button(onClick = onSettings) {
-            Text("Settings")
-        }
-
-        Spacer(Modifier.height(12.dp))
-
-        Button(onClick = { activity?.finish() }) {
-            Text("Exit")
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                icon()
+                Spacer(modifier = Modifier.size(12.dp))
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
         }
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package at.aau.serg.android.ui.screens.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Groups
@@ -90,154 +92,236 @@ fun HomeScreen(
     )
 
     val neutralButtonContentColor = if (darkMode) Color.White else Color(0xFF23314C)
-
+    val playerBarBackground = if (darkMode) Color(0xFF151D34) else Color(0xFFF3F6FC)
+    val playerBarBorder = if (darkMode) Color.White.copy(alpha = 0.05f) else Color(0xFFD5DDEA)
+    val playerIconBackground = if (darkMode) Color(0xFF27324A) else Color(0xFFE3E9F4)
+    val playerNameColor = if (darkMode) Color.White else Color(0xFF1E2847)
+    val playerLevelColor = if (darkMode) Color(0xFFFFD93D) else Color(0xFFC08A00)
+    val xpColor = if (darkMode) Color(0xFF9AA6C0) else Color(0xFF6A7692)
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(backgroundGradient)
-            .padding(horizontal = 28.dp, vertical = 32.dp),
+            .background(backgroundGradient),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.height(20.dp))
-
-        Box(
+        Column(
             modifier = Modifier
-                .size(120.dp)
-                .clip(RoundedCornerShape(28.dp))
-                .background(
-                    Brush.linearGradient(
-                        colors = listOf(
-                            Color(0xFF4F8DFF),
-                            Color(0xFF9B42FF)
-                        )
-                    )
-                ),
-            contentAlignment = Alignment.Center
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 28.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
-                imageVector = Icons.Filled.ViewInAr,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(60.dp)
-            )
-        }
+            Spacer(modifier = Modifier.height(20.dp))
 
-        Spacer(modifier = Modifier.height(22.dp))
-
-        Text(
-            text = "RUMMIKUB",
-            style = MaterialTheme.typography.displaySmall,
-            fontWeight = FontWeight.Black,
-            color = titleColor
-        )
-
-        Text(
-            text = "Classic Tile Game",
-            style = MaterialTheme.typography.bodyLarge,
-            color = subtitleColor
-        )
-
-        Spacer(modifier = Modifier.height(28.dp))
-
-        if (state is LoadState.Loading) {
-            CircularProgressIndicator(color = if (darkMode) Color.White else Color(0xFF456EFF))
-            Spacer(modifier = Modifier.height(14.dp))
-        }
-
-        if (state is LoadState.Error) {
-            Text(
-                text = state.message,
-                color = errorColor,
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Spacer(modifier = Modifier.height(14.dp))
-        }
-
-        HomeActionButton(
-            text = "Create Lobby",
-            onClick = onCreateLobby,
-            icon = { tint ->
-                Icon(
-                    imageVector = Icons.Filled.Person,
-                    contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(24.dp)
-                )
-            },
-            containerBrush = Brush.horizontalGradient(
-                colors = listOf(Color(0xFF4B68FF), Color(0xFF4B3FD4))
-            )
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        HomeActionButton(
-            text = "Browse Lobbies",
-            onClick = onBrowseLobbies,
-            icon = { tint ->
-                Icon(
-                    imageVector = Icons.Filled.Groups,
-                    contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(24.dp)
-                )
-            },
-            containerBrush = Brush.horizontalGradient(
-                colors = listOf(Color(0xFF9D3CFF), Color(0xFF7D23D7))
-            )
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        HomeActionButton(
-            text = "Waiting Room",
-            onClick = onWaitingRoom,
-            icon = { tint ->
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                Color(0xFF4F8DFF),
+                                Color(0xFF9B42FF)
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(
                     imageVector = Icons.Filled.ViewInAr,
                     contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(24.dp)
+                    tint = Color.White,
+                    modifier = Modifier.size(60.dp)
                 )
-            },
-            containerBrush = Brush.horizontalGradient(
-                colors = listOf(Color(0xFF4C59E8), Color(0xFF3154C8))
+            }
+
+            Spacer(modifier = Modifier.height(22.dp))
+
+            Text(
+                text = "RUMMIKUB",
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Black,
+                color = titleColor
             )
-        )
 
-        Spacer(modifier = Modifier.height(10.dp))
+            Text(
+                text = "Classic Tile Game",
+                style = MaterialTheme.typography.bodyLarge,
+                color = subtitleColor
+            )
 
-        HomeActionButton(
-            text = "Settings",
-            onClick = onSettings,
-            icon = { tint ->
-                Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(22.dp)
+            Spacer(modifier = Modifier.height(28.dp))
+
+            if (state is LoadState.Loading) {
+                CircularProgressIndicator(color = if (darkMode) Color.White else Color(0xFF456EFF))
+                Spacer(modifier = Modifier.height(14.dp))
+            }
+
+            if (state is LoadState.Error) {
+                Text(
+                    text = state.message,
+                    color = errorColor,
+                    style = MaterialTheme.typography.bodyMedium
                 )
-            },
-            containerBrush = settingsBrush,
-            contentColor = neutralButtonContentColor
-        )
+                Spacer(modifier = Modifier.height(14.dp))
+            }
 
-        Spacer(modifier = Modifier.height(4.dp))
-
-        HomeActionButton(
-            text = "Leaderboard",
-            onClick = onShowLeaderboard,
-            icon = { tint ->
-                Icon(
-                    imageVector = Icons.Filled.EmojiEvents,
-                    contentDescription = null,
-                    tint = tint,
-                    modifier = Modifier.size(22.dp)
+            HomeActionButton(
+                text = "Create Lobby",
+                onClick = onCreateLobby,
+                icon = { tint ->
+                    Icon(
+                        imageVector = Icons.Filled.Person,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier.size(24.dp)
+                    )
+                },
+                containerBrush = Brush.horizontalGradient(
+                    colors = listOf(Color(0xFF4B68FF), Color(0xFF4B3FD4))
                 )
-            },
-            containerBrush = leaderboardBrush,
-            contentColor = neutralButtonContentColor
-        )
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            HomeActionButton(
+                text = "Browse Lobbies",
+                onClick = onBrowseLobbies,
+                icon = { tint ->
+                    Icon(
+                        imageVector = Icons.Filled.Groups,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier.size(24.dp)
+                    )
+                },
+                containerBrush = Brush.horizontalGradient(
+                    colors = listOf(Color(0xFF9D3CFF), Color(0xFF7D23D7))
+                )
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            HomeActionButton(
+                text = "Waiting Room",
+                onClick = onWaitingRoom,
+                icon = { tint ->
+                    Icon(
+                        imageVector = Icons.Filled.ViewInAr,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier.size(24.dp)
+                    )
+                },
+                containerBrush = Brush.horizontalGradient(
+                    colors = listOf(Color(0xFF4C59E8), Color(0xFF3154C8))
+                )
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            HomeActionButton(
+                text = "Settings",
+                onClick = onSettings,
+                icon = { tint ->
+                    Icon(
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier.size(22.dp)
+                    )
+                },
+                containerBrush = settingsBrush,
+                contentColor = neutralButtonContentColor
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            HomeActionButton(
+                text = "Leaderboard",
+                onClick = onShowLeaderboard,
+                icon = { tint ->
+                    Icon(
+                        imageVector = Icons.Filled.EmojiEvents,
+                        contentDescription = null,
+                        tint = tint,
+                        modifier = Modifier.size(22.dp)
+                    )
+                },
+                containerBrush = leaderboardBrush,
+                contentColor = neutralButtonContentColor
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp))
+                .background(playerBarBackground)
+                .border(
+                    width = 1.dp,
+                    color = playerBarBorder,
+                    shape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp)
+                )
+                .padding(horizontal = 20.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(playerIconBackground),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Person,
+                        contentDescription = null,
+                        tint = if (darkMode) Color.White.copy(alpha = 0.92f) else Color(0xFF58657F),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Column {
+                    Text(
+                        text = "Player123",
+                        color = playerNameColor,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "#482731",
+                        color = xpColor,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            Column(
+                horizontalAlignment = Alignment.End
+            ) {
+                Text(
+                    text = "Level 12",
+                    color = playerLevelColor,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "850 XP",
+                    color = xpColor,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Add the initial Android **main landing / home screen UI design** for the lobby flow.

This PR focuses on the first visual and structural version of the Android home / landing experience for the lobby feature. It adds the new UI design, improves styling support for light and dark mode, and includes player info details in the bottom section of the screen.
<img width="2574" height="1572" alt="image" src="https://github.com/user-attachments/assets/cc8ec4ab-f912-4585-a397-5b33c6b34eb4" />


## Related Issues

- Related to #77 
- Related to #78
- Related to #103

## Type of Change

- [x] Feature
- [x] UI / design
- [x] Styling update

## What Was Done

- added the initial Android main landing / home screen UI design
- refactored the home / landing screen structure
- added styling improvements to better support light and dark mode
- added player info details in the lower section of the screen
- improved the general visual layout of the screen for the lobby entry flow

## Scope of This PR

This PR is mainly about the **design and presentation layer** of the Android lobby landing flow.

It focuses on:
- the main landing / home screen UI
- visual structure
- styling improvements
- player info presentation

It does **not** aim to fully implement the complete lobby flow, backend integration, or realtime functionality yet.

## How to Test

1. Build and run the Android app.
2. Open the app and navigate to the updated landing / home screen.
3. Verify that the new screen layout renders correctly.
4. Verify that the styling works in both light mode and dark mode.
5. Check that the player info section at the bottom is displayed correctly.
6. Review the overall layout spacing, readability, and visual consistency.

## Notes

- this PR is mainly a **UI design step** for the Android lobby flow
- it should be reviewed mostly from a screen structure, styling, and UX perspective
- backend/API integration is not the main focus here
- future follow-up work should connect this UI more cleanly with the full lobby navigation and state flow

## Checklist

- [x] I linked the related issues
- [x] The project builds locally
- [x] I tested my changes
- [x] I updated documentation if needed
- [x] I kept the PR focused and reasonably small