### PR TITLE
feat(backend)(game): introduce TurnDraftBoardSetEntity and structured draft persistence

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
@@ -3,6 +3,7 @@ package at.se2group.backend.mapper
 import at.se2group.backend.domain.*
 import at.se2group.backend.dto.*
 import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftBoardSetEntity
 import java.util.UUID
 import at.se2group.backend.dto.DraftResponse
 
@@ -33,13 +34,18 @@ fun TileRequest.toTileDomain(): Tile {
 }
 
 fun TurnDraft.toEntity(existing: TurnDraftEntity): TurnDraftEntity {
-    // NOTE: boardSets are currently flattened into boardTiles.
-    // This loses set structure, but is sufficient for the current draft persistence.
-    // Proper BoardSet persistence should be handled in a later iteration.
-    existing.boardTiles = boardSets
-        .flatMap { it.tiles }
-        .map { it.toEmbeddable() }
-        .toMutableList()
+    existing.boardSets.clear()
+
+    val newBoardSets = boardSets.map { set ->
+        TurnDraftBoardSetEntity(
+            draft = existing,
+            tiles = set.tiles
+                .map { it.toEmbeddable() }
+                .toMutableList()
+        )
+    }
+
+    existing.boardSets.addAll(newBoardSets)
 
     existing.rackTiles = rackTiles
         .map { it.toEmbeddable() }
@@ -48,12 +54,17 @@ fun TurnDraft.toEntity(existing: TurnDraftEntity): TurnDraftEntity {
     return existing
 }
 fun TurnDraftEntity.toDomain(): TurnDraft {
-    //map boardTiles and rackTiles back to domain representation
     return TurnDraft(
         gameId = gameId,
         playerUserId = playerUserId,
-        boardSets = emptyList(),
-        rackTiles = emptyList()
+        boardSets = boardSets.map { set ->
+            BoardSet(
+                boardSetId = set.id,
+                type = BoardSetType.UNRESOLVED,
+                tiles = set.tiles.map { it.toDomain() }
+            )
+        },
+        rackTiles = rackTiles.map { it.toDomain() }
     )
 }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftBoardSetEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftBoardSetEntity.kt
@@ -1,0 +1,24 @@
+package at.se2group.backend.persistence
+
+import jakarta.persistence.*
+import java.util.UUID
+
+@Entity
+@Table(name = "turn_draft_board_sets")
+class TurnDraftBoardSetEntity(
+
+    @Id
+    var id: String = UUID.randomUUID().toString(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "draft_id")
+    var draft: TurnDraftEntity? = null,
+
+    @ElementCollection
+    @CollectionTable(
+        name = "turn_draft_board_set_tiles",
+        joinColumns = [JoinColumn(name = "board_set_id")]
+    )
+    @OrderColumn(name = "tile_order")
+    var tiles: MutableList<TileEmbeddable> = mutableListOf()
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
@@ -13,6 +13,6 @@ class TurnDraftEntity(
     @ElementCollection
     var rackTiles: MutableList<TileEmbeddable> = mutableListOf(),
 
-    @ElementCollection
-    var boardTiles: MutableList<TileEmbeddable> = mutableListOf()
+    @OneToMany(mappedBy = "draft", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var boardSets: MutableList<TurnDraftBoardSetEntity> = mutableListOf()
 )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -99,10 +99,7 @@ class GameInitializationService(
             TurnDraftEntity(
                 gameId = draft.gameId,
                 playerUserId = draft.playerUserId,
-                boardTiles = draft.boardSets
-                    .flatMap { it.tiles }
-                    .map { it.toEmbeddable() }
-                    .toMutableList(),
+                boardSets = mutableListOf(),
                 rackTiles = draft.rackTiles
                     .map { it.toEmbeddable() }
                     .toMutableList()

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
@@ -1,5 +1,7 @@
 package at.se2group.backend.service
 
+import at.se2group.backend.persistence.TurnDraftBoardSetEntity
+
 import at.se2group.backend.domain.ConfirmedGame
 import at.se2group.backend.persistence.GameRepository
 import org.springframework.stereotype.Service
@@ -80,9 +82,16 @@ class GameService(
 
         draft.playerUserId = nextPlayer.userId
 
-        draft.boardTiles = game.boardSets
-            .flatMap { it.tiles }
-            .toMutableList()
+        draft.boardSets.clear()
+
+        val newBoardSets = game.boardSets.map { set ->
+            TurnDraftBoardSetEntity(
+                draft = draft,
+                tiles = set.tiles.toMutableList()
+            )
+        }
+
+        draft.boardSets.addAll(newBoardSets)
 
         draft.rackTiles = nextPlayer.rackTiles
             .toMutableList()

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceEndTurnTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceEndTurnTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.Mockito.*
 import java.time.Instant
 import java.util.Optional
+import org.junit.jupiter.api.Assertions.assertThrows
 
 class GameServiceEndTurnTest {
 
@@ -56,5 +57,33 @@ class GameServiceEndTurnTest {
         val result = gameService.endTurn("game-1", "user-1")
 
         assertEquals("user-2", result.currentPlayerUserId)
+    }
+
+    @Test
+    fun `should throw when user is not active player`() {
+
+        val game = GameEntity().apply {
+            gameId = "game1"
+            currentPlayerUserId = "user1"
+            players = mutableListOf(
+                GamePlayerEntity().apply { userId = "user1" },
+                GamePlayerEntity().apply { userId = "user2" }
+            )
+        }
+
+        val draft = TurnDraftEntity(
+            gameId = "game1",
+            playerUserId = "user1"
+        )
+
+        `when`(gameRepository.findById("game1"))
+            .thenReturn(Optional.of(game))
+
+        `when`(turnDraftRepository.findByGameId("game1"))
+            .thenReturn(draft)
+
+        assertThrows(IllegalStateException::class.java) {
+            gameService.endTurn("game1", "user2")
+        }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftEntityMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftEntityMapperTest.kt
@@ -2,6 +2,8 @@ package at.se2group.backend.mapper
 
 import at.se2group.backend.domain.*
 import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftBoardSetEntity
+import at.se2group.backend.persistence.TileEmbeddable
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -35,9 +37,39 @@ class TurnDraftEntityMapperTest {
             )
         )
 
-        assertEquals(2, entity.boardTiles.size)
+        assertEquals(1, entity.boardSets.size)
+        assertEquals(2, entity.boardSets[0].tiles.size)
         assertEquals(1, entity.rackTiles.size)
 
         assertTrue(entity.rackTiles[0].joker)
+    }
+
+    @Test
+    fun `should map TurnDraftEntity to TurnDraft`() {
+
+        val entity = TurnDraftEntity(
+            gameId = "game1",
+            playerUserId = "user1"
+        )
+
+        val boardSet = TurnDraftBoardSetEntity(
+            draft = entity,
+            tiles = mutableListOf(
+                TileEmbeddable(TileColor.RED, 5, false),
+                TileEmbeddable(TileColor.BLUE, 6, false)
+            )
+        )
+
+        entity.boardSets.add(boardSet)
+
+        entity.rackTiles = mutableListOf(
+            TileEmbeddable(TileColor.BLACK, null, true)
+        )
+
+        val domain = entity.toDomain()
+
+        assertEquals(1, domain.boardSets.size)
+        assertEquals(2, domain.boardSets[0].tiles.size)
+        assertEquals(1, domain.rackTiles.size)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
@@ -38,4 +38,30 @@ class TurnDraftMapperTest {
         assertEquals(1, result.rackTiles.size)
         assertTrue(result.rackTiles[0] is JokerTile)
     }
+
+    @Test
+    fun `toTileDomain maps joker`() {
+        val request = TileRequest(
+            color = "RED",
+            number = null,
+            joker = true
+        )
+
+        val result = request.toTileDomain()
+
+        assertTrue(result is JokerTile)
+    }
+
+    @Test
+    fun `toTileDomain throws if number missing`() {
+        val request = TileRequest(
+            color = "RED",
+            number = null,
+            joker = false
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            request.toTileDomain()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Introduces a structured draft persistence model to preserve board set boundaries.

This PR introduces a dedicated `TurnDraftBoardSetEntity` and replaces the previous flattened `boardTiles` approach with structured `boardSets`. This allows the backend to keep the actual grouping of tiles in the draft instead of losing set boundaries.

## What changed
- introduced `TurnDraftBoardSetEntity` for draft board sets
- replaced flattened `boardTiles` with structured `boardSets` in `TurnDraftEntity`
- prepared the persistence layer to support proper set reconstruction
- initial adjustments in related services and mapping

## Why
The previous approach stored all board tiles in a flat list, which loses the original grouping of sets. This makes it difficult to:
- reconstruct the board correctly
- validate runs and groups later
- reliably handle end-turn logic

With structured persistence, the backend can preserve the real board layout and serve as a foundation for future validation and game logic.

## Scope
This PR focuses on **draft persistence structure only**.

Included:
- new `TurnDraftBoardSetEntity`
- updated draft entity structure (`boardSets` instead of `boardTiles`)

Not included:
- full rule validation
- complete mapper refactor (follow-up)
- gameplay logic changes

## Impact
The draft model is now capable of representing real board sets instead of a flattened list. This prepares the system for proper validation and rule handling in future PRs.