### PR TITLE
feat(android): add game screen with board UI, tile components and navigation from waiting room

### DIFF
--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -204,7 +204,7 @@ fun AppNavHost(
 
         // GAME
         composable("game/{matchId}") {
-            GameScreen()
+            GameScreen(onBack = { navController.popBackStack() })
         }
 
     }

--- a/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/navigation/AppNavHost.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import at.aau.serg.android.ui.screens.browselobbies.LobbyBrowseItem
 import at.aau.serg.android.ui.screens.browselobbies.components.BrowsingLobbiesScreen
+import at.aau.serg.android.ui.screens.game.GameScreen
 import shared.models.lobby.response.LobbyListItemResponse
 
 
@@ -188,7 +189,7 @@ fun AppNavHost(
             WaitingRoomScreen(
                 onBack = { navController.popBackStack() },
                 onSettings = { navController.navigate("settings") },
-                onGameStarted = { /* TODO: navController.navigate("game/$matchId") if Game-Screen finished */ },
+                onGameStarted = { matchId -> navController.navigate("game/$matchId") },
                 lobbyId = lobbyId,
                 viewModel = vm
             )
@@ -200,6 +201,12 @@ fun AppNavHost(
                 onBack = { navController.popBackStack() }
             )
         }
+
+        // GAME
+        composable("game/{matchId}") {
+            GameScreen()
+        }
+
     }
 }
 

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyAPI.kt
@@ -26,4 +26,10 @@ class LobbyAPI(
         val response = service.leaveLobby(userId, lobbyId)
         return response.isSuccessful
     }
+
+    suspend fun startMatch(userId: String, lobbyId: String): Boolean {
+        val response = service.startMatch(userId, lobbyId)
+        return response.isSuccessful
+    }
+
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/network/lobby/LobbyService.kt
@@ -35,4 +35,11 @@ interface LobbyService {
         @Header("X-User-Id") userId: String,
         @Path("lobbyId") lobbyId: String
     ): Response<Unit>
+
+    @POST("lobbies/{lobbyId}/start")
+    suspend fun startMatch(
+        @Header("X-User-Id") userId: String,
+        @Path("lobbyId") lobbyId: String
+    ): Response<Unit>
+
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -175,7 +175,7 @@ fun GameScreen(
 
             LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 items(myTiles) { number ->
-                    TileItem(number = number, size = 52)
+                    TileItem(number = number, size = 44)
                 }
             }
 
@@ -284,7 +284,8 @@ private fun TileRow(tiles: List<Int>) {
 private fun TileItem(number: Int, size: Int) {
     Box(
         modifier = Modifier
-            .size(size.dp)
+            .width(size.dp)
+            .height((size * 1.4f).dp)
             .clip(RoundedCornerShape(10.dp))
             .background(tileColor(number)),
         contentAlignment = Alignment.Center

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -1,0 +1,24 @@
+package at.aau.serg.android.ui.screens.game
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+
+@Composable
+fun GameScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Game",
+            style = MaterialTheme.typography.displayMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -1,24 +1,299 @@
 package at.aau.serg.android.ui.screens.game
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// hardcoded tile colors by number (placeholder)
+private fun tileColor(number: Int): Brush {
+    return when (number % 7) {
+        0 -> Brush.verticalGradient(listOf(Color(0xFFEC4899), Color(0xFFA855F7)))
+        1 -> Brush.verticalGradient(listOf(Color(0xFF22C55E), Color(0xFF16A34A)))
+        2 -> Brush.verticalGradient(listOf(Color(0xFF3B82F6), Color(0xFF1D4ED8)))
+        3 -> Brush.verticalGradient(listOf(Color(0xFF06B6D4), Color(0xFF0284C7)))
+        4 -> Brush.verticalGradient(listOf(Color(0xFFA855F7), Color(0xFF7C3AED)))
+        5 -> Brush.verticalGradient(listOf(Color(0xFFF97316), Color(0xFFEAB308)))
+        else -> Brush.verticalGradient(listOf(Color(0xFFEF4444), Color(0xFFDC2626)))
+    }
+}
 
 @Composable
-fun GameScreen() {
+fun GameScreen(
+    onBack: () -> Unit = {}
+) {
+    // placeholder data
+    val boardSets = listOf(
+        listOf(7, 8, 9, 10, 11),
+        listOf(5, 5, 5)
+    )
+    val myTiles = listOf(3, 11, 7, 9, 12, 4, 10)
+    val players = listOf(
+        Triple("Player2", "14 tiles", 127),
+        Triple("Player3", "18 tiles", 89)
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF0F172A))
+    ) {
+        // HEADER
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFF1E293B))
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White
+                )
+            }
+
+            Column(modifier = Modifier.align(Alignment.Center)) {
+                Text(
+                    text = "Game #4821",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp
+                )
+                Text(
+                    text = "Round 2 of 3",
+                    color = Color(0xFF94A3B8),
+                    fontSize = 12.sp
+                )
+            }
+
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "3:45",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Filled.MoreVert,
+                    contentDescription = "Menu",
+                    tint = Color.White
+                )
+            }
+        }
+
+        // PLAYER CARDS
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            players.forEach { (name, tiles, score) ->
+                PlayerCard(
+                    name = name,
+                    tiles = tiles,
+                    score = score,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        // BOARD
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(Color(0xFF0F2D27))
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                boardSets.forEach { set ->
+                    TileRow(tiles = set)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // PLAYER HAND
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFF1E293B))
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "${myTiles.size}  Your Tiles",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
+                )
+                Text(
+                    text = "Turn ends in:  0:45",
+                    color = Color(0xFFF97316),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
+                )
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                items(myTiles) { number ->
+                    TileItem(number = number, size = 52)
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // ACTION BUTTONS
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = { },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(52.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF3B82F6))
+                ) {
+                    Icon(Icons.Filled.Check, contentDescription = null, tint = Color.White)
+                    Spacer(Modifier.width(6.dp))
+                    Text("End Turn", fontWeight = FontWeight.Bold, color = Color.White)
+                }
+
+                IconButton(
+                    onClick = { },
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(Color(0xFF334155))
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = "Add", tint = Color.White)
+                }
+
+                IconButton(
+                    onClick = { },
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(Color(0xFF334155))
+                ) {
+                    Icon(Icons.Filled.Refresh, contentDescription = "Reset", tint = Color.White)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerCard(
+    name: String,
+    tiles: String,
+    score: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(0xFF1E293B))
+            .border(1.dp, Color(0xFF334155), RoundedCornerShape(12.dp))
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFF334155)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("👤", fontSize = 16.sp)
+            }
+            Spacer(Modifier.width(8.dp))
+            Column {
+                Text(name, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                Text(tiles, color = Color(0xFF94A3B8), fontSize = 11.sp)
+            }
+        }
+        Text(
+            text = score.toString(),
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp
+        )
+    }
+}
+
+@Composable
+private fun TileRow(tiles: List<Int>) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .border(2.dp, Color.White.copy(alpha = 0.2f), RoundedCornerShape(12.dp))
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        tiles.forEach { number ->
+            TileItem(number = number, size = 60)
+        }
+    }
+}
+
+@Composable
+private fun TileItem(number: Int, size: Int) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .size(size.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(tileColor(number)),
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = "Game",
-            style = MaterialTheme.typography.displayMedium,
-            fontWeight = FontWeight.Bold
+            text = number.toString(),
+            color = Color.White,
+            fontWeight = FontWeight.Black,
+            fontSize = (size * 0.35f).sp
         )
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -253,26 +253,6 @@ fun HomeScreen(
                 modifier = Modifier.testTag("home_browse_lobbies_button")
             )
 
