### PR TITLE
feat(backend)(game): bootstrap game domain model

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/BoardSet.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/BoardSet.kt
@@ -1,0 +1,12 @@
+package at.se2group.backend.domain
+
+data class BoardSet(
+    val boardSetId: String,
+    val type: BoardSetType = BoardSetType.UNRESOLVED,
+    val tiles: List<Tile> = emptyList()
+) {
+    init {
+        require(boardSetId.isNotBlank()) { "boardSetId must not be blank" }
+        require(tiles.isNotEmpty()) { "board sets must contain at least one tile" }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/BoardSetType.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/BoardSetType.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.domain
+
+enum class BoardSetType {
+    SET,
+    RUN,
+    UNRESOLVED
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/ConfirmedGame.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/ConfirmedGame.kt
@@ -19,5 +19,8 @@ data class ConfirmedGame(
         require(lobbyId.isNotBlank()) { "lobbyId must not be blank" }
         require(players.isNotEmpty()) { "games must contain at least one player" }
         require(currentPlayerUserId.isNotBlank()) { "currentPlayerUserId must not be blank" }
+        require(players.any { it.userId == currentPlayerUserId }) {
+            "currentPlayerUserId must belong to one of the game players"
+        }
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/ConfirmedGame.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/ConfirmedGame.kt
@@ -1,0 +1,23 @@
+package at.se2group.backend.domain
+
+import java.time.Instant
+
+data class ConfirmedGame(
+    val gameId: String,
+    val lobbyId: String,
+    val players: List<GamePlayer>,
+    val boardSets: List<BoardSet> = emptyList(),
+    val drawPile: List<Tile> = emptyList(),
+    val currentPlayerUserId: String,
+    val status: GameStatus = GameStatus.WAITING,
+    val createdAt: Instant = Instant.now(),
+    val startedAt: Instant? = null,
+    val finishedAt: Instant? = null
+) {
+    init {
+        require(gameId.isNotBlank()) { "gameId must not be blank" }
+        require(lobbyId.isNotBlank()) { "lobbyId must not be blank" }
+        require(players.isNotEmpty()) { "games must contain at least one player" }
+        require(currentPlayerUserId.isNotBlank()) { "currentPlayerUserId must not be blank" }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/GamePlayer.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/GamePlayer.kt
@@ -15,5 +15,6 @@ data class GamePlayer(
         require(userId.isNotBlank()) { "userId must not be blank" }
         require(displayName.isNotBlank()) { "displayName must not be blank" }
         require(turnOrder >= 0) { "turnOrder must not be negative" }
+        require(score >= 0) { "score must not be negative" }
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/GamePlayer.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/GamePlayer.kt
@@ -1,0 +1,19 @@
+package at.se2group.backend.domain
+
+import java.time.Instant
+
+data class GamePlayer(
+    val userId: String,
+    val displayName: String,
+    val turnOrder: Int,
+    val rackTiles: List<Tile> = emptyList(),
+    val hasCompletedInitialMeld: Boolean = false,
+    val score: Int = 0,
+    val joinedAt: Instant = Instant.now()
+) {
+    init {
+        require(userId.isNotBlank()) { "userId must not be blank" }
+        require(displayName.isNotBlank()) { "displayName must not be blank" }
+        require(turnOrder >= 0) { "turnOrder must not be negative" }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/GameStatus.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/GameStatus.kt
@@ -1,0 +1,8 @@
+package at.se2group.backend.domain
+
+enum class GameStatus {
+    WAITING,
+    ACTIVE,
+    FINISHED,
+    CANCELLED
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/Tile.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/Tile.kt
@@ -1,21 +1,18 @@
 package at.se2group.backend.domain
 
-data class Tile(
-    val tileId: String,
-    val color: TileColor? = null,
-    val number: Int? = null,
-    val isJoker: Boolean = false
-) {
-    init {
-        require(tileId.isNotBlank()) { "tileId must not be blank" }
+sealed interface Tile {
+    val color: TileColor
+}
 
-        if (isJoker) {
-            require(color == null) { "joker tiles must not have a color" }
-            require(number == null) { "joker tiles must not have a number" }
-        } else {
-            require(color != null) { "numbered tiles must have a color" }
-            require(number != null) { "numbered tiles must have a number" }
-            require(number in 1..13) { "tile number must be between 1 and 13" }
-        }
+data class NumberedTile(
+    override val color: TileColor,
+    val number: Int
+) : Tile {
+    init {
+        require(number in 1..13) { "tile number must be between 1 and 13" }
     }
 }
+
+data class JokerTile(
+    override val color: TileColor
+) : Tile

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/Tile.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/Tile.kt
@@ -1,0 +1,21 @@
+package at.se2group.backend.domain
+
+data class Tile(
+    val tileId: String,
+    val color: TileColor? = null,
+    val number: Int? = null,
+    val isJoker: Boolean = false
+) {
+    init {
+        require(tileId.isNotBlank()) { "tileId must not be blank" }
+
+        if (isJoker) {
+            require(color == null) { "joker tiles must not have a color" }
+            require(number == null) { "joker tiles must not have a number" }
+        } else {
+            require(color != null) { "numbered tiles must have a color" }
+            require(number != null) { "numbered tiles must have a number" }
+            require(number in 1..13) { "tile number must be between 1 and 13" }
+        }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/TileColor.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/TileColor.kt
@@ -1,0 +1,8 @@
+package at.se2group.backend.domain
+
+enum class TileColor {
+    BLACK,
+    BLUE,
+    ORANGE,
+    RED
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/TurnDraft.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/TurnDraft.kt
@@ -1,0 +1,20 @@
+package at.se2group.backend.domain
+
+import java.time.Instant
+
+data class TurnDraft(
+    val gameId: String,
+    val playerUserId: String,
+    val boardSets: List<BoardSet> = emptyList(),
+    val rackTiles: List<Tile> = emptyList(),
+    val drawnTile: Tile? = null,
+    val status: TurnDraftStatus = TurnDraftStatus.IN_PROGRESS,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = createdAt
+) {
+    init {
+        require(gameId.isNotBlank()) { "gameId must not be blank" }
+        require(playerUserId.isNotBlank()) { "playerUserId must not be blank" }
+        require(!updatedAt.isBefore(createdAt)) { "updatedAt must not be before createdAt" }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/TurnDraftStatus.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/TurnDraftStatus.kt
@@ -1,0 +1,8 @@
+package at.se2group.backend.domain
+
+enum class TurnDraftStatus {
+    IN_PROGRESS,
+    SUBMITTED,
+    ACCEPTED,
+    REJECTED
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
@@ -46,6 +46,18 @@ class GameDomainModelTest {
     }
 
     @Test
+    fun `rejects game player with negative score`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GamePlayer(
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                score = -1
+            )
+        }
+    }
+
+    @Test
     fun `creates confirmed game with player and current turn`() {
         val player = GamePlayer(
             userId = "user-1",

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
@@ -77,6 +77,24 @@ class GameDomainModelTest {
     }
 
     @Test
+    fun `rejects confirmed game when current player is not part of game`() {
+        val player = GamePlayer(
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            ConfirmedGame(
+                gameId = "game-1",
+                lobbyId = "lobby-1",
+                players = listOf(player),
+                currentPlayerUserId = "user-2"
+            )
+        }
+    }
+
+    @Test
     fun `rejects turn draft with updated time before creation time`() {
         val createdAt = Instant.parse("2026-04-20T10:00:00Z")
         val updatedAt = Instant.parse("2026-04-20T09:59:59Z")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
@@ -1,0 +1,93 @@
+package at.se2group.backend.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class GameDomainModelTest {
+
+    @Test
+    fun `creates numbered tile with color and number`() {
+        val tile = Tile(
+            tileId = "tile-1",
+            color = TileColor.BLUE,
+            number = 7
+        )
+
+        assertEquals("tile-1", tile.tileId)
+        assertEquals(TileColor.BLUE, tile.color)
+        assertEquals(7, tile.number)
+    }
+
+    @Test
+    fun `creates joker tile without color or number`() {
+        val tile = Tile(
+            tileId = "joker-1",
+            isJoker = true
+        )
+
+        assertEquals("joker-1", tile.tileId)
+        assertEquals(true, tile.isJoker)
+        assertEquals(null, tile.color)
+        assertEquals(null, tile.number)
+    }
+
+    @Test
+    fun `rejects joker tile with numbered properties`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Tile(
+                tileId = "joker-1",
+                color = TileColor.RED,
+                number = 13,
+                isJoker = true
+            )
+        }
+    }
+
+    @Test
+    fun `rejects board set without tiles`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BoardSet(
+                boardSetId = "set-1",
+                tiles = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun `creates confirmed game with player and current turn`() {
+        val player = GamePlayer(
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0
+        )
+
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(player),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE
+        )
+
+        assertEquals("game-1", game.gameId)
+        assertEquals(GameStatus.ACTIVE, game.status)
+        assertEquals("user-1", game.currentPlayerUserId)
+    }
+
+    @Test
+    fun `rejects turn draft with updated time before creation time`() {
+        val createdAt = Instant.parse("2026-04-20T10:00:00Z")
+        val updatedAt = Instant.parse("2026-04-20T09:59:59Z")
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TurnDraft(
+                gameId = "game-1",
+                playerUserId = "user-1",
+                createdAt = createdAt,
+                updatedAt = updatedAt
+            )
+        }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
@@ -27,27 +27,43 @@ class GameDomainModelTest {
 
     @Test
     fun `rejects numbered tile outside valid range`() {
-        assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
             NumberedTile(
                 color = TileColor.RED,
                 number = 14
             )
         }
+
+        assertEquals("tile number must be between 1 and 13", exception.message)
+    }
+
+    @Test
+    fun `rejects numbered tile below valid range`() {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            NumberedTile(
+                color = TileColor.BLUE,
+                number = 0
+            )
+        }
+
+        assertEquals("tile number must be between 1 and 13", exception.message)
     }
 
     @Test
     fun `rejects board set without tiles`() {
-        assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
             BoardSet(
                 boardSetId = "set-1",
                 tiles = emptyList()
             )
         }
+
+        assertEquals("board sets must contain at least one tile", exception.message)
     }
 
     @Test
     fun `rejects game player with negative score`() {
-        assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
             GamePlayer(
                 userId = "user-1",
                 displayName = "Alice",
@@ -55,6 +71,8 @@ class GameDomainModelTest {
                 score = -1
             )
         }
+
+        assertEquals("score must not be negative", exception.message)
     }
 
     @Test
@@ -86,7 +104,7 @@ class GameDomainModelTest {
             turnOrder = 0
         )
 
-        assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
             ConfirmedGame(
                 gameId = "game-1",
                 lobbyId = "lobby-1",
@@ -94,6 +112,11 @@ class GameDomainModelTest {
                 currentPlayerUserId = "user-2"
             )
         }
+
+        assertEquals(
+            "currentPlayerUserId must belong to one of the game players",
+            exception.message
+        )
     }
 
     @Test
@@ -101,7 +124,7 @@ class GameDomainModelTest {
         val createdAt = Instant.parse("2026-04-20T10:00:00Z")
         val updatedAt = Instant.parse("2026-04-20T09:59:59Z")
 
-        assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalArgumentException::class.java) {
             TurnDraft(
                 gameId = "game-1",
                 playerUserId = "user-1",
@@ -109,5 +132,7 @@ class GameDomainModelTest {
                 updatedAt = updatedAt
             )
         }
+
+        assertEquals("updatedAt must not be before createdAt", exception.message)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameDomainModelTest.kt
@@ -9,38 +9,28 @@ class GameDomainModelTest {
 
     @Test
     fun `creates numbered tile with color and number`() {
-        val tile = Tile(
-            tileId = "tile-1",
+        val tile = NumberedTile(
             color = TileColor.BLUE,
             number = 7
         )
 
-        assertEquals("tile-1", tile.tileId)
         assertEquals(TileColor.BLUE, tile.color)
         assertEquals(7, tile.number)
     }
 
     @Test
-    fun `creates joker tile without color or number`() {
-        val tile = Tile(
-            tileId = "joker-1",
-            isJoker = true
-        )
+    fun `creates joker tile with color`() {
+        val tile = JokerTile(color = TileColor.RED)
 
-        assertEquals("joker-1", tile.tileId)
-        assertEquals(true, tile.isJoker)
-        assertEquals(null, tile.color)
-        assertEquals(null, tile.number)
+        assertEquals(TileColor.RED, tile.color)
     }
 
     @Test
-    fun `rejects joker tile with numbered properties`() {
+    fun `rejects numbered tile outside valid range`() {
         assertThrows(IllegalArgumentException::class.java) {
-            Tile(
-                tileId = "joker-1",
+            NumberedTile(
                 color = TileColor.RED,
-                number = 13,
-                isJoker = true
+                number = 14
             )
         }
     }


### PR DESCRIPTION
## Summary
Bootstraps the core backend game domain model for the Rummikub match flow.

This PR introduces the first set of backend domain classes and enums needed to represent game state in code. It establishes the foundational model for tiles, board sets, players, confirmed game state, and turn drafts, together with initial validation rules and domain tests. It is the first implementation slice for the parent issue covering the core game domain model.

## What changed

### Added core game enums
- `TileColor`
- `BoardSetType`
- `GameStatus`
- `TurnDraftStatus`

These enums provide the base vocabulary for tile identity, set classification, game lifecycle, and draft lifecycle. 

### Added tile and board set domain models
- `Tile`
- `BoardSet`

The tile model now distinguishes numbered tiles from jokers and validates valid combinations of `color`, `number`, and `isJoker`. Board sets include an ID, set type, and tile list, and currently enforce a non-blank ID and at least one tile.

### Added player and confirmed game domain models
- `GamePlayer`
- `ConfirmedGame`

The confirmed game model now holds the game ID, lobby ID, players, board sets, draw pile, current player, status, and timestamps for creation/start/finish. It also includes basic non-empty validation for key identifiers and the player list. 

### Added turn draft domain model
- `TurnDraft`

This adds the initial representation of a player’s editable turn draft state, including identifiers, board state, hand state, status, and timestamp fields.

### Added backend domain tests
- `GameDomainModelTest`

The PR also adds tests covering the new domain model behavior, including valid numbered/joker tiles and rejection of invalid tile combinations.

## Why
The backend needs a stable, validated domain model before persistence, services, REST endpoints, or websocket flows for the game can be implemented. This PR establishes that base so later issues can build on consistent game-state objects instead of introducing model structure ad hoc.
## Scope note
This PR is focused on the **domain model bootstrap only**. It does not yet add persistence, service logic, rule validation, or API/websocket handling. It is intended as the foundational first slice for the backend game implementation.

## How to test
1. Run backend tests
2. Verify the new domain model tests pass
3. Review the new domain classes under `apps/backend/src/main/kotlin/at/se2group/backend/domain`
4. Confirm the added invariants match the intended game-state rules for this early model layer.  

## Related issues

### Parent issue
- Closes #202

### Child issues included in this PR
- Closes #203 
- Closes #204 
- Closes #205 
- Closes #206 