### PR TITLE
test(backend)(websocket): add tests for web socket behaviour

### DIFF
--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
@@ -23,6 +23,10 @@ import java.time.Instant
 @ExtendWith(MockitoExtension::class)
 class LobbyBroadcastServiceTest {
 
+    companion object {
+        private const val TOPIC_LOBBIES_PATH = "/topic/lobbies"
+    }
+
     @Mock
     lateinit var messagingTemplate: SimpMessagingTemplate
 
@@ -51,16 +55,16 @@ class LobbyBroadcastServiceTest {
             createdAt = Instant.parse("2026-04-12T09:00:00Z")
         )
 
-        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+        val payloadCaptor = ArgumentCaptor.forClass(LobbyUpdatedEvent::class.java)
 
         lobbyBroadcastService.broadcastLobbyUpdated(lobby)
 
         verify(messagingTemplate).convertAndSend(
-            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            org.mockito.Mockito.eq("$TOPIC_LOBBIES_PATH/lobby-1"),
             payloadCaptor.capture()
         )
 
-        val event = payloadCaptor.value as LobbyUpdatedEvent
+        val event = payloadCaptor.value
         assertEquals("lobby.updated", event.type)
         assertEquals("lobby-1", event.lobby.lobbyId)
         assertEquals("host-1", event.lobby.hostUserId)
@@ -76,16 +80,16 @@ class LobbyBroadcastServiceTest {
 
     @Test
     fun `broadcastLobbyDeleted sends deleted event to lobby topic`() {
-        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+        val payloadCaptor = ArgumentCaptor.forClass(LobbyDeletedEvent::class.java)
 
         lobbyBroadcastService.broadcastLobbyDeleted("lobby-1")
 
         verify(messagingTemplate).convertAndSend(
-            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            org.mockito.Mockito.eq("$TOPIC_LOBBIES_PATH/lobby-1"),
             payloadCaptor.capture()
         )
 
-        val event = payloadCaptor.value as LobbyDeletedEvent
+        val event = payloadCaptor.value
         assertEquals("lobby.deleted", event.type)
         assertEquals("lobby-1", event.lobbyId)
 
@@ -94,16 +98,16 @@ class LobbyBroadcastServiceTest {
 
     @Test
     fun `broadcastLobbyStarted sends started event to lobby topic`() {
-        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+        val payloadCaptor = ArgumentCaptor.forClass(LobbyStartedEvent::class.java)
 
         lobbyBroadcastService.broadcastLobbyStarted("lobby-1", "match-1")
 
         verify(messagingTemplate).convertAndSend(
-            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            org.mockito.Mockito.eq("$TOPIC_LOBBIES_PATH/lobby-1"),
             payloadCaptor.capture()
         )
 
-        val event = payloadCaptor.value as LobbyStartedEvent
+        val event = payloadCaptor.value
         assertEquals("lobby.started", event.type)
         assertEquals("lobby-1", event.lobbyId)
         assertEquals("match-1", event.matchId)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
@@ -1,0 +1,113 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.LobbyPlayer
+import at.se2group.backend.domain.LobbySettings
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.dto.LobbyDeletedEvent
+import at.se2group.backend.dto.LobbyStartedEvent
+import at.se2group.backend.dto.LobbyUpdatedEvent
+import at.se2group.backend.service.LobbyBroadcastService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class LobbyBroadcastServiceTest {
+
+    @Mock
+    lateinit var messagingTemplate: SimpMessagingTemplate
+
+    @InjectMocks
+    lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Test
+    fun `broadcastLobbyUpdated sends updated event to lobby topic`() {
+        val lobby = Lobby(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            players = listOf(
+                LobbyPlayer(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = true,
+                    joinedAt = Instant.parse("2026-04-12T10:00:00Z")
+                )
+            ),
+            status = LobbyStatus.OPEN,
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            ),
+            createdAt = Instant.parse("2026-04-12T09:00:00Z")
+        )
+
+        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+
+        lobbyBroadcastService.broadcastLobbyUpdated(lobby)
+
+        verify(messagingTemplate).convertAndSend(
+            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            payloadCaptor.capture()
+        )
+
+        val event = payloadCaptor.value as LobbyUpdatedEvent
+        assertEquals("lobby.updated", event.type)
+        assertEquals("lobby-1", event.lobby.lobbyId)
+        assertEquals("host-1", event.lobby.hostUserId)
+        assertEquals("OPEN", event.lobby.status)
+        assertEquals(4, event.lobby.maxPlayers)
+        assertEquals(false, event.lobby.isPrivate)
+        assertEquals(true, event.lobby.allowGuests)
+        assertEquals(1, event.lobby.players.size)
+        assertEquals("Alice", event.lobby.players.first().displayName)
+
+        verifyNoMoreInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `broadcastLobbyDeleted sends deleted event to lobby topic`() {
+        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+
+        lobbyBroadcastService.broadcastLobbyDeleted("lobby-1")
+
+        verify(messagingTemplate).convertAndSend(
+            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            payloadCaptor.capture()
+        )
+
+        val event = payloadCaptor.value as LobbyDeletedEvent
+        assertEquals("lobby.deleted", event.type)
+        assertEquals("lobby-1", event.lobbyId)
+
+        verifyNoMoreInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `broadcastLobbyStarted sends started event to lobby topic`() {
+        val payloadCaptor = ArgumentCaptor.forClass(Any::class.java)
+
+        lobbyBroadcastService.broadcastLobbyStarted("lobby-1", "match-1")
+
+        verify(messagingTemplate).convertAndSend(
+            org.mockito.Mockito.eq("/topic/lobbies/lobby-1"),
+            payloadCaptor.capture()
+        )
+
+        val event = payloadCaptor.value as LobbyStartedEvent
+        assertEquals("lobby.started", event.type)
+        assertEquals("lobby-1", event.lobbyId)
+        assertEquals("match-1", event.matchId)
+
+        verifyNoMoreInteractions(messagingTemplate)
+    }
+}


### PR DESCRIPTION
## Summary

Add tests for the new lobby WebSocket behavior. Verify destination, payload structure, and correct emission of lobby.updated, lobby.started, and lobby.deleted after the supported lobby actions.

## Related Issue

Closes #128 