-            Spacer(modifier = Modifier.height(6.dp))
-
-            // go to waiting room
-            HomeActionButton(
-                text = "Waiting Room",
-                onClick = onWaitingRoom,
-                icon = { tint ->
-                    Icon(
-                        imageVector = Icons.Filled.ViewInAr,
-                        contentDescription = null,
-                        tint = tint,
-                        modifier = Modifier.size(24.dp)
-                    )
-                },
-                containerBrush = Brush.horizontalGradient(
-                    colors = listOf(Color(0xFF4C59E8), Color(0xFF3154C8))
-                ),
-                modifier = Modifier.testTag("home_waiting_room_button")
-            )
-
             Spacer(modifier = Modifier.height(8.dp))
 
             // settings action

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/LobbyViewModel.kt
@@ -186,4 +186,17 @@ class LobbyViewModel(
             onError = { onError() }
         )
     }
+
+    fun startMatch(
+        lobbyId: String,
+        userId: String = AppSession.userId,
+        onError: () -> Unit = {}
+    ) {
+        launchRequest(
+            request = { api.startMatch(userId, lobbyId) },
+            onSuccess = { },
+            onError = { onError() }
+        )
+    }
+
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/waiting/WaitingRoom.kt
@@ -44,7 +44,7 @@ import kotlin.random.Random
 fun WaitingRoomScreen(
     onBack: () -> Unit,
     onSettings: () -> Unit,
-    onGameStarted: () -> Unit = {},
+    onGameStarted: (String) -> Unit = {},
     lobbyId: String,
     viewModel: LobbyViewModel
 ) {
@@ -72,7 +72,8 @@ fun WaitingRoomScreen(
 
     // game started → navigate on
     LaunchedEffect(matchId) {
-        if (matchId != null) onGameStarted()
+        val id = matchId
+        if (id != null) onGameStarted(id)
     }
 
     // Lobby state
@@ -198,7 +199,8 @@ fun WaitingRoomScreen(
 
         // ACTIONS
         WaitingRoomActions(
-            onStart = { },
+            // TODO: replace with viewModel.startMatch(lobbyId) later — requires min. 2 players in lobby
+            onStart = { onGameStarted("test-match-id") },
             onInvite = { }
         )
 


### PR DESCRIPTION
## Summary

Adds a game screen scaffold that is navigated to when the host starts a match from the waiting room. The screen displays a game board with tile sets, player cards with scores, and a player hand with action buttons.

## Related Issue

Related to #96 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / setup
- [ ] Test

## What Was Done

- [x] Created `GameScreen.kt` with hardcoded UI scaffold (board, player cards, hand, action buttons)
- [x] Added tile components with color gradients and rectangular shape
- [x] Wired navigation from `WaitingRoomScreen` to `GameScreen` on match start
- [x] Removed non-functional Waiting Room button from Home Screen
- [x] Added `onBack` navigation support in Game Screen

## How to Test

1. Start the app
2. Create a lobby or join one
3. In the Waiting Room, press **Start Game**
4. Game screen should open showing the board, player cards and your tile hand
5. Press back arrow to return to Waiting Room

## Screenshots

<img width="430" height="822" alt="image" src="https://github.com/user-attachments/assets/df47bb80-e46d-4012-bb91-ebdd1d00ef2f" />


## Checklist

- [x] I linked the related issues
- [x] The project builds locally
- [x] I tested my changes
- [ ] I updated documentation if needed
- [x] I kept the PR focused and reasonably small