### PR TITLE
feat(android)(lobby): backend interaction support for browse & join lobbies in our frontend ui

### DIFF
--- a/apps/android/app/src/main/java/at/aau/serg/android/errors/ErrorMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/errors/ErrorMapper.kt
@@ -1,5 +1,7 @@
 package at.aau.serg.android.errors
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import retrofit2.HttpException
 
@@ -9,11 +11,38 @@ object ErrorCatalog {
     const val UNKNOWN = "Unexpected error"
 }
 
+data class ApiErrorResponse(
+    val errorCode: String,
+    val errorMessage: String
+)
+
 object ErrorMapper {
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    private val apiErrorAdapter = moshi.adapter(ApiErrorResponse::class.java)
+
     fun map(e: Throwable): String =
         when (e) {
             is IOException -> ErrorCatalog.NETWORK
-            is HttpException -> ErrorCatalog.SERVER
+            is HttpException -> mapHttpError(e)
             else -> ErrorCatalog.UNKNOWN
         }
+
+    private fun mapHttpError(e: HttpException): String {
+        val response = e.response()
+        val body = response?.errorBody()?.string()
+        val apiMessage = body
+            ?.let { apiErrorAdapter.fromJson(it)?.errorMessage }
+            ?.takeIf { it.isNotBlank() }
+
+        return apiMessage ?: when (e.code()) {
+            400 -> "Bad request"
+            403 -> "Access denied"
+            404 -> "Resource not found"
+            409 -> "Conflict"
+            in 500..599 -> ErrorCatalog.SERVER
+            else -> ErrorCatalog.UNKNOWN
+        }
+    }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -2,10 +2,8 @@ package at.aau.serg.android.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -27,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import at.aau.serg.android.ui.screens.browselobbies.BrowsingLobbiesScreen
 import at.aau.serg.android.ui.screens.browselobbies.LobbyBrowseItem
+import shared.models.lobby.response.LobbyListItemResponse
 
 
 @Composable
@@ -144,61 +143,29 @@ fun AppNavHost(
 
         // second browse screen
         composable("browsingLobbies") {
+            val parentEntry = remember(navController.currentBackStackEntry) {
+                navController.getBackStackEntry("root")
+            }
+            val lobbyVM: LobbyViewModel = viewModel(parentEntry)
+            val lobbySummaries by lobbyVM.lobbies.collectAsState()
+            val browseLoadState by lobbyVM.loadState.collectAsState()
+
+            LaunchedEffect(Unit) {
+                lobbyVM.loadLobbies()
+            }
+
             BrowsingLobbiesScreen(
-                lobbies = listOf(
-                    LobbyBrowseItem(
-                        lobbyId = "A1B2C3",
-                        hostId = "Miko",
-                        currentPlayers = 3,
-                        maxPlayers = 4,
-                        turnTimerSeconds = 60,
-                        startingCards = 7,
-                        isOpen = true,
-                        accentColor = Color(0xFF3B82F6)
-                    ),
-                    LobbyBrowseItem(
-                        lobbyId = "D4E5F6",
-                        hostId = "Sarah",
-                        currentPlayers = 2,
-                        maxPlayers = 6,
-                        turnTimerSeconds = 90,
-                        startingCards = 14,
-                        isOpen = true,
-                        accentColor = Color(0xFFA855F7)
-                    ),
-                    LobbyBrowseItem(
-                        lobbyId = "G7H8J9",
-                        hostId = "Alex",
-                        currentPlayers = 1,
-                        maxPlayers = 4,
-                        turnTimerSeconds = 30,
-                        startingCards = 7,
-                        isOpen = true,
-                        accentColor = Color(0xFF22C55E)
-                    ),
-                    LobbyBrowseItem(
-                        lobbyId = "K1L2M3",
-                        hostId = "David",
-                        currentPlayers = 4,
-                        maxPlayers = 4,
-                        turnTimerSeconds = 45,
-                        startingCards = 7,
-                        isOpen = false,
-                        accentColor = Color(0xFFF97316)
-                    ),
-                    LobbyBrowseItem(
-                        lobbyId = "N4P5Q6",
-                        hostId = "Emma",
-                        currentPlayers = 0,
-                        maxPlayers = 4,
-                        turnTimerSeconds = 120,
-                        startingCards = 10,
-                        isOpen = true,
-                        accentColor = Color(0xFFEC4899)
+                lobbies = lobbySummaries.map { it.toBrowseItem() },
+                isLoading = browseLoadState is LoadState.Loading && lobbySummaries.isEmpty(),
+                errorMessage = (browseLoadState as? LoadState.Error)?.message,
+                onJoinLobby = { lobbyId ->
+                    lobbyVM.joinLobby(
+                        lobbyId = lobbyId,
+                        onSuccess = { joinedLobby ->
+                            navController.navigate("waitingRoom/${joinedLobby.lobbyId}")
+                        },
+                        onError = { }
                     )
-                ),
-                onJoinLobby = { _ ->
-                    // later real join logic
                 },
                 onCreateNewLobby = {
                     navController.navigate("createLobbyFancy")
@@ -238,4 +205,31 @@ fun AppNavHost(
             )
         }
     }
+}
+
+private fun LobbyListItemResponse.toBrowseItem(): LobbyBrowseItem {
+    return LobbyBrowseItem(
+        lobbyId = lobbyId,
+        hostId = hostUserId,
+        currentPlayers = currentPlayerCount,
+        maxPlayers = maxPlayers,
+        // The current backend lobby list does not expose these fields yet.
+        turnTimerSeconds = 60,
+        startingCards = 7,
+        isOpen = status == "OPEN" && currentPlayerCount < maxPlayers,
+        accentColor = lobbyAccentColor(lobbyId)
+    )
+}
+
+private fun lobbyAccentColor(lobbyId: String): Color {
+    val palette = listOf(
+        Color(0xFF3B82F6),
+        Color(0xFFA855F7),
+        Color(0xFF22C55E),
+        Color(0xFFF97316),
+        Color(0xFFEC4899),
+        Color(0xFF06B6D4),
+        Color(0xFFEAB308)
+    )
+    return palette[(lobbyId.hashCode() and Int.MAX_VALUE) % palette.size]
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -159,7 +159,7 @@ fun AppNavHost(
                 isLoading = browseLoadState is LoadState.Loading && lobbySummaries.isEmpty(),
                 errorMessage = (browseLoadState as? LoadState.Error)?.message,
                 onJoinLobby = { lobbyId ->
-                    lobbyVM.joinLobby(
+                    lobbyVM.joinLobbyOrOpen(
                         lobbyId = lobbyId,
                         onSuccess = { joinedLobby ->
                             navController.navigate("waitingRoom/${joinedLobby.lobbyId}")

--- a/apps/android/app/src/main/java/at/aau/serg/android/session/AppSession.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/session/AppSession.kt
@@ -1,0 +1,13 @@
+package at.aau.serg.android.session
+
+import java.util.UUID
+
+object AppSession {
+    val userId: String by lazy {
+        UUID.randomUUID().toString()
+    }
+
+    val displayName: String by lazy {
+        "Player${userId.takeLast(4).uppercase()}"
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/browselobbies/BrowsingLobbiesScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/browselobbies/BrowsingLobbiesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -67,6 +68,8 @@ data class LobbyBrowseItem(
 @Composable
 fun BrowsingLobbiesScreen(
     lobbies: List<LobbyBrowseItem>,
+    isLoading: Boolean = false,
+    errorMessage: String? = null,
     onJoinLobby: (String) -> Unit,
     onCreateNewLobby: () -> Unit,
     onSettings: () -> Unit,
@@ -244,6 +247,26 @@ fun BrowsingLobbiesScreen(
 
         Spacer(modifier = Modifier.height(12.dp))
 
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 24.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = accentPurple)
+            }
+        }
+
+        if (errorMessage != null) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+        }
+
         // lobby list
         LazyColumn(
             modifier = Modifier.weight(1f),
@@ -253,7 +276,6 @@ fun BrowsingLobbiesScreen(
                 LobbyBrowseCard(
                     lobby = lobby,
                     cardColor = cardColor,
-                    borderColor = borderColor,
                     primaryText = primaryText,
                     secondaryText = secondaryText,
                     onJoinLobby = onJoinLobby
@@ -312,7 +334,6 @@ fun BrowsingLobbiesScreen(
 private fun LobbyBrowseCard(
     lobby: LobbyBrowseItem,
     cardColor: Color,
-    borderColor: Color,
     primaryText: Color,
     secondaryText: Color,
     onJoinLobby: (String) -> Unit

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/createlobby/NewLobbyScreen.kt
@@ -58,6 +58,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.aau.serg.android.ui.lobby.LobbyUiState
 import at.aau.serg.android.ui.theme.ThemeState
+import androidx.compose.ui.platform.LocalContext
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
 
 @Composable
 fun NewLobbyScreen(
@@ -67,16 +72,20 @@ fun NewLobbyScreen(
     onCreateLobby: (maxPlayers: Int, isPrivate: Boolean) -> Unit
 ) {
     val darkMode = ThemeState.isDarkMode.value
+    val context = LocalContext.current
 
     // align dark mode with waiting room styling
     val bgTop = if (darkMode) MaterialTheme.colorScheme.background else Color(0xFFF5F7FB)
     val bgBottom = if (darkMode) MaterialTheme.colorScheme.surface else Color(0xFFEAEFFF)
     val cardColor = MaterialTheme.colorScheme.surface
-    val cardBorder = if (darkMode) Color(0xFF2A3558) else Color(0xFFD8DEF0)
+    val cardBorder = if (darkMode) Color(0xFF394766) else Color(0xFFD8DEF0)
     val primaryText = MaterialTheme.colorScheme.onSurface
-    val selectedColor = if (darkMode) Color(0xFF2A3552) else Color(0xFF2F3A57)
-    val selectedBorder = if (darkMode) Color(0xFF4A5676) else Color(0xFF47536F)
-    val selectedContentColor = if (darkMode) Color(0xFF1E2430) else Color.White
+
+    // improved selected colors for dark mode
+    val selectedColor = if (darkMode) Color(0xFF7C3AED) else Color(0xFF2F3A57)
+    val selectedBorder = if (darkMode) Color(0xFFB794F4) else Color(0xFF47536F)
+    val selectedContentColor = Color.White
+
     val actionGreen = Color(0xFF22C55E)
     val settingButtonColor = if (darkMode) Color(0xFF2A3552) else Color(0xFF2F3A57)
     val secondaryText = if (darkMode) {
@@ -188,7 +197,18 @@ fun NewLobbyScreen(
                         Spacer(modifier = Modifier.width(6.dp))
 
                         IconButton(
-                            onClick = { },
+                            onClick = {
+                                val clipboardManager =
+                                    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                val clip = ClipData.newPlainText("Room Code", roomCode)
+                                clipboardManager.setPrimaryClip(clip)
+
+                                Toast.makeText(
+                                    context,
+                                    "Room code copied",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            },
                             modifier = Modifier.size(28.dp)
                         ) {
                             Icon(
@@ -206,7 +226,7 @@ fun NewLobbyScreen(
         Spacer(modifier = Modifier.height(20.dp))
 
         SectionTitle(
-            icon = { Icon(Icons.Filled.Groups, null, tint = Color(0xFF9D3CFF)) },
+            icon = { Icon(Icons.Filled.Groups, null, tint = Color(0x9C9D3CFF)) },
             title = "Maximum Players"
         )
 
@@ -238,7 +258,7 @@ fun NewLobbyScreen(
         Spacer(modifier = Modifier.height(20.dp))
 
         SectionTitle(
-            icon = { Icon(Icons.Filled.Lock, null, tint = Color(0xFF9D3CFF)) },
+            icon = { Icon(Icons.Filled.Lock, null, tint = Color(0x9E9D3CFF)) },
             title = "Privacy"
         )
 

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -61,6 +61,18 @@ fun HomeScreen(
         )
     )
 
+    val titleColor = if (darkMode) {
+        Color(0xFFEAEFFF)
+    } else {
+        Color(0xFF1D2750)
+    }
+
+    val subtitleColor = if (darkMode) {
+        Color.White.copy(alpha = 0.78f)
+    } else {
+        Color(0xFF4D5A78)
+    }
+
     // error text color
     val errorColor = if (darkMode) {
         Color(0xFFFF8F8F)
@@ -170,6 +182,21 @@ fun HomeScreen(
             }
 
             Spacer(modifier = Modifier.height(22.dp))
+
+            Text(
+                text = "RUMMIKUB",
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Black,
+                color = titleColor
+            )
+
+            Text(
+                text = "Classic Tile Game",
+                style = MaterialTheme.typography.bodyLarge,
+                color = subtitleColor
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
 
             // loading state
             if (state is LoadState.Loading) {

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
@@ -4,6 +4,7 @@ import at.aau.serg.android.data.lobby.mapper.toDomain
 import at.aau.serg.android.network.RetrofitProvider
 import at.aau.serg.android.network.lobby.LobbyAPI
 import at.aau.serg.android.network.lobby.LobbyService
+import at.aau.serg.android.session.AppSession
 import at.aau.serg.android.util.DefaultDispatcherProvider
 import at.aau.serg.android.util.DispatcherProvider
 import at.aau.serg.android.viewmodel.BaseViewModel
@@ -44,8 +45,8 @@ class LobbyViewModel(
     }
 
     fun createLobby(
-        userId: String = "test",
-        displayName: String = "tester",
+        userId: String = AppSession.userId,
+        displayName: String = AppSession.displayName,
         maxPlayers: Int = 4,
         isPrivate: Boolean = false,
         allowGuests: Boolean = true,
@@ -71,8 +72,8 @@ class LobbyViewModel(
 
     fun joinLobby(
         lobbyId: String,
-        userId: String = "test",
-        displayName: String = "Player",
+        userId: String = AppSession.userId,
+        displayName: String = AppSession.displayName,
         onSuccess: (Lobby) -> Unit = {},
         onError: () -> Unit = {}
     ) {
@@ -91,13 +92,41 @@ class LobbyViewModel(
         )
     }
 
+    fun joinLobbyOrOpen(
+        lobbyId: String,
+        userId: String = AppSession.userId,
+        displayName: String = AppSession.displayName,
+        onSuccess: (Lobby) -> Unit = {},
+        onError: () -> Unit = {}
+    ) {
+        launchRequest(
+            request = {
+                val existingLobby = api.getLobby(lobbyId).toDomain()
+                if (existingLobby.players.any { it.userId == userId }) {
+                    existingLobby
+                } else {
+                    api.joinLobby(
+                        lobbyId,
+                        JoinLobbyRequest(
+                            userId = userId,
+                            displayName = displayName
+                        )
+                    ).toDomain()
+                }
+            },
+            onSuccess = { lobby -> onSuccess(lobby) },
+            onError = { onError() }
+        )
+    }
+
     fun leaveLobby(
         lobbyId: String,
+        userId: String = AppSession.userId,
         onSuccess: () -> Unit = {},
         onError: () -> Unit = {}
     ) {
         launchRequest(
-            request = { api.leaveLobby("test", lobbyId) },
+            request = { api.leaveLobby(userId, lobbyId) },
             onSuccess = { success ->
                 if (success) onSuccess() else onError()
             },

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import shared.models.lobby.domain.Lobby
 import shared.models.lobby.request.CreateLobbyRequest
+import shared.models.lobby.request.JoinLobbyRequest
+import shared.models.lobby.response.LobbyListItemResponse
 
 class LobbyViewModel(
     private val api: LobbyAPI = LobbyAPI(
@@ -21,6 +23,17 @@ class LobbyViewModel(
 
     private val _lobby = MutableStateFlow<Lobby?>(null)
     val lobby = _lobby.asStateFlow()
+
+    private val _lobbies = MutableStateFlow<List<LobbyListItemResponse>>(emptyList())
+    val lobbies = _lobbies.asStateFlow()
+
+    fun loadLobbies(onError: () -> Unit = {}) {
+        launchRequest(
+            request = { api.getLobbies() },
+            onSuccess = { loaded -> _lobbies.value = loaded },
+            onError = { onError() }
+        )
+    }
 
     fun loadLobby(lobbyId: String) {
         launchRequest(
@@ -48,6 +61,28 @@ class LobbyViewModel(
                         maxPlayers = maxPlayers,
                         isPrivate = isPrivate,
                         allowGuests = allowGuests
+                    )
+                ).toDomain()
+            },
+            onSuccess = { lobby -> onSuccess(lobby) },
+            onError = { onError() }
+        )
+    }
+
+    fun joinLobby(
+        lobbyId: String,
+        userId: String = "test",
+        displayName: String = "Player",
+        onSuccess: (Lobby) -> Unit = {},
+        onError: () -> Unit = {}
+    ) {
+        launchRequest(
+            request = {
+                api.joinLobby(
+                    lobbyId,
+                    JoinLobbyRequest(
+                        userId = userId,
+                        displayName = displayName
                     )
                 ).toDomain()
             },

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
@@ -181,7 +181,7 @@ fun WaitingRoomScreen(
                 )
             )
             .verticalScroll(scrollState)
-            .padding(10.dp)
+            .padding(16.dp)
     ) {
         // top bar
         Row(


### PR DESCRIPTION
## Summary
Adds backend-backed browse and join support for the Android lobby flow.

## Related issues
- Closes #86 
- Closes #93   
- Related to #98 

## What changed
- connected the browse-lobbies flow to backend data instead of relying only on static placeholder entries
- added backend interaction for joining a lobby from the browse screen
- updated the navigation host to work with the current lobby screen flow and screen naming
- introduced a simple app session utility for frontend-side session/user identification
- improved error handling by parsing backend error responses and mapping HTTP errors to clearer user-facing messages
- added loading and error UI support to the browse-lobbies screen
- included small UI refinements such as dark mode color adjustments and clipboard support

## Technical details
- `ErrorMapper` now parses structured API error responses with Moshi and maps HTTP status codes to cleaner messages
- `BrowsingLobbiesScreen` now accepts `isLoading` and `errorMessage` state so backend requests can be reflected in the UI
- `AppNavHost` was updated as part of the lobby browse/join flow integration
- `AppSession` was added to provide a simple generated client-side identifier for the current app session

## Why
This PR moves the Android lobby experience closer to the intended real flow:
1. fetch available lobbies from the backend
2. display them in the browse screen
3. allow the user to join a selected lobby
4. show loading/error feedback when requests fail

That makes the lobby flow more realistic and gives the frontend the basic backend integration needed for the next lobby features.

## How to test
1. launch the Android app
2. open the browse lobbies screen
3. verify available lobbies are loaded from the backend
4. try joining an open lobby
5. verify the app continues into the expected lobby/waiting-room flow
6. simulate a backend/network error and verify a readable error message is shown
7. verify loading feedback appears while lobby data is being fetched
