### PR TITLE
feat(android)(lobby): create lobby via backend and load backend lobby state in waiting room

### DIFF
--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -118,6 +118,7 @@ fun AppNavHost(
             NewLobbyScreen(
                 onBack = { navController.popBackStack() },
                 onSettings = { navController.navigate("settings") },
+                isLoading = lobbyLoadState is LoadState.Loading,
                 onCreateLobby = { maxPlayers, isPrivate ->
                     lobbyVM.createLobby(
                         displayName = "Host",

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -156,6 +156,18 @@ fun AppNavHost(
             )
         }
 
+        composable("waitingRoom/{lobbyId}") { backStackEntry ->
+            val lobbyId = backStackEntry.arguments?.getString("lobbyId")!!
+            val vm: LobbyViewModel = viewModel()
+
+            WaitingRoomScreen(
+                onBack = { navController.popBackStack() },
+                onSettings = { navController.navigate("settings") },
+                lobbyId = lobbyId,
+                viewModel = vm
+            )
+        }
+
         // settings screen
         composable("settings") {
             SettingsScreen(

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -20,6 +20,8 @@ import at.aau.serg.android.ui.screens.lobby.LobbyScreen
 import at.aau.serg.android.ui.screens.lobby.LobbyViewModel
 import at.aau.serg.android.ui.screens.settings.SettingsScreen
 import at.aau.serg.android.ui.screens.waiting.WaitingRoomScreen
+import at.aau.serg.android.ui.state.LoadState
+import at.aau.serg.android.ui.lobby.LobbyUiState
 
 @Composable
 fun AppNavHost(
@@ -107,11 +109,29 @@ fun AppNavHost(
 
         // fancy create lobby screen
         composable("createLobbyFancy") {
+            val parentEntry = remember(navController.currentBackStackEntry) {
+                navController.getBackStackEntry("root")
+            }
+            val lobbyVM: LobbyViewModel = viewModel(parentEntry)
+            val lobbyLoadState by lobbyVM.loadState.collectAsState()
+
             NewLobbyScreen(
                 onBack = { navController.popBackStack() },
                 onSettings = { navController.navigate("settings") },
-                onCreateLobby = {
-                    navController.navigate("waitingRoom")
+                onCreateLobby = { maxPlayers, isPrivate ->
+                    lobbyVM.createLobby(
+                        displayName = "Host",
+                        maxPlayers = maxPlayers,
+                        isPrivate = isPrivate,
+                        allowGuests = true,
+                        onSuccess = { lobby ->
+                            LobbyUiState.lobbyName.value = "New Lobby"
+                            LobbyUiState.maxPlayers.intValue = lobby.settings.maxPlayers
+                            LobbyUiState.roomCode.value = lobby.lobbyId.take(6).uppercase()
+                            navController.navigate("waitingRoom/${lobby.lobbyId}")
+                        },
+                        onError = { }
+                    )
                 }
             )
         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
@@ -63,6 +63,7 @@ import at.aau.serg.android.ui.theme.ThemeState
 fun NewLobbyScreen(
     onBack: () -> Unit,
     onSettings: () -> Unit,
+    isLoading: Boolean = false,
     onCreateLobby: (maxPlayers: Int, isPrivate: Boolean) -> Unit
 ) {
     val darkMode = ThemeState.isDarkMode.value
@@ -364,6 +365,7 @@ fun NewLobbyScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp),
+            enabled = !isLoading,
             shape = RoundedCornerShape(18.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = Color(0xFF9D3CFF),
@@ -371,10 +373,18 @@ fun NewLobbyScreen(
             )
         ) {
             Text(
-                text = "Create Lobby",
+                text = if (isLoading) "Loading" else "Create Lobby",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold
             )
+            if (!isLoading) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
@@ -63,7 +63,7 @@ import at.aau.serg.android.ui.theme.ThemeState
 fun NewLobbyScreen(
     onBack: () -> Unit,
     onSettings: () -> Unit,
-    onCreateLobby: (String) -> Unit
+    onCreateLobby: (maxPlayers: Int, isPrivate: Boolean) -> Unit
 ) {
     val darkMode = ThemeState.isDarkMode.value
 
@@ -359,7 +359,7 @@ fun NewLobbyScreen(
                 LobbyUiState.stackEnabled.value = quickMode
                 LobbyUiState.roomCode.value = ""
 
-                onCreateLobby("New Lobby")
+                onCreateLobby(maxPlayers, isPrivate)
             },
             modifier = Modifier
                 .fillMaxWidth()
@@ -370,12 +370,6 @@ fun NewLobbyScreen(
                 contentColor = Color.White
             )
         ) {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = "Create Lobby",
                 style = MaterialTheme.typography.titleMedium,

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
@@ -31,18 +31,23 @@ class LobbyViewModel(
     }
 
     fun createLobby(
+        userId: String = "test",
+        displayName: String = "tester",
+        maxPlayers: Int = 4,
+        isPrivate: Boolean = false,
+        allowGuests: Boolean = true,
         onSuccess: (Lobby) -> Unit = {},
         onError: () -> Unit = {}
     ) {
         launchRequest(
             request = {
                 api.createLobby(
-                    "test",
+                    userId,
                     CreateLobbyRequest(
-                        displayName = "tester",
-                        maxPlayers = 4,
-                        isPrivate = false,
-                        allowGuests = true
+                        displayName = displayName,
+                        maxPlayers = maxPlayers,
+                        isPrivate = isPrivate,
+                        allowGuests = allowGuests
                     )
                 ).toDomain()
             },

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
@@ -41,7 +41,9 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -51,13 +53,16 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.aau.serg.android.ui.lobby.LobbyUiState
+import at.aau.serg.android.ui.screens.lobby.LobbyViewModel
 import at.aau.serg.android.ui.theme.ThemeState
 import kotlin.random.Random
 
 @Composable
 fun WaitingRoomScreen(
     onBack: () -> Unit,
-    onSettings: () -> Unit
+    onSettings: () -> Unit,
+    lobbyId: String? = null,
+    viewModel: LobbyViewModel? = null
 ) {
     // context for clipboard and toast
     val context = LocalContext.current
@@ -68,18 +73,34 @@ fun WaitingRoomScreen(
     // current theme mode
     val darkMode = ThemeState.isDarkMode.value
 
+    val fetchedLobbyState = viewModel?.lobby?.collectAsState()
+    val fetchedLobby = fetchedLobbyState?.value
+
+    LaunchedEffect(lobbyId) {
+        if (lobbyId != null && viewModel != null) {
+            viewModel.loadLobby(lobbyId)
+        }
+    }
+
     // shared lobby state
-    val lobbyName by LobbyUiState.lobbyName
-    val maxPlayers by LobbyUiState.maxPlayers
+    val fallbackLobbyName by LobbyUiState.lobbyName
+    val fallbackMaxPlayers by LobbyUiState.maxPlayers
     val turnTimer by LobbyUiState.turnTimer
     val startingCards by LobbyUiState.startingCards
     val stackEnabled by LobbyUiState.stackEnabled
 
     // generate room code once if missing
-    if (LobbyUiState.roomCode.value.isBlank()) {
+    if (LobbyUiState.roomCode.value.isBlank() && lobbyId == null) {
         LobbyUiState.roomCode.value = generateRoomCode()
     }
-    val roomCode by LobbyUiState.roomCode
+    val fallbackRoomCode by LobbyUiState.roomCode
+
+    val lobbyName = if (fetchedLobby != null) "Waiting Room" else fallbackLobbyName
+    val maxPlayers = fetchedLobby?.settings?.maxPlayers ?: fallbackMaxPlayers
+    val roomCode = fetchedLobby?.lobbyId?.take(6)?.uppercase() ?: fallbackRoomCode
+    val players = fetchedLobby?.players ?: emptyList()
+    val joinedCount = if (fetchedLobby != null) players.size else 2
+    val isLobbyLoading = lobbyId != null && fetchedLobby == null
 
     // background gradient colors
     val gradientTop = if (darkMode) {
@@ -279,7 +300,7 @@ fun WaitingRoomScreen(
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = "2/$maxPlayers",
+                        text = "$joinedCount/$maxPlayers",
                         color = primaryTextColor,
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold
@@ -305,7 +326,7 @@ fun WaitingRoomScreen(
                 fontWeight = FontWeight.SemiBold
             )
             Text(
-                text = "2 joined",
+                text = "$joinedCount joined",
                 color = secondaryTextColor,
                 style = MaterialTheme.typography.labelSmall
             )
@@ -313,34 +334,60 @@ fun WaitingRoomScreen(
 
         Spacer(modifier = Modifier.height(6.dp))
 
-        // host player
-        PlayerItem(
-            name = "You",
-            subtitle = "Level 24",
-            isHost = true,
-            isJoined = true,
-            isPlaceholder = false,
-            borderColor = activePlayerBorder,
-            backgroundColor = activePlayerBackground,
-            primaryTextColor = primaryTextColor,
-            secondaryTextColor = secondaryTextColor
-        )
+        if (isLobbyLoading) {
+            Text(
+                text = "Loading players...",
+                color = secondaryTextColor,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(vertical = 12.dp)
+            )
+        } else if (fetchedLobby != null) {
+            players.forEachIndexed { index, player ->
+                PlayerItem(
+                    name = player.displayName,
+                    subtitle = if (player.isReady) "Ready" else "Not ready",
+                    isHost = player.userId == fetchedLobby.hostUserId,
+                    isJoined = true,
+                    isPlaceholder = false,
+                    borderColor = if (index == 1) secondPlayerBorder else activePlayerBorder,
+                    backgroundColor = if (index == 1) secondPlayerBackground else activePlayerBackground,
+                    primaryTextColor = primaryTextColor,
+                    secondaryTextColor = secondaryTextColor
+                )
+            }
+        } else {
+            PlayerItem(
+                name = "You",
+                subtitle = "Level 24",
+                isHost = true,
+                isJoined = true,
+                isPlaceholder = false,
+                borderColor = activePlayerBorder,
+                backgroundColor = activePlayerBackground,
+                primaryTextColor = primaryTextColor,
+                secondaryTextColor = secondaryTextColor
+            )
 
-        // second joined player
-        PlayerItem(
-            name = "Alex",
-            subtitle = "Level 18",
-            isHost = false,
-            isJoined = true,
-            isPlaceholder = false,
-            borderColor = secondPlayerBorder,
-            backgroundColor = secondPlayerBackground,
-            primaryTextColor = primaryTextColor,
-            secondaryTextColor = secondaryTextColor
-        )
+            PlayerItem(
+                name = "Alex",
+                subtitle = "Level 18",
+                isHost = false,
+                isJoined = true,
+                isPlaceholder = false,
+                borderColor = secondPlayerBorder,
+                backgroundColor = secondPlayerBackground,
+                primaryTextColor = primaryTextColor,
+                secondaryTextColor = secondaryTextColor
+            )
+        }
 
-        // remaining placeholder slots
-        val placeholderCount = (maxPlayers - 2).coerceAtLeast(0)
+        val placeholderCount = if (isLobbyLoading) {
+            0
+        } else if (fetchedLobby != null) {
+            (maxPlayers - players.size).coerceAtLeast(0)
+        } else {
+            (maxPlayers - 2).coerceAtLeast(0)
+        }
         repeat(placeholderCount) {
             PlayerItem(
                 name = "Waiting for player...",

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -21,7 +21,7 @@ class LobbyService(
     private val lobbyBroadcastService: LobbyBroadcastService) {
 
     companion object {
-        const val MAX_PLAYERS = 4
+        const val MAX_PLAYERS = 8
         const val MIN_PLAYERS = 2
     }
 


### PR DESCRIPTION
## Summary
Connects the Android create-lobby flow to the backend and updates the waiting room to load and display the created lobby from backend data.

## Issues

- Closes #83 
- Closes #94 
- Related to #98 

## What changed
- wired the create-lobby form to actually call the backend on submission
- added a loading state for create-lobby submission
- passed the created `lobbyId` into the waiting room route after successful creation
- updated the waiting room to fetch lobby data on initial load using that `lobbyId`
- displayed backend-driven lobby information in the waiting room, including:
  - room code
  - max players
  - joined player count
  - player list
  - ready state
  - host indicator
- updated the lobby view model so create-lobby uses the submitted values instead of hardcoded defaults
- aligned max player handling with the current backend-supported value

## Navigation flow
This PR changes the lobby flow to:

1. open the create-lobby screen
2. submit the selected lobby settings
3. create the lobby in the backend
4. navigate to `waitingRoom/{lobbyId}` on success
5. fetch the created lobby again in the waiting room and render the returned data

## Files touched
- `AppNavHost.kt`
- `NewLobbyScreen.kt`
- `LobbyViewModel.kt`
- `WaitingRoom.kt`

## Why
Previously, the create-lobby flow was mainly local UI/navigation state. This PR moves the flow closer to the real product behavior by:
- creating the lobby on the backend
- using the returned lobby ID for navigation
- showing backend state again in the waiting room instead of relying only on temporary frontend values

## Notes
- the create-lobby screen now disables repeated submission while the request is loading
- the waiting room still keeps some fallback UI state for non-backend cases, but prefers fetched lobby data when a `lobbyId` is available
- room code is derived from the created/fetched `lobbyId`
- the waiting room now reflects actual backend players when available

## How to test
1. launch the Android app
2. open the create-lobby screen
3. choose the lobby settings and submit the form
4. verify the button enters a loading state during submission
5. verify the app navigates to the waiting room after success
6. verify the route includes the created `lobbyId`
7. verify the waiting room loads backend lobby data on entry
8. verify room code, max players, joined count, and player list are shown from backend data
9. verify host and ready-state rendering works for fetched players