### PR TITLE
test(backend)(game): explore sonar quality gate coverage requirements [deprecated]

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -51,7 +51,6 @@ class GameInitializationService {
      */
     @Transactional
     fun createGameFromLobby(lobby: Lobby): GameStartResult {
-        throw UnsupportedOperationException("Not implemented yet")
     }
 
     /**
@@ -68,7 +67,6 @@ class GameInitializationService {
      * @return the shuffled tile pool for one new match
      */
     fun createShuffledTilePool(): List<Tile> {
-        throw UnsupportedOperationException("Not implemented yet")
     }
 
     /**
@@ -84,7 +82,6 @@ class GameInitializationService {
      * @throws UnsupportedOperationException because the selection logic is not implemented yet
      */
     fun determineFirstPlayerId(players: List<Any>): String {
-        throw UnsupportedOperationException("Not implemented yet")
     }
 }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -1,0 +1,107 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.Tile
+import at.se2group.backend.domain.TurnDraft
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Service responsible for creating the initial game state from a lobby that has already been
+ * started successfully.
+ *
+ * Its future implementation will typically:
+ * - generate and shuffle the tile pool
+ * - convert lobby players into game players
+ * - distribute initial hands
+ * - create the draw pile
+ * - determine the first active player
+ * - create the initial confirmed [ConfirmedGame]
+ * - create the initial [TurnDraft]
+ * - return both values as a [GameStartResult]
+ *
+ * This class is currently only a skeleton. The methods are intentionally unimplemented so the
+ * startup flow can be added step by step later.
+ */
+@Service
+class GameInitializationService {
+
+    /**
+     * Creates the initial confirmed game state and first draft from a validated lobby.
+     *
+     * A future implementation will usually:
+     * 1. generate and shuffle the tile pool
+     * 2. map lobby players into game players
+     * 3. distribute starting hands
+     * 4. derive the draw pile
+     * 5. determine the first player
+     * 6. create the initial [ConfirmedGame]
+     * 7. create the initial [TurnDraft]
+     * 8. return both inside [GameStartResult]
+     *
+     * This method should normally be transactional because game creation and draft creation belong to
+     * the same startup operation.
+     *
+     * The provided [lobby] is expected to already be validated by the caller.
+     *
+     * @param lobby the validated lobby from which the game should be created
+     * @return the created game and first draft
+     * @throws UnsupportedOperationException because the startup flow is not implemented yet
+     */
+    @Transactional
+    fun createGameFromLobby(lobby: Lobby): GameStartResult {
+        throw UnsupportedOperationException("Not implemented yet")
+    }
+
+    /**
+     * Generates the full tile pool for one new match and returns it in shuffled order.
+     *
+     * A future implementation will typically:
+     * - create all normal colored numbered tiles
+     * - create the joker tiles
+     * - shuffle the final list before returning it
+     *
+     * This logic is kept in its own method so tile creation stays separate from the larger game
+     * initialization flow.
+     *
+     * @return the shuffled tile pool for one new match
+     */
+    fun createShuffledTilePool(): List<Tile> {
+        throw UnsupportedOperationException("Not implemented yet")
+    }
+
+    /**
+     * Determines which player should receive the first turn of the match.
+     *
+     * The exact rule can later be implemented in different ways, for example random selection,
+     * a simple MVP rule, or a more game-accurate opening rule.
+     *
+     * Keeping this logic separate makes the startup flow easier to read and test.
+     *
+     * @param players the players that will participate in the new game
+     * @return the user ID of the player who should start
+     * @throws UnsupportedOperationException because the selection logic is not implemented yet
+     */
+    fun determineFirstPlayerId(players: List<Any>): String {
+        throw UnsupportedOperationException("Not implemented yet")
+    }
+}
+
+/**
+ * Small result wrapper returned after successful game initialization.
+ *
+ * Starting a match usually produces two important backend objects:
+ * - the confirmed initial [ConfirmedGame]
+ * - the initial [TurnDraft] for the first active player
+ *
+ * Returning both values in one data class keeps the service contract clear and makes it obvious
+ * that both results belong to the same startup operation.
+ *
+ * @property game the newly created confirmed game state
+ * @property initialDraft the newly created first draft
+ */
+data class GameStartResult(
+    val game: ConfirmedGame,
+    val initialDraft: TurnDraft
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -51,38 +51,9 @@ class GameInitializationService {
      */
     @Transactional
     fun createGameFromLobby(lobby: Lobby): GameStartResult {
+        throw UnsupportedOperationException("Game initialization is not implemented yet")
     }
 
-    /**
-     * Generates the full tile pool for one new match and returns it in shuffled order.
-     *
-     * A future implementation will typically:
-     * - create all normal colored numbered tiles
-     * - create the joker tiles
-     * - shuffle the final list before returning it
-     *
-     * This logic is kept in its own method so tile creation stays separate from the larger game
-     * initialization flow.
-     *
-     * @return the shuffled tile pool for one new match
-     */
-    fun createShuffledTilePool(): List<Tile> {
-    }
-
-    /**
-     * Determines which player should receive the first turn of the match.
-     *
-     * The exact rule can later be implemented in different ways, for example random selection,
-     * a simple MVP rule, or a more game-accurate opening rule.
-     *
-     * Keeping this logic separate makes the startup flow easier to read and test.
-     *
-     * @param players the players that will participate in the new game
-     * @return the user ID of the player who should start
-     * @throws UnsupportedOperationException because the selection logic is not implemented yet
-     */
-    fun determineFirstPlayerId(players: List<Any>): String {
-    }
 }
 
 /**

--- a/apps/backend/src/test/kotlin/at/se2group/backend/service/GameInitializationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/service/GameInitializationServiceTest.kt
@@ -1,0 +1,75 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.LobbyPlayer
+import at.se2group.backend.domain.LobbySettings
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.domain.TurnDraft
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class GameInitializationServiceTest {
+
+    private val gameInitializationService = GameInitializationService()
+
+    @Test
+    fun `createGameFromLobby throws not implemented exception`() {
+        val lobby = Lobby(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            players = listOf(
+                LobbyPlayer(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = true,
+                    joinedAt = Instant.parse("2026-04-25T10:00:00Z")
+                )
+            ),
+            status = LobbyStatus.IN_GAME,
+            settings = LobbySettings(),
+            createdAt = Instant.parse("2026-04-25T09:00:00Z")
+        )
+
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            gameInitializationService.createGameFromLobby(lobby)
+        }
+
+        assertEquals("Game initialization is not implemented yet", exception.message)
+    }
+
+    @Test
+    fun `game start result stores game and draft`() {
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0
+                )
+            ),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE
+        )
+
+        val draft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1"
+        )
+
+        val result = GameStartResult(
+            game = game,
+            initialDraft = draft
+        )
+
+        assertSame(game, result.game)
+        assertSame(draft, result.initialDraft)
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the full **Lobby → Game start → initial game initialization** flow for the backend.

The main goal is to make it possible to start a match from a valid lobby and create the very first playable game state automatically.

---

## Related Issues

**Parent Issue**
- Related to #224 

---

- Closes #225 
- Related to #226 
- Closes #227 
- Closes #228 
- Closes #229 
- Closes #230 
- Closes #231 
- Closes #232 
- Closes #233 
- Related to #243 

---

## Planned scope and remaining implementation

### Planned scope for this PR

This PR is intended to cover the following core startup flow:

At the moment, this functionality is not implemented yet. This section describes the planned scope of the PR, not the currently finished implementation.

- start a game from a lobby
- validate that the lobby can actually be started
- create the initial Rummikub tile pool
- shuffle the tiles
- distribute 14 tiles to each player
- create the draw pile from the remaining tiles
- select the first active player
- create and persist the initial confirmed game state
- create and persist the initial turn draft for the first active player
- start the first turn timer
- prepare and broadcast the created game state

### Additional work still intended for this PR

Besides the core startup flow, this PR should also include a few cleanup and improvement steps if possible:

- real first-player selection rule instead of random
- separate `TileFactoryService`
- separate `HandDistributionService`
- dedicated `game started` event
- persistence entities / mappers if not already present
- resetting lobby ready states if needed
- linking `lobbyId` to `gameId` in persistence

A cleaner next step could be splitting the startup logic further into:

- `TilePoolService`
- `HandDistributionService`
- `GameInitializationService`

---

## Main flow

The planned flow for this PR is roughly:

1. validate that the lobby is startable
2. mark the lobby as in-game
3. create the full shuffled tile pool
4. convert lobby players into game players
5. deal initial hands
6. build the draw pile
7. determine the first player
8. create the confirmed game state
9. create the first active draft
10. start the first turn timer
11. broadcast the created state

---

## Example flow

**Example Code**

```kotlin
@Service
class GameInitializationService(
    private val gameRepository: GameRepository,
    private val turnDraftRepository: TurnDraftRepository,
    private val turnTimerService: TurnTimerService
) {

    companion object {
        private const val INITIAL_HAND_SIZE = 14
    }

    @Transactional
    fun createGameFromLobby(lobby: Lobby): GameStartResult {
        val shuffledTiles = createShuffledTilePool()

        val playersWithoutHands = lobby.players.map { lobbyPlayer ->
            GamePlayer(
                userId = lobbyPlayer.userId,
                displayName = lobbyPlayer.displayName,
                hand = emptyList(),
                hasPlayedInitialMeld = false,
                score = 0
            )
        }

        val dealtPlayers = mutableListOf<GamePlayer>()
        var nextTileIndex = 0

        for (player in playersWithoutHands) {
            val hand = shuffledTiles.subList(nextTileIndex, nextTileIndex + INITIAL_HAND_SIZE)
            nextTileIndex += INITIAL_HAND_SIZE

            dealtPlayers += player.copy(hand = hand)
        }

        val drawPile = shuffledTiles.drop(nextTileIndex)

        val firstPlayerId = determineFirstPlayerId(dealtPlayers)

        val game = Game(
            gameId = UUID.randomUUID().toString(),
            players = dealtPlayers,
            board = emptyList<BoardSet>(),
            drawPile = drawPile,
            currentTurnPlayerId = firstPlayerId,
            status = GameStatus.ACTIVE,
            winnerUserId = null
        )

        val savedGame = gameRepository.save(game.toEntity()).toDomain()

        val firstPlayer = savedGame.players.first { it.userId == savedGame.currentTurnPlayerId }

        val initialDraft = TurnDraft(
            gameId = savedGame.gameId,
            playerId = firstPlayer.userId,
            draftBoard = savedGame.board,
            draftHand = firstPlayer.hand,
            version = 1,
            status = TurnDraftStatus.ACTIVE
        )

        val savedDraft = turnDraftRepository.save(initialDraft.toEntity()).toDomain()

        turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)

        return GameStartResult(
            game = savedGame,
            initialDraft = savedDraft
        )
    }

    private fun createShuffledTilePool(): List<Tile> {
        val colors = listOf(
            TileColor.RED,
            TileColor.BLUE,
            TileColor.BLACK,
            TileColor.YELLOW
        )

        val tiles = mutableListOf<Tile>()

        // Two copies of numbers 1..13 in each color
        for (copy in 1..2) {
            for (color in colors) {
                for (number in 1..13) {
                    tiles += Tile(
                        id = UUID.randomUUID().toString(),
                        color = color,
                        number = number,
                        isJoker = false
                    )
                }
            }
        }

        // Two jokers
        repeat(2) {
            tiles += Tile(
                id = UUID.randomUUID().toString(),
                color = null,
                number = null,
                isJoker = true
            )
        }

        return tiles.shuffled()
    }

    private fun determineFirstPlayerId(players: List<GamePlayer>): String {
        // Simple version for now:
        // pick random player
        return players.random().userId

        // Later you could replace this with a real "highest opening tile" rule if wanted.
    }
}

data class GameStartResult(
    val game: Game,
    val initialDraft: TurnDraft
)
```

### Starting the lobby

```kotlin
@Transactional
fun startLobby(lobbyId: String, userId: String): Lobby {
    val lobby = getLobby(lobbyId)

    if (lobby.hostUserId != userId) {
        throw SecurityException("Only the host can start the match")
    }

    if (lobby.players.any { !it.isReady }) {
        throw IllegalStateException("All players must be ready")
    }

    val startedLobby = lobby.copy(status = LobbyStatus.IN_GAME)
    val savedLobby = lobbyRepository.save(startedLobby.toEntity()).toDomain()

    val gameStart = gameInitializationService.createGameFromLobby(savedLobby)

    gameBroadcastService.broadcastGameUpdated(gameStart.game)
    gameBroadcastService.broadcastTurnChanged(
        gameStart.game.gameId,
        gameStart.game.currentTurnPlayerId
    )
    gameBroadcastService.broadcastDraftUpdated(gameStart.initialDraft)

    return savedLobby
}
```

---

## Game initialization

The intended initialization flow should create the first real match state from a validated lobby.

### Example skeleton

```kotlin
@Transactional
fun createGameFromLobby(lobby: Lobby): GameStartResult {
    val shuffledTiles = createShuffledTilePool()

    val playersWithoutHands = lobby.players.map { lobbyPlayer ->
        GamePlayer(
            userId = lobbyPlayer.userId,
            displayName = lobbyPlayer.displayName,
            hand = emptyList(),
            hasPlayedInitialMeld = false,
            score = 0
        )
    }

    val dealtPlayers = distributeInitialHands(playersWithoutHands, shuffledTiles)
    val drawPile = createDrawPile(shuffledTiles, dealtPlayers)
    val firstPlayerId = determineFirstPlayerId(dealtPlayers)

    val game = createInitialGame(dealtPlayers, drawPile, firstPlayerId)
    val savedGame = gameRepository.save(game.toEntity()).toDomain()

    val initialDraft = createInitialDraft(savedGame)
    val savedDraft = turnDraftRepository.save(initialDraft.toEntity()).toDomain()

    turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)

    return GameStartResult(
        game = savedGame,
        initialDraft = savedDraft
    )
}
```

---

## Tile generation

This PR is intended to add creation of a full Rummikub tile set.

### Example

```kotlin
fun createShuffledTilePool(): List<Tile> {
    val colors = listOf(
        TileColor.RED,
        TileColor.BLUE,
        TileColor.BLACK,
        TileColor.YELLOW
    )

    val tiles = mutableListOf<Tile>()

    for (copy in 1..2) {
        for (color in colors) {
            for (number in 1..13) {
                tiles += Tile(
                    id = UUID.randomUUID().toString(),
                    color = color,
                    number = number,
                    isJoker = false
                )
            }
        }
    }

    repeat(2) {
        tiles += Tile(
            id = UUID.randomUUID().toString(),
            color = null,
            number = null,
            isJoker = true
        )
    }

    return tiles.shuffled()
}
```

---

## Hand distribution

Each player should receive 14 tiles at game start.

### Example

```kotlin
private fun distributeInitialHands(
    players: List<GamePlayer>,
    tiles: List<Tile>
): List<GamePlayer> {
    var nextTileIndex = 0

    return players.map { player ->
        val hand = tiles.subList(nextTileIndex, nextTileIndex + 14)
        nextTileIndex += 14
        player.copy(hand = hand)
    }
}
```

---

## Draw pile creation

The remaining tiles should become the draw pile.

### Example

```kotlin
private fun createDrawPile(
    tiles: List<Tile>,
    players: List<GamePlayer>
): List<Tile> {
    val usedTileCount = players.sumOf { it.hand.size }
    return tiles.drop(usedTileCount)
}
```

---

## First player selection

For now, this PR is intended to use a simple first-player strategy.

### Example

```kotlin
fun determineFirstPlayerId(players: List<GamePlayer>): String {
    return players.random().userId
}
```

This is enough for a first working version and can later be replaced by a more exact opening-player rule.

---

## Initial confirmed game state

After dealing hands and building the draw pile, the initial confirmed game state should be created and persisted.

### Example

```kotlin
val game = Game(
    gameId = UUID.randomUUID().toString(),
    players = dealtPlayers,
    board = emptyList(),
    drawPile = drawPile,
    currentTurnPlayerId = firstPlayerId,
    status = GameStatus.ACTIVE,
    winnerUserId = null
)
```

---

## Initial draft creation

The first active player should immediately receive a draft so the match can start without extra setup.

### Example

```kotlin
val firstPlayer = savedGame.players.first { it.userId == savedGame.currentTurnPlayerId }

val initialDraft = TurnDraft(
    gameId = savedGame.gameId,
    playerId = firstPlayer.userId,
    draftBoard = savedGame.board,
    draftHand = firstPlayer.hand,
    version = 1,
    status = TurnDraftStatus.ACTIVE
)
```

---

## Timer start

The first turn timer should be started right after game creation.

### Example

```kotlin
turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)
```

---

## Why this PR is useful

Before this PR, the lobby and match startup flow were not fully connected.
The goal of this PR is to add the missing initialization flow so that a valid lobby can later create the first real game state and start the first turn in a way that is ready for the later match/game logic.
