### PR TITLE
feat(backend)(lobby,game): lobby-to-game startup and initial match initialization

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,17 @@
+# apps/backend/Dockerfile
+
+FROM gradle:8.10.2-jdk21 AS build
+WORKDIR /app
+
+COPY . .
+
+RUN gradle :apps:backend:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/apps/backend/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,11 +1,10 @@
-# apps/backend/Dockerfile
-
-FROM gradle:8.10.2-jdk21 AS build
+FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
 COPY . .
 
-RUN gradle :apps:backend:bootJar --no-daemon
+RUN chmod +x ./gradlew
+RUN ./gradlew :apps:backend:bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
@@ -14,4 +13,4 @@ COPY --from=build /app/apps/backend/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java -Dserver.port=${PORT:-8080} -jar app.jar"]

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/GameStartResult.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/GameStartResult.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.domain
+
+data class GameStartResult(
+    val confirmedGame: ConfirmedGame,
+    val turnDraft: TurnDraft? = null
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/domain/TileRules.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/domain/TileRules.kt
@@ -1,0 +1,12 @@
+package at.se2group.backend.domain
+
+object TileRules {
+    const val NUMBERED_TILE_COPY_COUNT = 2
+    const val MIN_TILE_NUMBER = 1
+    const val MAX_TILE_NUMBER = 13
+
+    val jokerColors = listOf(
+        TileColor.BLACK,
+        TileColor.RED
+    )
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -18,9 +18,6 @@ import java.util.UUID
  * - create the initial confirmed [ConfirmedGame]
  * - create the initial [TurnDraft]
  * - return both values as a [GameStartResult]
- *
- * This class is currently only a skeleton. The methods are intentionally unimplemented so the
- * startup flow can be added step by step later.
  */
 @Service
 class GameInitializationService(
@@ -53,7 +50,6 @@ class GameInitializationService(
      *
      * @param lobby the validated lobby from which the confirmedGame should be created
      * @return the created confirmedGame and first draft
-     * @throws UnsupportedOperationException because the startup flow is not implemented yet
      */
     @Transactional
     fun createGameFromLobby(lobby: Lobby): GameStartResult {
@@ -75,7 +71,8 @@ class GameInitializationService(
         val playersWithHands = tileShuffleService.distributedHands(basePlayers, tiles)
         val drawPile = tileShuffleService.createDrawPile(tiles, playersWithHands)
 
-        val firstPlayerId = playersWithHands.random().userId
+        val firstPlayer = playersWithHands.minByOrNull { it.turnOrder }
+            ?: throw IllegalArgumentException("players must not be empty")
 
         val confirmedGame = ConfirmedGame(
             gameId = UUID.randomUUID().toString(),
@@ -83,16 +80,15 @@ class GameInitializationService(
             players = playersWithHands,
             boardSets = emptyList(),
             drawPile = drawPile,
-            currentPlayerUserId = firstPlayerId,
+            currentPlayerUserId = firstPlayer.userId,
             status = GameStatus.ACTIVE
         )
 
-        val starter = confirmedGame.players.first { it.userId == firstPlayerId }
         val draft = TurnDraft(
             gameId = confirmedGame.gameId,
-            playerUserId = starter.userId,
+            playerUserId = firstPlayer.userId,
             boardSets = emptyList(),
-            rackTiles = starter.rackTiles
+            rackTiles = firstPlayer.rackTiles
         )
         return GameStartResult(confirmedGame, draft )
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -1,19 +1,17 @@
 package at.se2group.backend.service
 
-import at.se2group.backend.domain.ConfirmedGame
-import at.se2group.backend.domain.Lobby
-import at.se2group.backend.domain.Tile
-import at.se2group.backend.domain.TurnDraft
+import at.se2group.backend.domain.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 /**
- * Service responsible for creating the initial game state from a lobby that has already been
+ * Service responsible for creating the initial confirmedGame state from a lobby that has already been
  * started successfully.
  *
  * Its future implementation will typically:
  * - generate and shuffle the tile pool
- * - convert lobby players into game players
+ * - convert lobby players into confirmedGame players
  * - distribute initial hands
  * - create the draw pile
  * - determine the first active player
@@ -25,14 +23,22 @@ import org.springframework.transaction.annotation.Transactional
  * startup flow can be added step by step later.
  */
 @Service
-class GameInitializationService {
+class GameInitializationService(
+    private val tilePoolGenerationService: TilePoolGenerationService,
+    private val tileShuffleService: TileShuffleService
+) {
+    companion object {
+        private const val INITIAL_HAND_SIZE = 14
+    }
+
+
 
     /**
-     * Creates the initial confirmed game state and first draft from a validated lobby.
+     * Creates the initial confirmed confirmedGame state and first draft from a validated lobby.
      *
      * A future implementation will usually:
      * 1. generate and shuffle the tile pool
-     * 2. map lobby players into game players
+     * 2. map lobby players into confirmedGame players
      * 3. distribute starting hands
      * 4. derive the draw pile
      * 5. determine the first player
@@ -40,36 +46,54 @@ class GameInitializationService {
      * 7. create the initial [TurnDraft]
      * 8. return both inside [GameStartResult]
      *
-     * This method should normally be transactional because game creation and draft creation belong to
+     * This method should normally be transactional because confirmedGame creation and draft creation belong to
      * the same startup operation.
      *
      * The provided [lobby] is expected to already be validated by the caller.
      *
-     * @param lobby the validated lobby from which the game should be created
-     * @return the created game and first draft
+     * @param lobby the validated lobby from which the confirmedGame should be created
+     * @return the created confirmedGame and first draft
      * @throws UnsupportedOperationException because the startup flow is not implemented yet
      */
     @Transactional
     fun createGameFromLobby(lobby: Lobby): GameStartResult {
-        throw UnsupportedOperationException("Game initialization is not implemented yet")
+
+        val orderedPool = tilePoolGenerationService.createTilePool()
+        val tiles = tileShuffleService.shuffleTiles(orderedPool)
+
+        val basePlayers = lobby.players.mapIndexed { index, it ->
+            GamePlayer(
+                userId = it.userId,
+                displayName = it.displayName,
+                turnOrder = index,
+                rackTiles = emptyList(),
+                hasCompletedInitialMeld = false,
+                score = 0
+            )
+        }
+
+        val playersWithHands = tileShuffleService.distributedHands(basePlayers, tiles)
+        val drawPile = tileShuffleService.createDrawPile(tiles, playersWithHands)
+
+        val firstPlayerId = playersWithHands.random().userId
+
+        val confirmedGame = ConfirmedGame(
+            gameId = UUID.randomUUID().toString(),
+            lobbyId = lobby.lobbyId,
+            players = playersWithHands,
+            boardSets = emptyList(),
+            drawPile = drawPile,
+            currentPlayerUserId = firstPlayerId,
+            status = GameStatus.ACTIVE
+        )
+
+        val starter = confirmedGame.players.first { it.userId == firstPlayerId }
+        val draft = TurnDraft(
+            gameId = confirmedGame.gameId,
+            playerUserId = starter.userId,
+            boardSets = emptyList(),
+            rackTiles = starter.rackTiles
+        )
+        return GameStartResult(confirmedGame, draft )
     }
-
 }
-
-/**
- * Small result wrapper returned after successful game initialization.
- *
- * Starting a match usually produces two important backend objects:
- * - the confirmed initial [ConfirmedGame]
- * - the initial [TurnDraft] for the first active player
- *
- * Returning both values in one data class keeps the service contract clear and makes it obvious
- * that both results belong to the same startup operation.
- *
- * @property game the newly created confirmed game state
- * @property initialDraft the newly created first draft
- */
-data class GameStartResult(
-    val game: ConfirmedGame,
-    val initialDraft: TurnDraft
-)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -1,0 +1,75 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.Tile
+import at.se2group.backend.domain.TurnDraft
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Service responsible for creating the initial game state from a lobby that has already been
+ * started successfully.
+ *
+ * Its future implementation will typically:
+ * - generate and shuffle the tile pool
+ * - convert lobby players into game players
+ * - distribute initial hands
+ * - create the draw pile
+ * - determine the first active player
+ * - create the initial confirmed [ConfirmedGame]
+ * - create the initial [TurnDraft]
+ * - return both values as a [GameStartResult]
+ *
+ * This class is currently only a skeleton. The methods are intentionally unimplemented so the
+ * startup flow can be added step by step later.
+ */
+@Service
+class GameInitializationService {
+
+    /**
+     * Creates the initial confirmed game state and first draft from a validated lobby.
+     *
+     * A future implementation will usually:
+     * 1. generate and shuffle the tile pool
+     * 2. map lobby players into game players
+     * 3. distribute starting hands
+     * 4. derive the draw pile
+     * 5. determine the first player
+     * 6. create the initial [ConfirmedGame]
+     * 7. create the initial [TurnDraft]
+     * 8. return both inside [GameStartResult]
+     *
+     * This method should normally be transactional because game creation and draft creation belong to
+     * the same startup operation.
+     *
+     * The provided [lobby] is expected to already be validated by the caller.
+     *
+     * @param lobby the validated lobby from which the game should be created
+     * @return the created game and first draft
+     * @throws UnsupportedOperationException because the startup flow is not implemented yet
+     */
+    @Transactional
+    fun createGameFromLobby(lobby: Lobby): GameStartResult {
+        throw UnsupportedOperationException("Game initialization is not implemented yet")
+    }
+
+}
+
+/**
+ * Small result wrapper returned after successful game initialization.
+ *
+ * Starting a match usually produces two important backend objects:
+ * - the confirmed initial [ConfirmedGame]
+ * - the initial [TurnDraft] for the first active player
+ *
+ * Returning both values in one data class keeps the service contract clear and makes it obvious
+ * that both results belong to the same startup operation.
+ *
+ * @property game the newly created confirmed game state
+ * @property initialDraft the newly created first draft
+ */
+data class GameStartResult(
+    val game: ConfirmedGame,
+    val initialDraft: TurnDraft
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -155,7 +155,8 @@ class LobbyService(
 
         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
 
-        lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, saved.lobbyId)
+        val gameStart = gameInitializationService.createGameFromLobby(saved)
+        lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, gameStart.confirmedGame.gameId)
         return saved
     }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -18,8 +18,7 @@ import java.time.Instant
 @Transactional(readOnly = true)
 class LobbyService(
     private val lobbyRepository: LobbyRepository,
-    private val lobbyBroadcastService: LobbyBroadcastService,
-    private val gameInitializationService: GameInitializationService) {
+    private val lobbyBroadcastService: LobbyBroadcastService) {
 
     companion object {
         const val MAX_PLAYERS = 8
@@ -156,8 +155,6 @@ class LobbyService(
         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
 
         lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, saved.lobbyId)
-        val gameStart = gameInitializationService.createGameFromLobby(saved)
-        lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, gameStart.confirmedGame.gameId)
         return saved
     }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -18,7 +18,8 @@ import java.time.Instant
 @Transactional(readOnly = true)
 class LobbyService(
     private val lobbyRepository: LobbyRepository,
-    private val lobbyBroadcastService: LobbyBroadcastService) {
+    private val lobbyBroadcastService: LobbyBroadcastService,
+    private val gameInitializationService: GameInitializationService) {
 
     companion object {
         const val MAX_PLAYERS = 8
@@ -153,7 +154,10 @@ class LobbyService(
         )
 
         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+
         lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, saved.lobbyId)
+        val gameStart = gameInitializationService.createGameFromLobby(saved)
+        lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, gameStart.confirmedGame.gameId)
         return saved
     }
 
@@ -216,27 +220,27 @@ class LobbyService(
         return saved
     }
 
-     @Transactional
-     fun unreadyLobby(lobbyId: String, userId: String): Lobby {
-         val lobby = getLobby(lobbyId)
+    @Transactional
+    fun unreadyLobby(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
 
-         if(lobby.status != LobbyStatus.OPEN) {
-             throw IllegalStateException("You cannot change the ready status, while lobby is not open")
-         }
+        if(lobby.status != LobbyStatus.OPEN) {
+            throw IllegalStateException("You cannot change the ready status, while lobby is not open")
+        }
 
-         if(lobby.players.none {it.userId == userId}) {
-             throw IllegalArgumentException("No player found in this lobby")
-         }
+        if(lobby.players.none {it.userId == userId}) {
+            throw IllegalArgumentException("No player found in this lobby")
+        }
 
-         val updatedLobby = lobby.copy(
-             players = lobby.players.map {
-                 if (it.userId == userId) it.copy(isReady = false) else it
-             }
-         )
-         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
-         lobbyBroadcastService.broadcastLobbyUpdated(saved)
-         return saved
-     }
+        val updatedLobby = lobby.copy(
+            players = lobby.players.map {
+                if (it.userId == userId) it.copy(isReady = false) else it
+            }
+        )
+        val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
+        lobbyBroadcastService.broadcastLobbyUpdated(saved)
+        return saved
+    }
 
     fun deleteLobby(lobbyId: String, userId: String) {
         val lobby = getLobby(lobbyId)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -18,7 +18,8 @@ import java.time.Instant
 @Transactional(readOnly = true)
 class LobbyService(
     private val lobbyRepository: LobbyRepository,
-    private val lobbyBroadcastService: LobbyBroadcastService) {
+    private val lobbyBroadcastService: LobbyBroadcastService,
+    private val gameInitializationService: GameInitializationService) {
 
     companion object {
         const val MAX_PLAYERS = 8

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TilePoolGenerationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TilePoolGenerationService.kt
@@ -1,0 +1,29 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.*
+import org.springframework.stereotype.Service
+
+@Service
+class TilePoolGenerationService {
+
+    fun createTilePool(): List<Tile> {
+        val tiles = mutableListOf<Tile>()
+
+        repeat(TileRules.NUMBERED_TILE_COPY_COUNT) {
+            for (color in TileColor.entries) {
+                for (number in TileRules.MIN_TILE_NUMBER..TileRules.MAX_TILE_NUMBER) {
+                    tiles += NumberedTile(
+                        color = color,
+                        number = number
+                    )
+                }
+            }
+        }
+        tiles += TileRules.jokerColors.map { color ->
+            JokerTile(
+                color = color
+            )
+        }
+        return tiles
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
@@ -1,0 +1,40 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.GamePlayer
+import org.springframework.stereotype.Service
+import at.se2group.backend.domain.Tile
+
+@Service
+class TileShuffleService {
+    companion object {
+        private const val HAND_SIZE = 14
+    }
+
+    fun shuffleTiles(tiles: List<Tile>): List<Tile> {
+        return tiles.shuffled()
+    }
+
+    fun distributedHands(
+        players: List<GamePlayer>,
+        tiles: List<Tile>
+    ): List<GamePlayer> {
+
+        var index = 0
+
+        return players.map { player ->
+            val hand = tiles.subList(index, index + HAND_SIZE)
+            index += HAND_SIZE
+
+            player.copy(rackTiles = hand)
+
+        }
+    }
+
+    fun createDrawPile(
+        tiles: List<Tile>,
+        players: List<GamePlayer>
+    ): List<Tile> {
+        val used = players.sumOf { it.rackTiles.size }
+        return tiles.drop(used)
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
@@ -18,6 +18,10 @@ class TileShuffleService {
         players: List<GamePlayer>,
         tiles: List<Tile>
     ): List<GamePlayer> {
+        val requiredTiles = players.size * HAND_SIZE
+        require(tiles.size >= requiredTiles) {
+            "Not enough tiles to distribute $HAND_SIZE tiles to ${players.size} players"
+        }
 
         var index = 0
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameStartResultTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameStartResultTest.kt
@@ -1,0 +1,49 @@
+package at.se2group.backend.domain
+
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class GameStartResultTest {
+
+    @Test
+    fun `GameStartResult should hold the given ConfirmedGame and TurnDraft instances`() {
+        val player = GamePlayer(
+            userId = "user-1",
+            displayName = "Player One",
+            turnOrder = 0,
+            rackTiles = listOf(
+                NumberedTile(color = TileColor.RED, number = 3)
+            ),
+            hasCompletedInitialMeld = false,
+            score = 0
+        )
+
+        val confirmedGame = ConfirmedGame(
+            gameId = UUID.randomUUID().toString(),
+            lobbyId = "lobby-123",
+            players = listOf(player),
+            boardSets = emptyList(),
+            drawPile = listOf(
+                NumberedTile(color = TileColor.BLUE, number = 5)
+            ),
+            currentPlayerUserId = player.userId,
+            status = GameStatus.ACTIVE
+        )
+
+        val turnDraft = TurnDraft(
+            gameId = confirmedGame.gameId,
+            playerUserId = player.userId,
+            boardSets = emptyList(),
+            rackTiles = player.rackTiles
+        )
+
+        val gameStartResult = GameStartResult(
+            confirmedGame = confirmedGame,
+            turnDraft = turnDraft
+        )
+
+        assertSame(confirmedGame, gameStartResult.confirmedGame)
+        assertSame(turnDraft, gameStartResult.turnDraft)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameStartResultTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/GameStartResultTest.kt
@@ -1,32 +1,28 @@
 package at.se2group.backend.domain
 
-import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class GameStartResultTest {
 
     @Test
-    fun `GameStartResult should hold the given ConfirmedGame and TurnDraft instances`() {
+    fun `should store confirmed game and turn draft`() {
         val player = GamePlayer(
             userId = "user-1",
             displayName = "Player One",
             turnOrder = 0,
-            rackTiles = listOf(
-                NumberedTile(color = TileColor.RED, number = 3)
-            ),
+            rackTiles = listOf(NumberedTile(color = TileColor.RED, number = 3)),
             hasCompletedInitialMeld = false,
             score = 0
         )
 
         val confirmedGame = ConfirmedGame(
-            gameId = UUID.randomUUID().toString(),
-            lobbyId = "lobby-123",
+            gameId = "game-1",
+            lobbyId = "lobby-1",
             players = listOf(player),
             boardSets = emptyList(),
-            drawPile = listOf(
-                NumberedTile(color = TileColor.BLUE, number = 5)
-            ),
+            drawPile = listOf(NumberedTile(color = TileColor.BLUE, number = 5)),
             currentPlayerUserId = player.userId,
             status = GameStatus.ACTIVE
         )
@@ -38,12 +34,39 @@ class GameStartResultTest {
             rackTiles = player.rackTiles
         )
 
-        val gameStartResult = GameStartResult(
+        val result = GameStartResult(
             confirmedGame = confirmedGame,
             turnDraft = turnDraft
         )
 
-        assertSame(confirmedGame, gameStartResult.confirmedGame)
-        assertSame(turnDraft, gameStartResult.turnDraft)
+        assertEquals(confirmedGame, result.confirmedGame)
+        assertEquals(turnDraft, result.turnDraft)
+    }
+
+    @Test
+    fun `should default turn draft to null`() {
+        val player = GamePlayer(
+            userId = "user-1",
+            displayName = "Player One",
+            turnOrder = 0,
+            rackTiles = emptyList(),
+            hasCompletedInitialMeld = false,
+            score = 0
+        )
+
+        val confirmedGame = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(player),
+            boardSets = emptyList(),
+            drawPile = emptyList(),
+            currentPlayerUserId = player.userId,
+            status = GameStatus.ACTIVE
+        )
+
+        val result = GameStartResult(confirmedGame = confirmedGame)
+
+        assertEquals(confirmedGame, result.confirmedGame)
+        assertNull(result.turnDraft)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/domain/TileRulesTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/domain/TileRulesTest.kt
@@ -1,0 +1,22 @@
+package at.se2group.backend.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TileRulesTest {
+
+    @Test
+    fun `tile rules expose expected numbered tile constants`() {
+        assertEquals(2, TileRules.NUMBERED_TILE_COPY_COUNT)
+        assertEquals(1, TileRules.MIN_TILE_NUMBER)
+        assertEquals(13, TileRules.MAX_TILE_NUMBER)
+    }
+
+    @Test
+    fun `tile rules expose expected joker colors`() {
+        assertEquals(
+            listOf(TileColor.BLACK, TileColor.RED),
+            TileRules.jokerColors
+        )
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
@@ -1,0 +1,75 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.domain.Lobby
+import at.se2group.backend.domain.LobbyPlayer
+import at.se2group.backend.domain.LobbySettings
+import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.domain.TurnDraft
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class GameInitializationServiceTest {
+
+    private val gameInitializationService = GameInitializationService()
+
+    @Test
+    fun `createGameFromLobby throws not implemented exception`() {
+        val lobby = Lobby(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            players = listOf(
+                LobbyPlayer(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = true,
+                    joinedAt = Instant.parse("2026-04-25T10:00:00Z")
+                )
+            ),
+            status = LobbyStatus.IN_GAME,
+            settings = LobbySettings(),
+            createdAt = Instant.parse("2026-04-25T09:00:00Z")
+        )
+
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            gameInitializationService.createGameFromLobby(lobby)
+        }
+
+        assertEquals("Game initialization is not implemented yet", exception.message)
+    }
+
+    @Test
+    fun `game start result stores game and draft`() {
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0
+                )
+            ),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE
+        )
+
+        val draft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1"
+        )
+
+        val result = GameStartResult(
+            game = game,
+            initialDraft = draft
+        )
+
+        assertSame(game, result.game)
+        assertSame(draft, result.initialDraft)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
@@ -1,25 +1,36 @@
 package at.se2group.backend.service
 
-import at.se2group.backend.domain.ConfirmedGame
-import at.se2group.backend.domain.GamePlayer
-import at.se2group.backend.domain.GameStatus
 import at.se2group.backend.domain.Lobby
 import at.se2group.backend.domain.LobbyPlayer
 import at.se2group.backend.domain.LobbySettings
 import at.se2group.backend.domain.LobbyStatus
-import at.se2group.backend.domain.TurnDraft
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.Tile
+import at.se2group.backend.domain.TileColor
+import at.se2group.backend.domain.GameStatus
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Instant
 
+@ExtendWith(MockitoExtension::class)
 class GameInitializationServiceTest {
 
-    private val gameInitializationService = GameInitializationService()
+    @Mock
+    lateinit var tilePoolGenerationService: TilePoolGenerationService
 
     @Test
-    fun `createGameFromLobby throws not implemented exception`() {
+    fun `createGameFromLobby creates confirmed game and initial draft from lobby`() {
+        val gameInitializationService = GameInitializationService(
+            tilePoolGenerationService = tilePoolGenerationService,
+            tileShuffleService = TileShuffleService()
+        )
+
         val lobby = Lobby(
             lobbyId = "lobby-1",
             hostUserId = "host-1",
@@ -28,48 +39,73 @@ class GameInitializationServiceTest {
                     userId = "host-1",
                     displayName = "Alice",
                     isReady = true,
-                    joinedAt = Instant.parse("2026-04-25T10:00:00Z")
+                    joinedAt = Instant.parse("2026-04-26T10:00:00Z")
+                ),
+                LobbyPlayer(
+                    userId = "user-2",
+                    displayName = "Bob",
+                    isReady = true,
+                    joinedAt = Instant.parse("2026-04-26T10:01:00Z")
                 )
             ),
             status = LobbyStatus.IN_GAME,
-            settings = LobbySettings(),
-            createdAt = Instant.parse("2026-04-25T09:00:00Z")
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            ),
+            createdAt = Instant.parse("2026-04-26T09:00:00Z")
         )
 
-        val exception = assertThrows(UnsupportedOperationException::class.java) {
-            gameInitializationService.createGameFromLobby(lobby)
-        }
+        val orderedPool = createTiles(40)
+        `when`(tilePoolGenerationService.createTilePool()).thenReturn(orderedPool)
 
-        assertEquals("Game initialization is not implemented yet", exception.message)
+        val result = gameInitializationService.createGameFromLobby(lobby)
+
+        assertEquals("lobby-1", result.confirmedGame.lobbyId)
+        assertEquals(GameStatus.ACTIVE, result.confirmedGame.status)
+        assertTrue(result.confirmedGame.gameId.isNotBlank())
+        assertEquals(2, result.confirmedGame.players.size)
+        assertEquals(12, result.confirmedGame.drawPile.size)
+        assertTrue(
+            result.confirmedGame.players.any {
+                it.userId == result.confirmedGame.currentPlayerUserId
+            }
+        )
+
+        val firstPlayer = result.confirmedGame.players.first { it.turnOrder == 0 }
+        val secondPlayer = result.confirmedGame.players.first { it.turnOrder == 1 }
+
+        assertEquals("host-1", firstPlayer.userId)
+        assertEquals("Alice", firstPlayer.displayName)
+        assertEquals("user-2", secondPlayer.userId)
+        assertEquals("Bob", secondPlayer.displayName)
+        assertEquals(14, firstPlayer.rackTiles.size)
+        assertEquals(14, secondPlayer.rackTiles.size)
+        assertEquals(28, result.confirmedGame.players.sumOf { it.rackTiles.size })
+
+        val allDistributedTiles = result.confirmedGame.players.flatMap { it.rackTiles }
+        val allGameTiles = allDistributedTiles + result.confirmedGame.drawPile
+        assertEquals(40, allGameTiles.size)
+        assertEquals(orderedPool.toSet(), allGameTiles.toSet())
+
+        val starter = result.confirmedGame.players.first {
+            it.userId == result.confirmedGame.currentPlayerUserId
+        }
+        assertEquals(result.confirmedGame.gameId, result.turnDraft?.gameId)
+        assertEquals(starter.userId, result.turnDraft?.playerUserId)
+        assertEquals(starter.rackTiles, result.turnDraft?.rackTiles)
+        assertEquals(emptyList<Nothing>(), result.turnDraft?.boardSets)
+
+        verify(tilePoolGenerationService).createTilePool()
     }
 
-    @Test
-    fun `game start result stores game and draft`() {
-        val game = ConfirmedGame(
-            gameId = "game-1",
-            lobbyId = "lobby-1",
-            players = listOf(
-                GamePlayer(
-                    userId = "user-1",
-                    displayName = "Alice",
-                    turnOrder = 0
-                )
-            ),
-            currentPlayerUserId = "user-1",
-            status = GameStatus.ACTIVE
-        )
-
-        val draft = TurnDraft(
-            gameId = "game-1",
-            playerUserId = "user-1"
-        )
-
-        val result = GameStartResult(
-            game = game,
-            initialDraft = draft
-        )
-
-        assertSame(game, result.game)
-        assertSame(draft, result.initialDraft)
+    private fun createTiles(count: Int): List<Tile> {
+        return (0 until count).map { index ->
+            NumberedTile(
+                color = TileColor.entries[index % TileColor.entries.size],
+                number = (index % 13) + 1
+            )
+        }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/GameInitializationServiceTest.kt
@@ -83,18 +83,16 @@ class GameInitializationServiceTest {
         assertEquals(14, firstPlayer.rackTiles.size)
         assertEquals(14, secondPlayer.rackTiles.size)
         assertEquals(28, result.confirmedGame.players.sumOf { it.rackTiles.size })
+        assertEquals("host-1", result.confirmedGame.currentPlayerUserId)
 
         val allDistributedTiles = result.confirmedGame.players.flatMap { it.rackTiles }
         val allGameTiles = allDistributedTiles + result.confirmedGame.drawPile
         assertEquals(40, allGameTiles.size)
         assertEquals(orderedPool.toSet(), allGameTiles.toSet())
 
-        val starter = result.confirmedGame.players.first {
-            it.userId == result.confirmedGame.currentPlayerUserId
-        }
         assertEquals(result.confirmedGame.gameId, result.turnDraft?.gameId)
-        assertEquals(starter.userId, result.turnDraft?.playerUserId)
-        assertEquals(starter.rackTiles, result.turnDraft?.rackTiles)
+        assertEquals(firstPlayer.userId, result.turnDraft?.playerUserId)
+        assertEquals(firstPlayer.rackTiles, result.turnDraft?.rackTiles)
         assertEquals(emptyList<Nothing>(), result.turnDraft?.boardSets)
 
         verify(tilePoolGenerationService).createTilePool()

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.dto.CreateLobbyRequest
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -31,6 +32,9 @@ class LobbyServiceCreateTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -29,6 +30,9 @@ class LobbyServiceDeleteTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -29,6 +30,9 @@ class LobbyServiceGetTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -6,6 +6,7 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -33,6 +34,9 @@ class LobbyServiceJoinTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -31,6 +32,9 @@ class LobbyServiceLeaveTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
@@ -4,6 +4,7 @@ import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -25,6 +26,9 @@ class LobbyServiceListOpenTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -32,6 +33,9 @@ class LobbyServiceReadyTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
@@ -1,10 +1,16 @@
 package at.se2group.backend.lobby.service
 
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.GameStartResult
+import at.se2group.backend.domain.GameStatus
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.domain.TurnDraft
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -29,6 +35,9 @@ class LobbyServiceStartTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
@@ -58,6 +67,28 @@ class LobbyServiceStartTest {
         `when`(lobbyRepository.findById("lobby-1")).thenReturn(Optional.of(entity))
         `when`(lobbyRepository.save(any()))
             .thenAnswer { it.arguments[0] as LobbyEntity }
+        `when`(gameInitializationService.createGameFromLobby(any()))
+            .thenReturn(
+                GameStartResult(
+                    confirmedGame = ConfirmedGame(
+                        gameId = "game-123",
+                        lobbyId = "lobby-1",
+                        players = listOf(
+                            GamePlayer(
+                                userId = "host-1",
+                                displayName = "Anna",
+                                turnOrder = 0
+                            )
+                        ),
+                        currentPlayerUserId = "host-1",
+                        status = GameStatus.ACTIVE
+                    ),
+                    turnDraft = TurnDraft(
+                        gameId = "game-123",
+                        playerUserId = "host-1"
+                    )
+                )
+            )
 
 
         val result = lobbyService.startLobby("lobby-1", "host-1")
@@ -76,7 +107,8 @@ class LobbyServiceStartTest {
         assertEquals(3, saved.players.size)
 
 
-        verify(lobbyBroadcastService).broadcastLobbyStarted(result.lobbyId, result.lobbyId)
+        verify(gameInitializationService).createGameFromLobby(result)
+        verify(lobbyBroadcastService).broadcastLobbyStarted(result.lobbyId, "game-123")
 
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -32,6 +33,9 @@ class LobbyServiceUnreadyTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
@@ -6,6 +6,7 @@ import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -31,6 +32,9 @@ class LobbyServiceUpdateSettingsTest {
 
     @Mock
     lateinit var lobbyBroadcastService: LobbyBroadcastService
+
+    @Mock
+    lateinit var gameInitializationService: GameInitializationService
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TilePoolGenerationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TilePoolGenerationServiceTest.kt
@@ -1,0 +1,66 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.JokerTile
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.TileColor
+import at.se2group.backend.domain.TileRules
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TilePoolGenerationServiceTest {
+
+    private val service = TilePoolGenerationService()
+
+    @Test
+    fun `createTilePool returns correct total number of tiles`() {
+        val tiles = service.createTilePool()
+
+        val expectedNumberedTiles =
+            TileColor.entries.size *
+                (TileRules.MAX_TILE_NUMBER - TileRules.MIN_TILE_NUMBER + 1) *
+                TileRules.NUMBERED_TILE_COPY_COUNT
+
+        val expectedTotal = expectedNumberedTiles + TileRules.jokerColors.size
+
+        assertEquals(expectedTotal, tiles.size)
+    }
+
+    @Test
+    fun `createTilePool contains exactly two copies of every numbered tile`() {
+        val tiles = service.createTilePool()
+        val numberedTiles = tiles.filterIsInstance<NumberedTile>()
+
+        for (color in TileColor.entries) {
+            for (number in TileRules.MIN_TILE_NUMBER..TileRules.MAX_TILE_NUMBER) {
+                val count = numberedTiles.count { it.color == color && it.number == number }
+                assertEquals(
+                    TileRules.NUMBERED_TILE_COPY_COUNT,
+                    count,
+                    "Expected $color $number to appear ${TileRules.NUMBERED_TILE_COPY_COUNT} times"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `createTilePool contains exactly one joker for each configured joker color`() {
+        val tiles = service.createTilePool()
+        val jokerTiles = tiles.filterIsInstance<JokerTile>()
+
+        assertEquals(TileRules.jokerColors.size, jokerTiles.size)
+
+        for (color in TileRules.jokerColors) {
+            val count = jokerTiles.count { it.color == color }
+            assertEquals(1, count, "Expected exactly one joker with color $color")
+        }
+    }
+
+    @Test
+    fun `createTilePool contains only configured joker colors for jokers`() {
+        val tiles = service.createTilePool()
+        val jokerTiles = tiles.filterIsInstance<JokerTile>()
+
+        assertTrue(jokerTiles.all { it.color in TileRules.jokerColors })
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
@@ -8,6 +8,7 @@ import at.se2group.backend.service.TileShuffleService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertIterableEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class TileShuffleServiceTest {
 
@@ -38,6 +39,21 @@ class TileShuffleServiceTest {
         assertIterableEquals(tiles.subList(14, 28), result[1].rackTiles)
         assertEquals("user-1", result[0].userId)
         assertEquals("user-2", result[1].userId)
+    }
+
+    @Test
+    fun `distributedHands rejects when there are not enough tiles for all players`() {
+        val players = listOf(
+            GamePlayer(userId = "user-1", displayName = "Alice", turnOrder = 0),
+            GamePlayer(userId = "user-2", displayName = "Bob", turnOrder = 1)
+        )
+        val tiles = createNumberedTiles(1, 27)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            tileShuffleService.distributedHands(players, tiles)
+        }
+
+        assertEquals("Not enough tiles to distribute 14 tiles to 2 players", exception.message)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
@@ -1,0 +1,78 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.Tile
+import at.se2group.backend.domain.TileColor
+import at.se2group.backend.service.TileShuffleService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.Test
+
+class TileShuffleServiceTest {
+
+    private val tileShuffleService = TileShuffleService()
+
+    @Test
+    fun `shuffleTiles returns same tiles with same size`() {
+        val tiles = createNumberedTiles(1, 10)
+
+        val result = tileShuffleService.shuffleTiles(tiles)
+
+        assertEquals(tiles.size, result.size)
+        assertEquals(tiles.toSet(), result.toSet())
+    }
+
+    @Test
+    fun `distributedHands gives each player 14 tiles in order`() {
+        val players = listOf(
+            GamePlayer(userId = "user-1", displayName = "Alice", turnOrder = 0),
+            GamePlayer(userId = "user-2", displayName = "Bob", turnOrder = 1)
+        )
+        val tiles = createNumberedTiles(1, 28)
+
+        val result = tileShuffleService.distributedHands(players, tiles)
+
+        assertEquals(2, result.size)
+        assertIterableEquals(tiles.subList(0, 14), result[0].rackTiles)
+        assertIterableEquals(tiles.subList(14, 28), result[1].rackTiles)
+        assertEquals("user-1", result[0].userId)
+        assertEquals("user-2", result[1].userId)
+    }
+
+    @Test
+    fun `createDrawPile drops tiles already distributed to players`() {
+        val tiles = createNumberedTiles(1, 30)
+        val players = listOf(
+            GamePlayer(
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                rackTiles = tiles.subList(0, 14)
+            ),
+            GamePlayer(
+                userId = "user-2",
+                displayName = "Bob",
+                turnOrder = 1,
+                rackTiles = tiles.subList(14, 28)
+            )
+        )
+
+        val result = tileShuffleService.createDrawPile(tiles, players)
+
+        assertIterableEquals(tiles.drop(28), result)
+        assertEquals(2, result.size)
+    }
+
+    private fun createNumberedTiles(
+        startNumber: Int,
+        count: Int
+    ): List<Tile> {
+        return (0 until count).map { offset ->
+            NumberedTile(
+                color = TileColor.entries[offset % TileColor.entries.size],
+                number = ((startNumber - 1 + offset) % 13) + 1
+            )
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
     }
 }
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Description

This PR adds the full **Lobby → Game start → initial game initialization** flow for the backend.

The main goal is to make it possible to start a match from a valid lobby and create the very first playable game state automatically.

---

## Related Issues

**Parent Issue**
- Related to #224 

---

- Closes #225 
- Closes #373
- 
- Related to #226 
- Closes #227 
- Closes #228 
- Closes #229 
- Closes #230 
- Closes #231 
- Closes #232 
- Closes #233 
- Should close but only Related to #217 
- Related to #243 
- Related to #384 
- Related to #386 
- Closes #251 

---

## Planned scope and remaining implementation

### Planned scope for this PR

This PR is intended to cover the following core startup flow:

At the moment, this functionality is not implemented yet. This section describes the planned scope of the PR, not the currently finished implementation.

- start a game from a lobby
- validate that the lobby can actually be started
- create the initial Rummikub tile pool
- shuffle the tiles
- distribute 14 tiles to each player
- create the draw pile from the remaining tiles
- select the first active player
- create and persist the initial confirmed game state
- create and persist the initial turn draft for the first active player
- start the first turn timer
- prepare and broadcast the created game state

### Additional work still intended for this PR

Besides the core startup flow, this PR should also include a few cleanup and improvement steps if possible:

- real first-player selection rule instead of random
- separate `TileFactoryService`
- separate `HandDistributionService`
- dedicated `game started` event
- persistence entities / mappers if not already present
- resetting lobby ready states if needed
- linking `lobbyId` to `gameId` in persistence

A cleaner next step could be splitting the startup logic further into:

- `TilePoolService`
- `HandDistributionService`
- `GameInitializationService`

---

## Main flow

The planned flow for this PR is roughly:

1. validate that the lobby is startable
2. mark the lobby as in-game
3. create the full shuffled tile pool
4. convert lobby players into game players
5. deal initial hands
6. build the draw pile
7. determine the first player
8. create the confirmed game state
9. create the first active draft
10. start the first turn timer
11. broadcast the created state

---

## Example flow

**Example Code**

```kotlin
@Service
class GameInitializationService(
    private val gameRepository: GameRepository,
    private val turnDraftRepository: TurnDraftRepository,
    private val turnTimerService: TurnTimerService
) {

    companion object {
        private const val INITIAL_HAND_SIZE = 14
    }

    @Transactional
    fun createGameFromLobby(lobby: Lobby): GameStartResult {
        val shuffledTiles = createShuffledTilePool()

        val playersWithoutHands = lobby.players.map { lobbyPlayer ->
            GamePlayer(
                userId = lobbyPlayer.userId,
                displayName = lobbyPlayer.displayName,
                hand = emptyList(),
                hasPlayedInitialMeld = false,
                score = 0
            )
        }

        val dealtPlayers = mutableListOf<GamePlayer>()
        var nextTileIndex = 0

        for (player in playersWithoutHands) {
            val hand = shuffledTiles.subList(nextTileIndex, nextTileIndex + INITIAL_HAND_SIZE)
            nextTileIndex += INITIAL_HAND_SIZE

            dealtPlayers += player.copy(hand = hand)
        }

        val drawPile = shuffledTiles.drop(nextTileIndex)

        val firstPlayerId = determineFirstPlayerId(dealtPlayers)

        val game = Game(
            gameId = UUID.randomUUID().toString(),
            players = dealtPlayers,
            board = emptyList<BoardSet>(),
            drawPile = drawPile,
            currentTurnPlayerId = firstPlayerId,
            status = GameStatus.ACTIVE,
            winnerUserId = null
        )

        val savedGame = gameRepository.save(game.toEntity()).toDomain()

        val firstPlayer = savedGame.players.first { it.userId == savedGame.currentTurnPlayerId }

        val initialDraft = TurnDraft(
            gameId = savedGame.gameId,
            playerId = firstPlayer.userId,
            draftBoard = savedGame.board,
            draftHand = firstPlayer.hand,
            version = 1,
            status = TurnDraftStatus.ACTIVE
        )

        val savedDraft = turnDraftRepository.save(initialDraft.toEntity()).toDomain()

        turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)

        return GameStartResult(
            game = savedGame,
            initialDraft = savedDraft
        )
    }

    private fun createShuffledTilePool(): List<Tile> {
        val colors = listOf(
            TileColor.RED,
            TileColor.BLUE,
            TileColor.BLACK,
            TileColor.YELLOW
        )

        val tiles = mutableListOf<Tile>()

        // Two copies of numbers 1..13 in each color
        for (copy in 1..2) {
            for (color in colors) {
                for (number in 1..13) {
                    tiles += Tile(
                        id = UUID.randomUUID().toString(),
                        color = color,
                        number = number,
                        isJoker = false
                    )
                }
            }
        }

        // Two jokers
        repeat(2) {
            tiles += Tile(
                id = UUID.randomUUID().toString(),
                color = null,
                number = null,
                isJoker = true
            )
        }

        return tiles.shuffled()
    }

    private fun determineFirstPlayerId(players: List<GamePlayer>): String {
        // Simple version for now:
        // pick random player
        return players.random().userId

        // Later you could replace this with a real "highest opening tile" rule if wanted.
    }
}

data class GameStartResult(
    val game: Game,
    val initialDraft: TurnDraft
)
```

### Starting the lobby

```kotlin
@Transactional
fun startLobby(lobbyId: String, userId: String): Lobby {
    val lobby = getLobby(lobbyId)

    if (lobby.hostUserId != userId) {
        throw SecurityException("Only the host can start the match")
    }

    if (lobby.players.any { !it.isReady }) {
        throw IllegalStateException("All players must be ready")
    }

    val startedLobby = lobby.copy(status = LobbyStatus.IN_GAME)
    val savedLobby = lobbyRepository.save(startedLobby.toEntity()).toDomain()

    val gameStart = gameInitializationService.createGameFromLobby(savedLobby)

    gameBroadcastService.broadcastGameUpdated(gameStart.game)
    gameBroadcastService.broadcastTurnChanged(
        gameStart.game.gameId,
        gameStart.game.currentTurnPlayerId
    )
    gameBroadcastService.broadcastDraftUpdated(gameStart.initialDraft)

    return savedLobby
}
```

---

## Game initialization

The intended initialization flow should create the first real match state from a validated lobby.

### Example skeleton

```kotlin
@Transactional
fun createGameFromLobby(lobby: Lobby): GameStartResult {
    val shuffledTiles = createShuffledTilePool()

    val playersWithoutHands = lobby.players.map { lobbyPlayer ->
        GamePlayer(
            userId = lobbyPlayer.userId,
            displayName = lobbyPlayer.displayName,
            hand = emptyList(),
            hasPlayedInitialMeld = false,
            score = 0
        )
    }

    val dealtPlayers = distributeInitialHands(playersWithoutHands, shuffledTiles)
    val drawPile = createDrawPile(shuffledTiles, dealtPlayers)
    val firstPlayerId = determineFirstPlayerId(dealtPlayers)

    val game = createInitialGame(dealtPlayers, drawPile, firstPlayerId)
    val savedGame = gameRepository.save(game.toEntity()).toDomain()

    val initialDraft = createInitialDraft(savedGame)
    val savedDraft = turnDraftRepository.save(initialDraft.toEntity()).toDomain()

    turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)

    return GameStartResult(
        game = savedGame,
        initialDraft = savedDraft
    )
}
```

---

## Tile generation

This PR is intended to add creation of a full Rummikub tile set.

### Example

```kotlin
fun createShuffledTilePool(): List<Tile> {
    val colors = listOf(
        TileColor.RED,
        TileColor.BLUE,
        TileColor.BLACK,
        TileColor.YELLOW
    )

    val tiles = mutableListOf<Tile>()

    for (copy in 1..2) {
        for (color in colors) {
            for (number in 1..13) {
                tiles += Tile(
                    id = UUID.randomUUID().toString(),
                    color = color,
                    number = number,
                    isJoker = false
                )
            }
        }
    }

    repeat(2) {
        tiles += Tile(
            id = UUID.randomUUID().toString(),
            color = null,
            number = null,
            isJoker = true
        )
    }

    return tiles.shuffled()
}
```

---

## Hand distribution

Each player should receive 14 tiles at game start.

### Example

```kotlin
private fun distributeInitialHands(
    players: List<GamePlayer>,
    tiles: List<Tile>
): List<GamePlayer> {
    var nextTileIndex = 0

    return players.map { player ->
        val hand = tiles.subList(nextTileIndex, nextTileIndex + 14)
        nextTileIndex += 14
        player.copy(hand = hand)
    }
}
```

---

## Draw pile creation

The remaining tiles should become the draw pile.

### Example

```kotlin
private fun createDrawPile(
    tiles: List<Tile>,
    players: List<GamePlayer>
): List<Tile> {
    val usedTileCount = players.sumOf { it.hand.size }
    return tiles.drop(usedTileCount)
}
```

---

## First player selection

For now, this PR is intended to use a simple first-player strategy.

### Example

```kotlin
fun determineFirstPlayerId(players: List<GamePlayer>): String {
    return players.random().userId
}
```

This is enough for a first working version and can later be replaced by a more exact opening-player rule.

---

## Initial confirmed game state

After dealing hands and building the draw pile, the initial confirmed game state should be created and persisted.

### Example

```kotlin
val game = Game(
    gameId = UUID.randomUUID().toString(),
    players = dealtPlayers,
    board = emptyList(),
    drawPile = drawPile,
    currentTurnPlayerId = firstPlayerId,
    status = GameStatus.ACTIVE,
    winnerUserId = null
)
```

---

## Initial draft creation

The first active player should immediately receive a draft so the match can start without extra setup.

### Example

```kotlin
val firstPlayer = savedGame.players.first { it.userId == savedGame.currentTurnPlayerId }

val initialDraft = TurnDraft(
    gameId = savedGame.gameId,
    playerId = firstPlayer.userId,
    draftBoard = savedGame.board,
    draftHand = firstPlayer.hand,
    version = 1,
    status = TurnDraftStatus.ACTIVE
)
```

---

## Timer start

The first turn timer should be started right after game creation.

### Example

```kotlin
turnTimerService.startTurn(savedGame.gameId, savedGame.currentTurnPlayerId)
```

---

## Why this PR is useful

Before this PR, the lobby and match startup flow were not fully connected.
The goal of this PR is to add the missing initialization flow so that a valid lobby can later create the first real game state and start the first turn in a way that is ready for the later match/game logic.
