### PR TITLE
feat(backend)(game): add confirmed game read endpoint and response mapping

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
@@ -1,0 +1,20 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.dto.GameResponse
+import at.se2group.backend.mapper.toResponse
+import at.se2group.backend.service.GameService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/games")
+class GameController(
+    private val gameService: GameService
+) {
+    @GetMapping("/{gameId}")
+    fun getGame(@PathVariable gameId: String): GameResponse {
+        return gameService.getGame(gameId).toResponse()
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/BoardSetResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/BoardSetResponse.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.dto
+
+data class BoardSetResponse(
+    val boardSetId: String,
+    val type: String,
+    val tiles: List<TileResponse>
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/GamePlayerResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/GamePlayerResponse.kt
@@ -1,0 +1,13 @@
+package at.se2group.backend.dto
+
+import java.time.Instant
+
+data class GamePlayerResponse(
+    val userId: String,
+    val displayName: String,
+    val turnOrder: Int,
+    val rackTiles: List<TileResponse>,
+    val hasCompletedInitialMeld: Boolean,
+    val score: Int,
+    val joinedAt: Instant
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/GameResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/GameResponse.kt
@@ -1,0 +1,16 @@
+package at.se2group.backend.dto
+
+import java.time.Instant
+
+data class GameResponse(
+    val gameId: String,
+    val lobbyId: String,
+    val players: List<GamePlayerResponse>,
+    val boardSets: List<BoardSetResponse>,
+    val drawPile: List<TileResponse>,
+    val currentPlayerUserId: String,
+    val status: String,
+    val createdAt: Instant,
+    val startedAt: Instant?,
+    val finishedAt: Instant?
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/TileResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/TileResponse.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.dto
+
+data class TileResponse(
+    val color: String,
+    val number: Int?,
+    val joker: Boolean
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
@@ -6,6 +6,10 @@ import at.se2group.backend.domain.GamePlayer
 import at.se2group.backend.domain.JokerTile
 import at.se2group.backend.domain.NumberedTile
 import at.se2group.backend.domain.Tile
+import at.se2group.backend.dto.BoardSetResponse
+import at.se2group.backend.dto.GamePlayerResponse
+import at.se2group.backend.dto.GameResponse
+import at.se2group.backend.dto.TileResponse
 import at.se2group.backend.persistence.BoardSetEntity
 import at.se2group.backend.persistence.GameEntity
 import at.se2group.backend.persistence.GamePlayerEntity
@@ -97,6 +101,52 @@ fun Tile.toEmbeddable(): TileEmbeddable =
         )
         is NumberedTile -> TileEmbeddable(
             color = color,
+            number = number,
+            joker = false
+        )
+    }
+
+fun ConfirmedGame.toResponse(): GameResponse =
+    GameResponse(
+        gameId = gameId,
+        lobbyId = lobbyId,
+        players = players.map { it.toResponse() },
+        boardSets = boardSets.map { it.toResponse() },
+        drawPile = drawPile.map { it.toResponse() },
+        currentPlayerUserId = currentPlayerUserId,
+        status = status.name,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt
+    )
+
+fun GamePlayer.toResponse(): GamePlayerResponse =
+    GamePlayerResponse(
+        userId = userId,
+        displayName = displayName,
+        turnOrder = turnOrder,
+        rackTiles = rackTiles.map { it.toResponse() },
+        hasCompletedInitialMeld = hasCompletedInitialMeld,
+        score = score,
+        joinedAt = joinedAt
+    )
+
+fun BoardSet.toResponse(): BoardSetResponse =
+    BoardSetResponse(
+        boardSetId = boardSetId,
+        type = type.name,
+        tiles = tiles.map { it.toResponse() }
+    )
+
+fun Tile.toResponse(): TileResponse =
+    when (this) {
+        is JokerTile -> TileResponse(
+            color = color.name,
+            number = null,
+            joker = true
+        )
+        is NumberedTile -> TileResponse(
+            color = color.name,
             number = number,
             joker = false
         )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
@@ -1,0 +1,103 @@
+package at.se2group.backend.mapper
+
+import at.se2group.backend.domain.BoardSet
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.JokerTile
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.Tile
+import at.se2group.backend.persistence.BoardSetEntity
+import at.se2group.backend.persistence.GameEntity
+import at.se2group.backend.persistence.GamePlayerEntity
+import at.se2group.backend.persistence.TileEmbeddable
+
+fun GameEntity.toDomain(): ConfirmedGame =
+    ConfirmedGame(
+        gameId = gameId,
+        lobbyId = lobbyId,
+        players = players.map { it.toDomain() },
+        boardSets = boardSets.map { it.toDomain() },
+        drawPile = drawPile.map { it.toDomain() },
+        currentPlayerUserId = currentPlayerUserId,
+        status = status,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt
+    )
+
+fun ConfirmedGame.toEntity(): GameEntity {
+    val gameEntity = GameEntity(
+        gameId = gameId,
+        lobbyId = lobbyId,
+        currentPlayerUserId = currentPlayerUserId,
+        status = status,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        drawPile = drawPile.map { it.toEmbeddable() }.toMutableList()
+    )
+
+    gameEntity.players = players.map { it.toEntity(gameEntity) }.toMutableList()
+    gameEntity.boardSets = boardSets.map { it.toEntity(gameEntity) }.toMutableList()
+
+    return gameEntity
+}
+
+fun GamePlayerEntity.toDomain(): GamePlayer =
+    GamePlayer(
+        userId = userId,
+        displayName = displayName,
+        turnOrder = turnOrder,
+        rackTiles = rackTiles.map { it.toDomain() },
+        hasCompletedInitialMeld = hasCompletedInitialMeld,
+        score = score,
+        joinedAt = joinedAt
+    )
+
+fun GamePlayer.toEntity(game: GameEntity): GamePlayerEntity =
+    GamePlayerEntity(
+        game = game,
+        userId = userId,
+        displayName = displayName,
+        turnOrder = turnOrder,
+        rackTiles = rackTiles.map { it.toEmbeddable() }.toMutableList(),
+        hasCompletedInitialMeld = hasCompletedInitialMeld,
+        score = score,
+        joinedAt = joinedAt
+    )
+
+fun BoardSetEntity.toDomain(): BoardSet =
+    BoardSet(
+        boardSetId = boardSetId,
+        type = type,
+        tiles = tiles.map { it.toDomain() }
+    )
+
+fun BoardSet.toEntity(game: GameEntity): BoardSetEntity =
+    BoardSetEntity(
+        game = game,
+        boardSetId = boardSetId,
+        type = type,
+        tiles = tiles.map { it.toEmbeddable() }.toMutableList()
+    )
+
+fun TileEmbeddable.toDomain(): Tile =
+    if (joker) {
+        JokerTile(color)
+    } else {
+        NumberedTile(color, number ?: throw IllegalStateException("Numbered tile must have a number"))
+    }
+
+fun Tile.toEmbeddable(): TileEmbeddable =
+    when (this) {
+        is JokerTile -> TileEmbeddable(
+            color = color,
+            number = null,
+            joker = true
+        )
+        is NumberedTile -> TileEmbeddable(
+            color = color,
+            number = number,
+            joker = false
+        )
+    }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/BoardSetEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/BoardSetEntity.kt
@@ -1,0 +1,41 @@
+package at.se2group.backend.persistence
+
+import at.se2group.backend.domain.BoardSetType
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OrderColumn
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "game_board_sets")
+class BoardSetEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    var game: GameEntity? = null,
+
+    @Column(name = "board_set_id", nullable = false)
+    var boardSetId: String = "",
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    var type: BoardSetType = BoardSetType.UNRESOLVED,
+
+    @ElementCollection
+    @CollectionTable(name = "game_board_set_tiles", joinColumns = [JoinColumn(name = "board_set_entity_id")])
+    @OrderColumn(name = "tile_order")
+    var tiles: MutableList<TileEmbeddable> = mutableListOf()
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
@@ -1,0 +1,56 @@
+package at.se2group.backend.persistence
+
+import at.se2group.backend.domain.GameStatus
+import jakarta.persistence.CascadeType
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderColumn
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "games")
+class GameEntity(
+    @Id
+    @Column(name = "game_id")
+    var gameId: String = "",
+
+    @Column(name = "lobby_id", nullable = false)
+    var lobbyId: String = "",
+
+    @Column(name = "current_player_user_id", nullable = false)
+    var currentPlayerUserId: String = "",
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: GameStatus = GameStatus.WAITING,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.now(),
+
+    @Column(name = "started_at")
+    var startedAt: Instant? = null,
+
+    @Column(name = "finished_at")
+    var finishedAt: Instant? = null,
+
+    @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OrderColumn(name = "player_order")
+    var players: MutableList<GamePlayerEntity> = mutableListOf(),
+
+    @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OrderColumn(name = "board_set_order")
+    var boardSets: MutableList<BoardSetEntity> = mutableListOf(),
+
+    @ElementCollection
+    @CollectionTable(name = "game_draw_pile_tiles", joinColumns = [JoinColumn(name = "game_id")])
+    @OrderColumn(name = "draw_pile_order")
+    var drawPile: MutableList<TileEmbeddable> = mutableListOf()
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
@@ -1,0 +1,50 @@
+package at.se2group.backend.persistence
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OrderColumn
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name= "game_players")
+class GamePlayerEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    var game: GameEntity? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: String = "",
+
+    @Column(name = "display_name", nullable = false)
+    var displayName: String = "",
+
+    @Column(name = "turn_order", nullable = false)
+    var turnOrder: Int = 0,
+
+    @Column(name = "has_completed_initial_meld", nullable = false)
+    var hasCompletedInitialMeld: Boolean = false,
+
+    @Column(name = "score", nullable = false)
+    var score: Int = 0,
+
+    @Column(name = "joined_at", nullable = false)
+    var joinedAt: Instant = Instant.now(),
+
+    @ElementCollection
+    @CollectionTable(name = "game_player_rack_tiles", joinColumns = [JoinColumn(name = "game_player_id")])
+    @OrderColumn(name = "rack_tile_order")
+    var rackTiles: MutableList<TileEmbeddable> = mutableListOf()
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameRepository.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameRepository.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameRepository : JpaRepository<GameEntity, String> {
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TileEmbeddable.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TileEmbeddable.kt
@@ -1,0 +1,20 @@
+package at.se2group.backend.persistence
+
+import at.se2group.backend.domain.TileColor
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Embeddable
+data class TileEmbeddable(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "color", nullable = false)
+    var color: TileColor = TileColor.BLACK,
+
+    @Column(name = "number")
+    var number: Int? = null,
+
+    @Column(name = "joker", nullable = false)
+    var joker: Boolean = false
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
@@ -1,0 +1,19 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.mapper.toDomain
+import at.se2group.backend.persistence.GameRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GameService(
+    private val gameRepository: GameRepository
+) {
+    fun getGame(gameId: String): ConfirmedGame {
+        return gameRepository.findById(gameId)
+            .orElseThrow { NoSuchElementException("Game not found") }
+            .toDomain()
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -9,6 +9,7 @@ import at.se2group.backend.dto.JoinLobbyRequest
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import at.se2group.backend.mapper.toDomain
 import at.se2group.backend.mapper.toEntity
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,7 +20,8 @@ import java.time.Instant
 class LobbyService(
     private val lobbyRepository: LobbyRepository,
     private val lobbyBroadcastService: LobbyBroadcastService,
-    private val gameInitializationService: GameInitializationService) {
+    private val gameInitializationService: GameInitializationService,
+    private val gameRepository: GameRepository) {
 
     companion object {
         const val MAX_PLAYERS = 8
@@ -156,6 +158,7 @@ class LobbyService(
         val saved = lobbyRepository.save(updatedLobby.toEntity()).toDomain()
 
         val gameStart = gameInitializationService.createGameFromLobby(saved)
+        gameRepository.save(gameStart.confirmedGame.toEntity())
         lobbyBroadcastService.broadcastLobbyStarted(saved.lobbyId, gameStart.confirmedGame.gameId)
         return saved
     }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -1,0 +1,84 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.TileColor
+import at.se2group.backend.service.GameService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.Instant
+
+@WebMvcTest(GameController::class)
+@Import(GlobalExceptionHandler::class)
+class GameControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var gameService: GameService
+
+    @Test
+    fun `getGame returns game response`() {
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0,
+                    rackTiles = listOf(
+                        NumberedTile(TileColor.BLUE, 3)
+                    ),
+                    score = 10,
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                )
+            ),
+            drawPile = listOf(
+                NumberedTile(TileColor.RED, 7)
+            ),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        )
+
+        `when`(gameService.getGame("game-1")).thenReturn(game)
+
+        mockMvc.get("/api/games/game-1")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.gameId") { value("game-1") }
+                jsonPath("$.lobbyId") { value("lobby-1") }
+                jsonPath("$.currentPlayerUserId") { value("user-1") }
+                jsonPath("$.status") { value("ACTIVE") }
+                jsonPath("$.players[0].userId") { value("user-1") }
+                jsonPath("$.players[0].displayName") { value("Alice") }
+                jsonPath("$.players[0].rackTiles[0].color") { value("BLUE") }
+                jsonPath("$.players[0].rackTiles[0].number") { value(3) }
+                jsonPath("$.players[0].rackTiles[0].joker") { value(false) }
+                jsonPath("$.drawPile[0].color") { value("RED") }
+            }
+    }
+
+    @Test
+    fun `getGame returns 404 when game does not exist`() {
+        `when`(gameService.getGame("missing-game"))
+            .thenThrow(NoSuchElementException("Game not found"))
+
+        mockMvc.get("/api/games/missing-game")
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.errorCode") { value("NOT_FOUND") }
+                jsonPath("$.errorMessage") { value("Game not found") }
+            }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameDtoTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameDtoTest.kt
@@ -1,0 +1,133 @@
+package at.se2group.backend.dto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import java.time.Instant
+
+class GameDtoTest {
+
+    @Test
+    fun `creates tile response`() {
+        val dto = TileResponse(
+            color = "BLUE",
+            number = 7,
+            joker = false
+        )
+
+        assertEquals("BLUE", dto.color)
+        assertEquals(7, dto.number)
+        assertEquals(false, dto.joker)
+    }
+
+    @Test
+    fun `creates joker tile response`() {
+        val dto = TileResponse(
+            color = "RED",
+            number = null,
+            joker = true
+        )
+
+        assertEquals("RED", dto.color)
+        assertNull(dto.number)
+        assertTrue(dto.joker)
+    }
+
+    @Test
+    fun `creates board set response`() {
+        val dto = BoardSetResponse(
+            boardSetId = "set-1",
+            type = "RUN",
+            tiles = listOf(
+                TileResponse("BLUE", 7, false),
+                TileResponse("BLUE", 8, false),
+                TileResponse("BLUE", 9, false)
+            )
+        )
+
+        assertEquals("set-1", dto.boardSetId)
+        assertEquals("RUN", dto.type)
+        assertEquals(3, dto.tiles.size)
+        assertEquals(7, dto.tiles[0].number)
+    }
+
+    @Test
+    fun `creates game player response`() {
+        val joinedAt = Instant.parse("2026-04-27T18:00:00Z")
+
+        val dto = GamePlayerResponse(
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0,
+            rackTiles = listOf(
+                TileResponse("BLACK", 5, false),
+                TileResponse("ORANGE", null, true)
+            ),
+            hasCompletedInitialMeld = true,
+            score = 25,
+            joinedAt = joinedAt
+        )
+
+        assertEquals("user-1", dto.userId)
+        assertEquals("Alice", dto.displayName)
+        assertEquals(0, dto.turnOrder)
+        assertEquals(2, dto.rackTiles.size)
+        assertEquals(true, dto.hasCompletedInitialMeld)
+        assertEquals(25, dto.score)
+        assertEquals(joinedAt, dto.joinedAt)
+    }
+
+    @Test
+    fun `creates game response`() {
+        val createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        val startedAt = Instant.parse("2026-04-27T18:05:00Z")
+
+        val dto = GameResponse(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayerResponse(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0,
+                    rackTiles = listOf(TileResponse("BLUE", 3, false)),
+                    hasCompletedInitialMeld = false,
+                    score = 10,
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                )
+            ),
+            boardSets = listOf(
+                BoardSetResponse(
+                    boardSetId = "set-1",
+                    type = "SET",
+                    tiles = listOf(
+                        TileResponse("RED", 10, false),
+                        TileResponse("BLUE", 10, false),
+                        TileResponse("BLACK", 10, false)
+                    )
+                )
+            ),
+            drawPile = listOf(
+                TileResponse("ORANGE", 5, false),
+                TileResponse("RED", null, true)
+            ),
+            currentPlayerUserId = "user-1",
+            status = "ACTIVE",
+            createdAt = createdAt,
+            startedAt = startedAt,
+            finishedAt = null
+        )
+
+        assertEquals("game-1", dto.gameId)
+        assertEquals("lobby-1", dto.lobbyId)
+        assertEquals(1, dto.players.size)
+        assertEquals(1, dto.boardSets.size)
+        assertEquals(2, dto.drawPile.size)
+        assertEquals("user-1", dto.currentPlayerUserId)
+        assertEquals("ACTIVE", dto.status)
+        assertEquals(createdAt, dto.createdAt)
+        assertEquals(startedAt, dto.startedAt)
+        assertNull(dto.finishedAt)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceGetTest.kt
@@ -1,0 +1,79 @@
+package at.se2group.backend.game.service
+
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.persistence.GameEntity
+import at.se2group.backend.persistence.GamePlayerEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.service.GameService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class GameServiceGetTest {
+
+    @Mock
+    lateinit var gameRepository: GameRepository
+
+    @InjectMocks
+    lateinit var gameService: GameService
+
+    @Test
+    fun `getGame returns existing game`() {
+        val entity = GameEntity(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        )
+
+        entity.players = mutableListOf(
+            GamePlayerEntity(
+                game = entity,
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                rackTiles = mutableListOf(),
+                hasCompletedInitialMeld = false,
+                score = 0,
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            )
+        )
+
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+
+        val result = gameService.getGame("game-1")
+
+        assertEquals("game-1", result.gameId)
+        assertEquals("lobby-1", result.lobbyId)
+        assertEquals("user-1", result.currentPlayerUserId)
+        assertEquals(GameStatus.ACTIVE, result.status)
+        assertEquals(1, result.players.size)
+        assertEquals("Alice", result.players[0].displayName)
+
+        verify(gameRepository).findById("game-1")
+    }
+
+    @Test
+    fun `getGame throws NoSuchElementException when game does not exist`() {
+        `when`(gameRepository.findById("missing-game"))
+            .thenReturn(Optional.empty())
+
+        val exception = assertThrows<NoSuchElementException> {
+            gameService.getGame("missing-game")
+        }
+
+        assertEquals("Game not found", exception.message)
+        verify(gameRepository).findById("missing-game")
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceCreateTest.kt
@@ -2,6 +2,7 @@ package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.dto.CreateLobbyRequest
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
@@ -35,6 +36,9 @@ class LobbyServiceCreateTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceDeleteTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
@@ -33,6 +34,9 @@ class LobbyServiceDeleteTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
@@ -33,6 +34,9 @@ class LobbyServiceGetTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -2,6 +2,7 @@ package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
@@ -37,6 +38,9 @@ class LobbyServiceJoinTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceLeaveTest.kt
@@ -2,6 +2,7 @@ package at.se2group.backend.lobby.service
 
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
@@ -35,6 +36,9 @@ class LobbyServiceLeaveTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceListOpenTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
@@ -29,6 +30,9 @@ class LobbyServiceListOpenTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceReadyTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
@@ -36,6 +37,9 @@ class LobbyServiceReadyTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceStartTest.kt
@@ -7,6 +7,7 @@ import at.se2group.backend.domain.GameStatus
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.domain.LobbyStatus
 import at.se2group.backend.domain.TurnDraft
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
@@ -38,6 +39,9 @@ class LobbyServiceStartTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService
@@ -109,7 +113,7 @@ class LobbyServiceStartTest {
 
         verify(gameInitializationService).createGameFromLobby(result)
         verify(lobbyBroadcastService).broadcastLobbyStarted(result.lobbyId, "game-123")
-
+        verify(gameRepository).save(any())
     }
 
     @Test
@@ -137,7 +141,7 @@ class LobbyServiceStartTest {
         assertEquals("Only the host can start the match", exception.message)
         verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
-
+        verifyNoInteractions(gameRepository)
     }
 
     @Test
@@ -165,6 +169,7 @@ class LobbyServiceStartTest {
         assertEquals("Match can only be started while the lobby is open", exception.message)
         verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
+        verifyNoInteractions(gameRepository)
     }
 
     @Test
@@ -192,6 +197,7 @@ class LobbyServiceStartTest {
         assertEquals("At least 2 players are required to start the match", exception.message)
         verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
+        verifyNoInteractions(gameRepository)
     }
 
     @Test
@@ -220,6 +226,7 @@ class LobbyServiceStartTest {
         assertEquals("All players must be ready to start the match", exception.message)
         verify(lobbyRepository, never()).save(any())
         verifyNoInteractions(lobbyBroadcastService)
+        verifyNoInteractions(gameRepository)
     }
 
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUnreadyTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.lobby.service
 
 import at.se2group.backend.domain.LobbyStatus
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyEntity
 import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
@@ -36,6 +37,9 @@ class LobbyServiceUnreadyTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceUpdateSettingsTest.kt
@@ -6,6 +6,7 @@ import at.se2group.backend.persistence.LobbyPlayerEmbeddable
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.service.LobbyBroadcastService
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.service.GameInitializationService
 import at.se2group.backend.service.LobbyService
 import org.junit.jupiter.api.extension.ExtendWith
@@ -35,6 +36,9 @@ class LobbyServiceUpdateSettingsTest {
 
     @Mock
     lateinit var gameInitializationService: GameInitializationService
+
+    @Mock
+    lateinit var gameRepository: GameRepository
 
     @InjectMocks
     lateinit var lobbyService: LobbyService

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
@@ -232,4 +232,102 @@ class GameMapperTest {
 
         assertEquals("Numbered tile must have a number", exception.message)
     }
+
+    @Test
+    fun `toResponse maps complete confirmed game`() {
+        val createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        val startedAt = Instant.parse("2026-04-27T18:05:00Z")
+
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0,
+                    rackTiles = listOf(
+                        NumberedTile(TileColor.BLUE, 3),
+                        JokerTile(TileColor.RED)
+                    ),
+                    hasCompletedInitialMeld = true,
+                    score = 25,
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                )
+            ),
+            boardSets = listOf(
+                BoardSet(
+                    boardSetId = "set-1",
+                    type = BoardSetType.RUN,
+                    tiles = listOf(
+                        NumberedTile(TileColor.BLUE, 7),
+                        NumberedTile(TileColor.BLUE, 8),
+                        JokerTile(TileColor.BLACK)
+                    )
+                )
+            ),
+            drawPile = listOf(
+                NumberedTile(TileColor.ORANGE, 5),
+                JokerTile(TileColor.BLUE)
+            ),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = createdAt,
+            startedAt = startedAt,
+            finishedAt = null
+        )
+
+        val response = game.toResponse()
+
+        assertEquals("game-1", response.gameId)
+        assertEquals("lobby-1", response.lobbyId)
+        assertEquals("user-1", response.currentPlayerUserId)
+        assertEquals("ACTIVE", response.status)
+        assertEquals(createdAt, response.createdAt)
+        assertEquals(startedAt, response.startedAt)
+        assertEquals(1, response.players.size)
+        assertEquals(1, response.boardSets.size)
+        assertEquals(2, response.drawPile.size)
+
+        assertEquals("user-1", response.players[0].userId)
+        assertEquals("Alice", response.players[0].displayName)
+        assertEquals(0, response.players[0].turnOrder)
+        assertEquals(2, response.players[0].rackTiles.size)
+        assertEquals("BLUE", response.players[0].rackTiles[0].color)
+        assertEquals(3, response.players[0].rackTiles[0].number)
+        assertEquals(false, response.players[0].rackTiles[0].joker)
+        assertEquals("RED", response.players[0].rackTiles[1].color)
+        assertEquals(null, response.players[0].rackTiles[1].number)
+        assertEquals(true, response.players[0].rackTiles[1].joker)
+
+        assertEquals("set-1", response.boardSets[0].boardSetId)
+        assertEquals("RUN", response.boardSets[0].type)
+        assertEquals(3, response.boardSets[0].tiles.size)
+        assertEquals("BLACK", response.boardSets[0].tiles[2].color)
+        assertEquals(true, response.boardSets[0].tiles[2].joker)
+
+        assertEquals("ORANGE", response.drawPile[0].color)
+        assertEquals(5, response.drawPile[0].number)
+        assertEquals(false, response.drawPile[0].joker)
+        assertEquals("BLUE", response.drawPile[1].color)
+        assertEquals(null, response.drawPile[1].number)
+        assertEquals(true, response.drawPile[1].joker)
+    }
+
+    @Test
+    fun `tile toResponse maps numbered and joker tiles`() {
+        val numbered = NumberedTile(TileColor.BLACK, 11)
+        val joker = JokerTile(TileColor.ORANGE)
+
+        val numberedResponse = numbered.toResponse()
+        val jokerResponse = joker.toResponse()
+
+        assertEquals("BLACK", numberedResponse.color)
+        assertEquals(11, numberedResponse.number)
+        assertEquals(false, numberedResponse.joker)
+
+        assertEquals("ORANGE", jokerResponse.color)
+        assertEquals(null, jokerResponse.number)
+        assertEquals(true, jokerResponse.joker)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
@@ -1,0 +1,235 @@
+package at.se2group.backend.mapper
+
+import at.se2group.backend.domain.BoardSet
+import at.se2group.backend.domain.BoardSetType
+import at.se2group.backend.domain.ConfirmedGame
+import at.se2group.backend.domain.GamePlayer
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.domain.JokerTile
+import at.se2group.backend.domain.NumberedTile
+import at.se2group.backend.domain.TileColor
+import at.se2group.backend.persistence.BoardSetEntity
+import at.se2group.backend.persistence.GameEntity
+import at.se2group.backend.persistence.GamePlayerEntity
+import at.se2group.backend.persistence.TileEmbeddable
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class GameMapperTest {
+    @Test
+    fun `toEntity maps complete confirmed game`() {
+        val createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        val startedAt = Instant.parse("2026-04-27T18:05:00Z")
+
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(
+                    userId = "user-1",
+                    displayName = "Alice",
+                    turnOrder = 0,
+                    rackTiles = listOf(
+                        NumberedTile(TileColor.BLUE, 3),
+                        JokerTile(TileColor.RED)
+                    ),
+                    hasCompletedInitialMeld = true,
+                    score = 25,
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                ),
+                GamePlayer(
+                    userId = "user-2",
+                    displayName = "Bob",
+                    turnOrder = 1,
+                    rackTiles = listOf(
+                        NumberedTile(TileColor.BLACK, 11)
+                    ),
+                    hasCompletedInitialMeld = false,
+                    score = 10,
+                    joinedAt = Instant.parse("2026-04-27T17:56:00Z")
+                )
+            ),
+            boardSets = listOf(
+                BoardSet(
+                    boardSetId = "set-1",
+                    type = BoardSetType.RUN,
+                    tiles = listOf(
+                        NumberedTile(TileColor.BLUE, 7),
+                        NumberedTile(TileColor.BLUE, 8),
+                        NumberedTile(TileColor.BLUE, 9)
+                    )
+                )
+            ),
+            drawPile = listOf(
+                NumberedTile(TileColor.ORANGE, 5),
+                JokerTile(TileColor.BLACK)
+            ),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = createdAt,
+            startedAt = startedAt,
+            finishedAt = null
+        )
+
+        val entity = game.toEntity()
+
+        assertEquals("game-1", entity.gameId)
+        assertEquals("lobby-1", entity.lobbyId)
+        assertEquals("user-1", entity.currentPlayerUserId)
+        assertEquals(GameStatus.ACTIVE, entity.status)
+        assertEquals(createdAt, entity.createdAt)
+        assertEquals(startedAt, entity.startedAt)
+
+        assertEquals(2, entity.players.size)
+        assertEquals("user-1", entity.players[0].userId)
+        assertEquals("Alice", entity.players[0].displayName)
+        assertEquals(0, entity.players[0].turnOrder)
+        assertEquals(2, entity.players[0].rackTiles.size)
+        assertTrue(entity.players.all { it.game === entity })
+
+        assertEquals(1, entity.boardSets.size)
+        assertEquals("set-1", entity.boardSets[0].boardSetId)
+        assertEquals(BoardSetType.RUN, entity.boardSets[0].type)
+        assertEquals(3, entity.boardSets[0].tiles.size)
+        assertTrue(entity.boardSets.all { it.game === entity })
+
+        assertEquals(2, entity.drawPile.size)
+        assertEquals(TileColor.ORANGE, entity.drawPile[0].color)
+        assertEquals(5, entity.drawPile[0].number)
+        assertEquals(false, entity.drawPile[0].joker)
+        assertEquals(true, entity.drawPile[1].joker)
+    }
+
+    @Test
+    fun `toDomain maps complete game entity`() {
+        val entity = GameEntity(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            currentPlayerUserId = "user-2",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z"),
+            startedAt = Instant.parse("2026-04-27T18:05:00Z"),
+            finishedAt = null,
+            drawPile = mutableListOf(
+                TileEmbeddable(color = TileColor.RED, number = 6, joker = false),
+                TileEmbeddable(color = TileColor.BLUE, number = null, joker = true)
+            )
+        )
+
+        entity.players = mutableListOf(
+            GamePlayerEntity(
+                game = entity,
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                rackTiles = mutableListOf(
+                    TileEmbeddable(color = TileColor.BLACK, number = 4, joker = false)
+                ),
+                hasCompletedInitialMeld = true,
+                score = 20,
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            ),
+            GamePlayerEntity(
+                game = entity,
+                userId = "user-2",
+                displayName = "Bob",
+                turnOrder = 1,
+                rackTiles = mutableListOf(
+                    TileEmbeddable(color = TileColor.ORANGE, number = null, joker = true)
+                ),
+                hasCompletedInitialMeld = false,
+                score = 15,
+                joinedAt = Instant.parse("2026-04-27T17:56:00Z")
+            )
+        )
+
+        entity.boardSets = mutableListOf(
+            BoardSetEntity(
+                game = entity,
+                boardSetId = "set-1",
+                type = BoardSetType.SET,
+                tiles = mutableListOf(
+                    TileEmbeddable(color = TileColor.RED, number = 10, joker = false),
+                    TileEmbeddable(color = TileColor.BLUE, number = 10, joker = false),
+                    TileEmbeddable(color = TileColor.BLACK, number = 10, joker = false)
+                )
+            )
+        )
+
+        val game = entity.toDomain()
+
+        assertEquals("game-1", game.gameId)
+        assertEquals("lobby-1", game.lobbyId)
+        assertEquals("user-2", game.currentPlayerUserId)
+        assertEquals(GameStatus.ACTIVE, game.status)
+
+        assertEquals(2, game.players.size)
+        assertEquals("Alice", game.players[0].displayName)
+        assertEquals(0, game.players[0].turnOrder)
+        assertEquals(1, game.players[0].rackTiles.size)
+
+        assertEquals(1, game.boardSets.size)
+        assertEquals("set-1", game.boardSets[0].boardSetId)
+        assertEquals(BoardSetType.SET, game.boardSets[0].type)
+        assertEquals(3, game.boardSets[0].tiles.size)
+
+        assertEquals(2, game.drawPile.size)
+        assertEquals(NumberedTile(TileColor.RED, 6), game.drawPile[0])
+        assertEquals(JokerTile(TileColor.BLUE), game.drawPile[1])
+    }
+
+    @Test
+    fun `toEntity preserves list order`() {
+        val game = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(
+                GamePlayer(userId = "user-2", displayName = "Bob", turnOrder = 1),
+                GamePlayer(userId = "user-1", displayName = "Alice", turnOrder = 0)
+            ),
+            boardSets = listOf(
+                BoardSet(
+                    boardSetId = "set-b",
+                    tiles = listOf(NumberedTile(TileColor.RED, 1))
+                ),
+                BoardSet(
+                    boardSetId = "set-a",
+                    tiles = listOf(NumberedTile(TileColor.BLUE, 2))
+                )
+            ),
+            drawPile = listOf(
+                NumberedTile(TileColor.BLACK, 13),
+                JokerTile(TileColor.ORANGE),
+                NumberedTile(TileColor.BLUE, 1)
+            ),
+            currentPlayerUserId = "user-2"
+        )
+
+        val entity = game.toEntity()
+
+        assertEquals(listOf("user-2", "user-1"), entity.players.map { it.userId })
+        assertEquals(listOf("set-b", "set-a"), entity.boardSets.map { it.boardSetId })
+        assertEquals(
+            listOf(TileColor.BLACK, TileColor.ORANGE, TileColor.BLUE),
+            entity.drawPile.map { it.color }
+        )
+    }
+
+    @Test
+    fun `tile embeddable toDomain throws when numbered tile has no number`() {
+        val tile = TileEmbeddable(
+            color = TileColor.RED,
+            number = null,
+            joker = false
+        )
+
+        val exception = assertThrows<IllegalStateException> {
+            tile.toDomain()
+        }
+
+        assertEquals("Numbered tile must have a number", exception.message)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/persistence/GameRepositoryTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/persistence/GameRepositoryTest.kt
@@ -1,0 +1,194 @@
+package at.se2group.backend.persistence
+
+import at.se2group.backend.domain.BoardSetType
+import at.se2group.backend.domain.GameStatus
+import at.se2group.backend.domain.TileColor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.time.Instant
+
+@DataJpaTest
+class GameRepositoryTest {
+
+    @Autowired
+    lateinit var gameRepository: GameRepository
+
+    @Test
+    fun `save and findById persists complete game graph`() {
+        val game = GameEntity(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z"),
+            startedAt = Instant.parse("2026-04-27T18:05:00Z"),
+            finishedAt = null,
+            drawPile = mutableListOf(
+                TileEmbeddable(color = TileColor.RED, number = 5, joker = false),
+                TileEmbeddable(color = TileColor.BLUE, number = null, joker = true),
+                TileEmbeddable(color = TileColor.BLACK, number = 11, joker = false)
+            )
+        )
+
+        val player1 = GamePlayerEntity(
+            game = game,
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0,
+            rackTiles = mutableListOf(
+                TileEmbeddable(color = TileColor.BLUE, number = 1, joker = false),
+                TileEmbeddable(color = TileColor.ORANGE, number = null, joker = true)
+            ),
+            hasCompletedInitialMeld = true,
+            score = 25,
+            joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+        )
+
+        val player2 = GamePlayerEntity(
+            game = game,
+            userId = "user-2",
+            displayName = "Bob",
+            turnOrder = 1,
+            rackTiles = mutableListOf(
+                TileEmbeddable(color = TileColor.BLACK, number = 13, joker = false)
+            ),
+            hasCompletedInitialMeld = false,
+            score = 10,
+            joinedAt = Instant.parse("2026-04-27T17:56:00Z")
+        )
+
+        val boardSet = BoardSetEntity(
+            game = game,
+            boardSetId = "set-1",
+            type = BoardSetType.RUN,
+            tiles = mutableListOf(
+                TileEmbeddable(color = TileColor.RED, number = 7, joker = false),
+                TileEmbeddable(color = TileColor.RED, number = 8, joker = false),
+                TileEmbeddable(color = TileColor.RED, number = 9, joker = false)
+            )
+        )
+
+        game.players = mutableListOf(player1, player2)
+        game.boardSets = mutableListOf(boardSet)
+
+        gameRepository.save(game)
+
+        val result = gameRepository.findById("game-1")
+
+        assertTrue(result.isPresent)
+
+        val saved = result.get()
+        assertEquals("game-1", saved.gameId)
+        assertEquals("lobby-1", saved.lobbyId)
+        assertEquals("user-1", saved.currentPlayerUserId)
+        assertEquals(GameStatus.ACTIVE, saved.status)
+        assertEquals(2, saved.players.size)
+        assertEquals(1, saved.boardSets.size)
+        assertEquals(3, saved.drawPile.size)
+
+        assertEquals("user-1", saved.players[0].userId)
+        assertEquals("Alice", saved.players[0].displayName)
+        assertEquals(2, saved.players[0].rackTiles.size)
+        assertEquals(true, saved.players[0].hasCompletedInitialMeld)
+        assertEquals(25, saved.players[0].score)
+
+        assertEquals("user-2", saved.players[1].userId)
+        assertEquals("Bob", saved.players[1].displayName)
+        assertEquals(1, saved.players[1].rackTiles.size)
+
+        assertEquals("set-1", saved.boardSets[0].boardSetId)
+        assertEquals(BoardSetType.RUN, saved.boardSets[0].type)
+        assertEquals(3, saved.boardSets[0].tiles.size)
+    }
+
+    @Test
+    fun `save and findById preserves collection order`() {
+        val game = GameEntity(
+            gameId = "game-2",
+            lobbyId = "lobby-2",
+            currentPlayerUserId = "user-2",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:10:00Z"),
+            drawPile = mutableListOf(
+                TileEmbeddable(color = TileColor.BLACK, number = 13, joker = false),
+                TileEmbeddable(color = TileColor.ORANGE, number = null, joker = true),
+                TileEmbeddable(color = TileColor.BLUE, number = 1, joker = false)
+            )
+        )
+
+        val player1 = GamePlayerEntity(
+            game = game,
+            userId = "user-2",
+            displayName = "Bob",
+            turnOrder = 1,
+            rackTiles = mutableListOf(
+                TileEmbeddable(color = TileColor.RED, number = 4, joker = false),
+                TileEmbeddable(color = TileColor.BLUE, number = 5, joker = false)
+            ),
+            joinedAt = Instant.parse("2026-04-27T17:56:00Z")
+        )
+
+        val player2 = GamePlayerEntity(
+            game = game,
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0,
+            rackTiles = mutableListOf(
+                TileEmbeddable(color = TileColor.BLACK, number = 2, joker = false)
+            ),
+            joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+        )
+
+        val boardSet1 = BoardSetEntity(
+            game = game,
+            boardSetId = "set-b",
+            type = BoardSetType.SET,
+            tiles = mutableListOf(
+                TileEmbeddable(color = TileColor.RED, number = 10, joker = false)
+            )
+        )
+
+        val boardSet2 = BoardSetEntity(
+            game = game,
+            boardSetId = "set-a",
+            type = BoardSetType.RUN,
+            tiles = mutableListOf(
+                TileEmbeddable(color = TileColor.BLUE, number = 3, joker = false),
+                TileEmbeddable(color = TileColor.BLUE, number = 4, joker = false)
+            )
+        )
+
+        game.players = mutableListOf(player1, player2)
+        game.boardSets = mutableListOf(boardSet1, boardSet2)
+
+        gameRepository.save(game)
+
+        val saved = gameRepository.findById("game-2").get()
+
+        assertEquals(listOf("user-2", "user-1"), saved.players.map { it.userId })
+        assertEquals(listOf("set-b", "set-a"), saved.boardSets.map { it.boardSetId })
+        assertEquals(
+            listOf(TileColor.BLACK, TileColor.ORANGE, TileColor.BLUE),
+            saved.drawPile.map { it.color }
+        )
+        assertEquals(
+            listOf(TileColor.RED, TileColor.BLUE),
+            saved.players[0].rackTiles.map { it.color }
+        )
+        assertEquals(
+            listOf(3, 4),
+            saved.boardSets[1].tiles.map { it.number }
+        )
+    }
+
+    @Test
+    fun `findById returns empty for missing game`() {
+        val result = gameRepository.findById("missing-game")
+
+        assertFalse(result.isPresent)
+    }
+}


### PR DESCRIPTION
## Summary
Adds the first confirmed game read endpoint for the backend game API.

This PR introduces the initial read flow for confirmed game state so the frontend can load the current authoritative match state from the backend. It lays the foundation for initial game screen load, reconnect recovery, and refreshing the confirmed game state during later game interactions.

## What changed
- added the backend game controller endpoint for `GET /api/games/{gameId}`
- added the service load flow for retrieving a confirmed game by id
- added confirmed game response DTOs and response mapping
- added persistence/domain mapping needed for loading and returning game state
- added tests for repository, mapper, service, and controller behavior
- added not-found handling for missing games in the API flow

## Why
This is the first backend read endpoint in the game flow and establishes the base path for loading confirmed game state before adding the draft read/update flow and end-turn flow.

It gives the frontend a defined way to:
- load the current confirmed game state when entering the game screen
- recover state after reconnect
- refresh the latest authoritative game state from the backend

## Related Issues
- Closes #341 
- Closes #416 
- Closes #419 
- Closes #340 
- Closes #341 
- Closes #219 
- Closes #217 
- Closes #208 
- Closes #209 
- Closes #210 
- Closes #211 
- Closes #416 
- Closes #419 

---

- Related to #421 
- Related to #384 
- Related to #386 
- Related to #249 
- Related to #235 
- Related to #350 
- Related to #385 
- Related to #353 
- Related to #384 
- Related to #349



## Scope
This PR is intentionally focused on **confirmed game read access** only.

Included:
- confirmed game loading
- confirmed game response mapping
- controller/service/repository test coverage
- missing-game API handling

Not included:
- current draft loading
- draft updates
- end-turn submission
- draw/reset actions
- websocket game events

## Related planned issues
This PR aligns most directly with these planned game issues:


## Notes
This PR is the first REST read slice for the backend game module. The natural follow-up is the draft read endpoint (`GET /api/games/{gameId}/draft`), followed by draft update and end-turn flow.