### PR TITLE
test(backend)(lobby): add lobby service unit tests - update, start & leave lobby

### DIFF
--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
@@ -1,12 +1,28 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.domain.Lobby
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.Optional
+import java.time.Instant
+
+
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceLeaveTest {
@@ -19,4 +35,149 @@ class LobbyServiceLeaveTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    private fun <T> any(): T {
+        org.mockito.Mockito.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
+
+    @Test
+    fun `leaveLobby allows player to leave successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any()))
+            .thenAnswer {it.arguments[0] as LobbyEntity}
+
+        lobbyService.leaveLobby("lobby-1", "player-2")
+
+        verify(lobbyRepository).save(any())
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(any())
+    }
+
+    @Test
+    fun `leaveLobby rejects when lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.IN_GAME,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.leaveLobby("lobby-1", "player-2")
+        }
+
+        assertEquals("Cannot leave an unopen lobby", exception.message)
+        verify(lobbyRepository, never()).save(any())
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+
+    @Test
+    fun `leaveLobby rejects when player is not in lobby`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now())
+
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            lobbyService.leaveLobby("lobby-1", "missed-player")
+        }
+
+        assertEquals("No player found in this lobby", exception.message)
+        verify(lobbyRepository, never()).save(any())
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+
+    @Test
+    fun `leaveLobby assigns new host when previous host and its players exit the game`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any()))
+            .thenAnswer {it.arguments[0] as LobbyEntity }
+
+        val result = lobbyService.leaveLobby("lobby-1", "host-1")
+
+
+        assertEquals("player-2", result!!.hostUserId)
+        verify(lobbyRepository).save(any())
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(any())
+    }
+
+
+
+
+    @Test
+    fun `leaveLobby deletes lobby when host leaves`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now())
+            )
+        )
+
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+
+            lobbyService.leaveLobby("lobby-1", "host-1")
+
+
+
+        verify(lobbyRepository).deleteById("lobby-1")
+        verify(lobbyBroadcastService).broadcastLobbyDeleted("lobby-1")
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
@@ -5,8 +5,6 @@ import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
-import at.se2group.backend.dto.UpdateLobbySettingsRequest
-import at.se2group.backend.domain.Lobby
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -16,6 +14,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.ArgumentCaptor
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -62,9 +61,23 @@ class LobbyServiceLeaveTest {
         `when`(lobbyRepository.save(any()))
             .thenAnswer {it.arguments[0] as LobbyEntity}
 
-        lobbyService.leaveLobby("lobby-1", "player-2")
+        val result = lobbyService.leaveLobby("lobby-1", "player-2")
 
-        verify(lobbyRepository).save(any())
+        assertEquals("lobby-1", result!!.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(1, result.players.size)
+        assertEquals("host-1", result.players[0].userId)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+        val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(1, saved.players.size)
+        assertEquals("host-1", saved.players[0].userId)
+
+
         verify(lobbyBroadcastService).broadcastLobbyUpdated(any())
     }
 
@@ -146,9 +159,20 @@ class LobbyServiceLeaveTest {
 
         val result = lobbyService.leaveLobby("lobby-1", "host-1")
 
+        assertEquals("lobby-1", result!!.lobbyId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(1, result.players.size)
+        assertEquals("player-2", result.players[0].userId)
 
-        assertEquals("player-2", result!!.hostUserId)
-        verify(lobbyRepository).save(any())
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+
+        val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("player-2", saved.hostUserId)
+        assertEquals(1, saved.players.size)
+        assertEquals("player-2", saved.players[0].userId)
+
         verify(lobbyBroadcastService).broadcastLobbyUpdated(any())
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
@@ -5,10 +5,8 @@ import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
-import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -19,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.ArgumentCaptor
 import java.util.Optional
 import java.time.Instant
 
@@ -33,6 +32,12 @@ class LobbyServiceStartTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    private fun <T> any(): T {
+        org.mockito.Mockito.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
 
     @Test
     fun `startLobby allows host to start successfully`() {
@@ -51,14 +56,26 @@ class LobbyServiceStartTest {
             )
         )
         `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
-        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+        `when`(lobbyRepository.save(any()))
             .thenAnswer { it.arguments[0] as LobbyEntity }
 
 
         val result = lobbyService.startLobby("lobby-1", "host-1")
 
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
         assertEquals(LobbyStatus.IN_GAME, result.status)
-        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        assertEquals(3, result.players.size)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+        val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(LobbyStatus.IN_GAME, saved.status)
+        assertEquals(3, saved.players.size)
+
+
         verify(lobbyBroadcastService).broadcastLobbyStarted(result.lobbyId, result.lobbyId)
 
     }
@@ -86,7 +103,7 @@ class LobbyServiceStartTest {
         }
 
         assertEquals("Only the host can start the match", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
 
     }
@@ -102,7 +119,8 @@ class LobbyServiceStartTest {
             allowGuests = true,
             createdAt = Instant.now(),
             players = mutableListOf(
-                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now())
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", true, Instant.now())
             )
         )
         `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
@@ -113,7 +131,7 @@ class LobbyServiceStartTest {
 
 
         assertEquals("Match can only be started while the lobby is open", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 
@@ -140,7 +158,7 @@ class LobbyServiceStartTest {
         }
 
         assertEquals("At least 2 players are required to start the match", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 
@@ -168,7 +186,7 @@ class LobbyServiceStartTest {
         }
 
         assertEquals("All players must be ready to start the match", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
@@ -1,12 +1,27 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.Optional
+import java.time.Instant
+
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceStartTest {
@@ -18,4 +33,143 @@ class LobbyServiceStartTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    @Test
+    fun `startLobby allows host to start successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-3", "Alex", true, Instant.now())
+            )
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+            .thenAnswer { it.arguments[0] as LobbyEntity }
+
+
+        val result = lobbyService.startLobby("lobby-1", "host-1")
+
+        assertEquals(LobbyStatus.IN_GAME, result.status)
+        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        verify(lobbyBroadcastService).broadcastLobbyStarted(result.lobbyId, result.lobbyId)
+
+    }
+
+    @Test
+    fun `startLobby rejects when non host tries to start`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", true, Instant.now())
+            )
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+
+        val exception = assertThrows<SecurityException> {
+            lobbyService.startLobby("lobby-1","player-2")
+        }
+
+        assertEquals("Only the host can start the match", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+
+    }
+
+    @Test
+    fun `startLobby rejects when lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.IN_GAME,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now())
+            )
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.startLobby("lobby-1", "host-1")
+        }
+
+
+        assertEquals("Match can only be started while the lobby is open", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `startLobby rejects when MIN_PLAYERS is not valid`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now())
+            )
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.startLobby("lobby-1", "host-1")
+        }
+
+        assertEquals("At least 2 players are required to start the match", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `startLobby rejects when not all players are ready`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", true, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-3", "Alex", true, Instant.now())
+            )
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.startLobby("lobby-1", "host-1")
+        }
+
+        assertEquals("All players must be ready to start the match", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
@@ -8,7 +8,6 @@ import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -19,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.ArgumentCaptor
 import java.util.Optional
 import java.time.Instant
 
@@ -34,6 +34,12 @@ class LobbyServiceUpdateSettingsTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+    private fun <T> any(): T {
+        org.mockito.Mockito.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
 
 
     @Test
@@ -52,14 +58,28 @@ class LobbyServiceUpdateSettingsTest {
 
         )
         `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
-        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+        `when`(lobbyRepository.save(any()))
         .thenAnswer { it.arguments[0] as LobbyEntity }
 
         val request = UpdateLobbySettingsRequest(maxPlayers = 3, isPrivate = true, allowGuests = false)
         val result = lobbyService.updateLobbySettings("lobby-1", "host-1", request)
 
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("host-1", result.hostUserId)
+        assertEquals(LobbyStatus.OPEN, result.status)
+        assertEquals(true, result.settings.isPrivate)
+        assertEquals(false, result.settings.allowGuests)
+
+        val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
+        verify(lobbyRepository).save(captor.capture())
+        val saved = captor.value
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("host-1", saved.hostUserId)
+        assertEquals(3, saved.maxPlayers)
+        assertEquals(true, saved.isPrivate)
+        assertEquals(false, saved.allowGuests)
+
         assertEquals(3, result.settings.maxPlayers)
-        verify(lobbyRepository).save(any(LobbyEntity::class.java))
         verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
     }
 
@@ -87,7 +107,7 @@ class LobbyServiceUpdateSettingsTest {
         }
 
         assertEquals("Only the host can update lobby settings", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 
@@ -115,12 +135,12 @@ class LobbyServiceUpdateSettingsTest {
         }
 
         assertEquals("Lobby settings can only be changed while the lobby is open", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 
     @Test
-    fun `updateLobbySettings rejects when number of players exceeds mayPlayers`() {
+    fun `updateLobbySettings rejects when number of players exceeds maxPlayers`() {
         val entity = LobbyEntity(
             lobbyId = "lobby-1",
             hostUserId = "host-1",
@@ -145,7 +165,7 @@ class LobbyServiceUpdateSettingsTest {
         }
 
         assertEquals("Maximum players must be between 3 and 4", exception.message)
-        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
@@ -1,12 +1,27 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.persistence.LobbyEntity
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.Optional
+import java.time.Instant
+
 
 @ExtendWith(MockitoExtension::class)
 class LobbyServiceUpdateSettingsTest {
@@ -19,4 +34,118 @@ class LobbyServiceUpdateSettingsTest {
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
+
+
+    @Test
+    fun ` updateLobbySettings allows host to update successfully`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate  = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now())
+            )
+
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+        `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
+        .thenAnswer { it.arguments[0] as LobbyEntity }
+
+        val request = UpdateLobbySettingsRequest(maxPlayers = 3, isPrivate = true, allowGuests = false)
+        val result = lobbyService.updateLobbySettings("lobby-1", "host-1", request)
+
+        assertEquals(3, result.settings.maxPlayers)
+        verify(lobbyRepository).save(any(LobbyEntity::class.java))
+        verify(lobbyBroadcastService).broadcastLobbyUpdated(result)
+    }
+
+    @Test
+    fun ` updateLobbySettings rejects when non host tries to update`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate  = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now())
+            )
+
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val request = UpdateLobbySettingsRequest(maxPlayers = 3, isPrivate = true, allowGuests = false)
+        val exception = assertThrows<SecurityException> {
+            lobbyService.updateLobbySettings("lobby-1", "player-2",request)
+        }
+
+        assertEquals("Only the host can update lobby settings", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun ` updateLobbySettings rejects when lobby is not open`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.IN_GAME,
+            maxPlayers = 4,
+            isPrivate  = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+
+            )
+
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val request = UpdateLobbySettingsRequest(maxPlayers = 3, isPrivate = true, allowGuests = false)
+        val exception = assertThrows<IllegalStateException> {
+            lobbyService.updateLobbySettings("lobby-1", "host-1",request)
+        }
+
+        assertEquals("Lobby settings can only be changed while the lobby is open", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
+
+    @Test
+    fun `updateLobbySettings rejects when number of players exceeds mayPlayers`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate  = false,
+            allowGuests = true,
+            createdAt = Instant.now(),
+            players = mutableListOf(
+                LobbyPlayerEmbeddable("host-1", "Anna", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-2", "Marco", false, Instant.now()),
+                LobbyPlayerEmbeddable("player-3", "Alex", false, Instant.now())
+
+            )
+
+        )
+        `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
+
+        val request = UpdateLobbySettingsRequest(maxPlayers = 2, isPrivate = true, allowGuests = false)
+        val exception = assertThrows<IllegalArgumentException> {
+            lobbyService.updateLobbySettings("lobby-1", "host-1",request)
+        }
+
+        assertEquals("Maximum players must be between 3 and 4", exception.message)
+        verify(lobbyRepository, never()).save(any(LobbyEntity::class.java))
+        verifyNoInteractions(lobbyBroadcastService)
+    }
 }


### PR DESCRIPTION
```bash
# run tests
./gradlew :apps:backend:test
```

---

## Description

Add unit tests for the core `LobbyService` methods that cover the main lobby lifecycle and player interaction flows.

The goal of this issue is to create a solid service-layer test foundation for the lobby feature. The tests should verify both valid behavior and important invalid cases for all main lobby operations.

These tests should focus only on `LobbyService`. The repository and broadcast service should be mocked, and the tests should verify service logic independently from the controller/web layer.

## Issues

#### In this PR was done
- Related to (parent issue) #141 
- Closes #150 
- Closes #145 
- Closes #151 

---


- Does **not** cover #150 
- Does **not** cover #151 
- Does **not** cover #154 
- Does **not** cover #155 
- Does **not** cover #144 
- Does **not** cover #147 
- Does **not** cover #152 
- Does **not** cover #153 


## Scope

This PR should include tests for:
- `deleteLobby`
- `readyLobby`
- `unreadyLobby`

This PR should **not** include tests for:

- `updateLobbySettings`
- `startLobby`
- `leaveLobby`


# Mockito Quick Guide **(please use mockito in the unit tests!!!)**

Use Mockito to fake dependencies like repositories and services in tests.

## Basic setup

```kotlin
@ExtendWith(MockitoExtension::class)
class LobbyServiceTest {

    @Mock lateinit var lobbyRepository: LobbyRepository
    @Mock lateinit var lobbyBroadcastService: LobbyBroadcastService

    @InjectMocks lateinit var lobbyService: LobbyService
}
```

## Most useful examples

### Return a value

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))
```

### Test exception case

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.empty())

assertThrows<NoSuchElementException> {
    lobbyService.getLobby("1")
}
```

### Verify a method call

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyRepository).findById("1")
```

### Verify something was not called

```kotlin
whenever(lobbyRepository.findById("1")).thenReturn(Optional.of(entity))

lobbyService.getLobby("1")

verify(lobbyBroadcastService, never()).broadcastLobbyUpdated(any())
```

### Verify call count

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

verify(lobbyRepository, times(1)).save(any())
```

### Use `any()` for generic arguments

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)
```

### Return the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenAnswer { it.arguments[0] }
```

### Capture the passed argument

```kotlin
whenever(lobbyRepository.save(any())).thenReturn(entity)

lobbyService.createLobby("u1", request)

val captor = argumentCaptor<LobbyEntity>()
verify(lobbyRepository).save(captor.capture())

assertEquals("lobby-1", captor.firstValue.lobbyId)
```

## Simple rule

- mock dependencies
- test the real service
- verify important interactions

Example:

- mock `LobbyRepository`
- mock `LobbyBroadcastService`
- test real `LobbyService`