### PR TITLE
feat(backend)(rules): add rule validation foundation and top-level rule service skeleton

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
@@ -1,0 +1,65 @@
+package at.se2group.backend.rules.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.TurnDraft
+import shared.models.game.validation.ValidationResult
+
+/**
+ * Top-level orchestration entry point for backend Rummikub rule validation.
+ *
+ * This service is intended to become the single backend-facing rule-validation
+ * boundary for submitted turn drafts. Lower-level validators such as
+ * tile-conservation, set validation, board validation, and first-move rules can
+ * later be composed behind this class without exposing that orchestration
+ * detail to controllers or higher-level game services.
+ *
+ * In the full rule-validation flow, this service will typically be responsible
+ * for coordinating checks such as:
+ * - validating that the submitted draft belongs to the active player and the
+ *   correct game context
+ * - invoking tile-conservation checks
+ * - invoking set-level validation for groups and runs
+ * - invoking board-level validation across all submitted sets
+ * - invoking first-move validation for players who have not yet completed their
+ *   initial meld
+ * - aggregating all collectable rule failures into one [ValidationResult]
+ *
+ * At the current foundation stage this class intentionally stays minimal. The
+ * goal is to establish a clear service boundary and method shape first, so
+ * future pull requests can add real rule composition without having to revisit
+ * where top-level validation belongs.
+ */
+@Service
+class RummikubRuleService {
+
+    /**
+     * Validates a submitted draft against the authoritative confirmed game
+     * state.
+     *
+     * The method accepts the currently confirmed backend game state, the acting
+     * player identifier, and the candidate submitted draft that should be
+     * checked before any end-turn commit is allowed.
+     *
+     * In later iterations this method should evolve into the main orchestration
+     * pipeline for full submitted-draft validation. For now it deliberately
+     * returns a successful empty [ValidationResult] so the service boundary can
+     * be introduced without prematurely coupling it to unfinished validators.
+     *
+     * @param confirmedGame the authoritative committed game state that provides
+     * the validation baseline
+     * @param actingPlayerUserId the unique identifier of the player submitting
+     * the draft for validation
+     * @param submittedDraft the candidate draft that would be committed if rule
+     * validation succeeds
+     * @return a validation result that is currently always valid and ready to be
+     * extended by later rule-validation steps
+     */
+    fun validateSubmittedDraft(
+        confirmedGame: ConfirmedGame,
+        actingPlayerUserId: String,
+        submittedDraft: TurnDraft
+    ): ValidationResult {
+        return ValidationResult()
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.TurnDraft
 import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.valid
 
 /**
  * Top-level orchestration entry point for backend Rummikub rule validation.
@@ -60,6 +61,6 @@ class RummikubRuleService {
         actingPlayerUserId: String,
         submittedDraft: TurnDraft
     ): ValidationResult {
-        return ValidationResult()
+        return valid()
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -1,0 +1,42 @@
+package at.se2group.backend.rules.service
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.TurnDraft
+
+class RummikubRuleServiceTest {
+
+    private val ruleService = RummikubRuleService()
+
+    @Test
+    fun `validateSubmittedDraft returns valid empty result for foundation skeleton`() {
+        val player = GamePlayer(
+            userId = "user-1",
+            displayName = "Alice",
+            turnOrder = 0
+        )
+        val confirmedGame = ConfirmedGame(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            players = listOf(player),
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE
+        )
+        val submittedDraft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1"
+        )
+
+        val result = ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+}

--- a/apps/shared/src/main/kotlin/shared/models/game/validation/RuleViolation.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/validation/RuleViolation.kt
@@ -1,5 +1,30 @@
 package shared.models.game.validation
 
+/**
+ * Structured description of one concrete rule-validation failure in the
+ * Rummikub game domain.
+ *
+ * This model is intended for validation paths that continue checking multiple
+ * rules and return a collected result instead of failing fast with an
+ * exception. That makes it suitable for submitted-draft validation where the
+ * backend may want to report more than one problem at once.
+ *
+ * Each violation should remain small, stable, and transport-friendly:
+ * - [code] identifies the violated rule in a machine-readable way
+ * - [message] explains the failure in human-readable form
+ * - [setIndex] can point to one affected board set if the violation is set-scoped
+ * - [tileIds] can point to the specific tiles involved when tile-level
+ *   highlighting or debugging is needed
+ *
+ * The class deliberately avoids carrying rich domain objects. Validation
+ * results should reference the problematic area of the draft, not duplicate the
+ * full game state inside the error payload.
+ *
+ * @property code stable machine-readable identifier for the violated rule
+ * @property message human-readable explanation of the problem
+ * @property setIndex optional board-set index for violations tied to one set
+ * @property tileIds optional list of tile identifiers involved in the failure
+ */
 data class RuleViolation(
     val code: String,
     val message: String,

--- a/apps/shared/src/main/kotlin/shared/models/game/validation/RuleViolation.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/validation/RuleViolation.kt
@@ -1,0 +1,8 @@
+package shared.models.game.validation
+
+data class RuleViolation(
+    val code: String,
+    val message: String,
+    val setIndex: Int? = null,
+    val tileIds: List<String> = emptyList()
+)

--- a/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResult.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResult.kt
@@ -1,0 +1,8 @@
+package shared.models.game.validation
+
+data class ValidationResult(
+    val violations: List<RuleViolation> = emptyList()
+) {
+    val isValid: Boolean
+        get() = violations.isEmpty()
+}

--- a/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResult.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResult.kt
@@ -1,8 +1,37 @@
 package shared.models.game.validation
 
+/**
+ * Common result wrapper for game-rule validation in the shared Rummikub model.
+ *
+ * A validation run is represented as a collection of [violations]. An empty
+ * collection means the validated input satisfied all rules checked by the
+ * validator. A non-empty collection means validation failed and each contained
+ * [RuleViolation] describes one specific problem.
+ *
+ * The class derives [isValid] from the current violation list instead of
+ * storing a second mutable truth source. This prevents contradictory states
+ * such as "valid result with violations" or "invalid result with no
+ * violations" and keeps downstream validator composition straightforward.
+ *
+ * Typical uses:
+ * - set validation
+ * - board validation
+ * - first-move validation
+ * - top-level submitted-draft validation orchestration
+ *
+ * This model is intentionally different from fail-fast use-case errors such as
+ * missing game state, unauthorized player access, or broken persistence state.
+ * Those conditions should still be represented through exceptions, while
+ * [ValidationResult] is reserved for collectable rule failures.
+ *
+ * @property violations collected rule violations produced by one validation run
+ */
 data class ValidationResult(
     val violations: List<RuleViolation> = emptyList()
 ) {
+    /**
+     * Whether the validation finished without any collected rule violations.
+     */
     val isValid: Boolean
         get() = violations.isEmpty()
 }

--- a/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResults.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/validation/ValidationResults.kt
@@ -1,0 +1,110 @@
+package shared.models.game.validation
+
+/**
+ * Creates a successful rule-validation result with no collected violations.
+ *
+ * This helper keeps validator implementations concise when a validation path
+ * completes successfully and does not need to report any rule failures.
+ *
+ * @return a valid [ValidationResult] without violations
+ */
+fun valid(): ValidationResult = ValidationResult()
+
+/**
+ * Creates an invalid validation result from one prebuilt [RuleViolation].
+ *
+ * This helper is useful when a validator has already constructed the exact
+ * violation object it wants to return and only needs to wrap it into the common
+ * [ValidationResult] container.
+ *
+ * @param violation the single violation that should make the result invalid
+ * @return an invalid [ValidationResult] containing exactly [violation]
+ */
+fun invalid(violation: RuleViolation): ValidationResult =
+    ValidationResult(violations = listOf(violation))
+
+/**
+ * Creates an invalid validation result from a list of [violations].
+ *
+ * If the provided list is empty, the helper falls back to [valid] so callers do
+ * not accidentally construct a contradictory "invalid but empty" result.
+ *
+ * @param violations collected violations that should be returned together
+ * @return a valid result when [violations] is empty, otherwise an invalid
+ * result containing all provided violations
+ */
+fun invalid(violations: List<RuleViolation>): ValidationResult =
+    if (violations.isEmpty()) {
+        valid()
+    } else {
+        ValidationResult(violations = violations)
+    }
+
+/**
+ * Creates an invalid validation result from one violation described inline.
+ *
+ * This helper is intended for validators that want to return a single
+ * rule-specific failure without manually constructing a [RuleViolation] first.
+ *
+ * @param code stable machine-readable rule identifier
+ * @param message human-readable explanation of the failure
+ * @param setIndex optional affected board-set index
+ * @param tileIds optional affected tile identifiers
+ * @return an invalid [ValidationResult] containing the constructed violation
+ */
+fun invalid(
+    code: String,
+    message: String,
+    setIndex: Int? = null,
+    tileIds: List<String> = emptyList()
+): ValidationResult =
+    invalid(
+        RuleViolation(
+            code = code,
+            message = message,
+            setIndex = setIndex,
+            tileIds = tileIds
+        )
+    )
+
+/**
+ * Merges multiple validation results into one combined result.
+ *
+ * The combined result is valid only if every input result is valid. Violation
+ * order is preserved in the same order as the provided [results], which makes
+ * aggregated outputs deterministic for testing, logging, and frontend display.
+ *
+ * @param results individual validation results that should be combined
+ * @return one [ValidationResult] containing all collected violations
+ */
+fun merge(vararg results: ValidationResult): ValidationResult =
+    results.asIterable().merge()
+
+/**
+ * Merges an arbitrary iterable of validation results into one combined result.
+ *
+ * This overload is useful when a validator builds results dynamically in a list
+ * during iteration and wants to aggregate them at the end without converting
+ * back to varargs.
+ *
+ * @return one [ValidationResult] whose violations are the concatenation of all
+ * violations in this iterable
+ */
+fun Iterable<ValidationResult>.merge(): ValidationResult {
+    // Flatten all collected rule failures while preserving validator order.
+    val mergedViolations = flatMap { it.violations }
+    return invalid(mergedViolations)
+}
+
+/**
+ * Combines this validation result with [other] and returns the aggregated
+ * result.
+ *
+ * This operator-style helper keeps small validator compositions readable when
+ * only two result values need to be merged.
+ *
+ * @param other the second validation result to combine with this one
+ * @return one aggregated [ValidationResult]
+ */
+operator fun ValidationResult.plus(other: ValidationResult): ValidationResult =
+    merge(this, other)

--- a/apps/shared/src/test/kotlin/shared/models/game/validation/ValidationResultTest.kt
+++ b/apps/shared/src/test/kotlin/shared/models/game/validation/ValidationResultTest.kt
@@ -1,0 +1,57 @@
+package shared.models.game.validation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ValidationResultTest {
+
+    @Test
+    fun `validation result is valid when no violations exist`() {
+        val result = ValidationResult()
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `validation result is invalid when violations exist`() {
+        val violation = RuleViolation(
+            code = "RUN_COLOR_MISMATCH",
+            message = "Run tiles must have the same color"
+        )
+
+        val result = ValidationResult(violations = listOf(violation))
+
+        assertFalse(result.isValid)
+        assertEquals(listOf(violation), result.violations)
+    }
+
+    @Test
+    fun `rule violation keeps optional defaults`() {
+        val violation = RuleViolation(
+            code = "GROUP_MIN_SIZE",
+            message = "Group must contain at least three tiles"
+        )
+
+        assertEquals("GROUP_MIN_SIZE", violation.code)
+        assertEquals("Group must contain at least three tiles", violation.message)
+        assertNull(violation.setIndex)
+        assertTrue(violation.tileIds.isEmpty())
+    }
+
+    @Test
+    fun `rule violation keeps set and tile references`() {
+        val violation = RuleViolation(
+            code = "TILE_DUPLICATED",
+            message = "Submitted draft contains a duplicated tile",
+            setIndex = 1,
+            tileIds = listOf("tile-17", "tile-22")
+        )
+
+        assertEquals(1, violation.setIndex)
+        assertEquals(listOf("tile-17", "tile-22"), violation.tileIds)
+    }
+}

--- a/apps/shared/src/test/kotlin/shared/models/game/validation/ValidationResultsHelperTest.kt
+++ b/apps/shared/src/test/kotlin/shared/models/game/validation/ValidationResultsHelperTest.kt
@@ -1,0 +1,91 @@
+package shared.models.game.validation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ValidationResultsHelperTest {
+
+    @Test
+    fun `valid helper returns empty valid result`() {
+        val result = valid()
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `invalid helper wraps one violation`() {
+        val violation = RuleViolation(
+            code = "RUN_COLOR_MISMATCH",
+            message = "Run tiles must have the same color"
+        )
+
+        val result = invalid(violation)
+
+        assertFalse(result.isValid)
+        assertEquals(listOf(violation), result.violations)
+    }
+
+    @Test
+    fun `invalid helper can build a violation inline`() {
+        val result = invalid(
+            code = "GROUP_MIN_SIZE",
+            message = "Group must contain at least three tiles",
+            setIndex = 2,
+            tileIds = listOf("tile-7")
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_MIN_SIZE", result.violations.single().code)
+        assertEquals(2, result.violations.single().setIndex)
+        assertEquals(listOf("tile-7"), result.violations.single().tileIds)
+    }
+
+    @Test
+    fun `invalid helper with empty list falls back to valid result`() {
+        val result = invalid(emptyList())
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `merge vararg combines violations in stable order`() {
+        val first = invalid("RULE_A", "First violation")
+        val second = valid()
+        val third = invalid("RULE_B", "Second violation")
+
+        val result = merge(first, second, third)
+
+        assertFalse(result.isValid)
+        assertEquals(listOf("RULE_A", "RULE_B"), result.violations.map { it.code })
+    }
+
+    @Test
+    fun `iterable merge combines violations in stable order`() {
+        val results = listOf(
+            invalid("RULE_A", "First violation"),
+            invalid("RULE_B", "Second violation")
+        )
+
+        val result = results.merge()
+
+        assertFalse(result.isValid)
+        assertEquals(2, result.violations.size)
+        assertEquals("RULE_A", result.violations[0].code)
+        assertEquals("RULE_B", result.violations[1].code)
+    }
+
+    @Test
+    fun `plus operator merges two validation results`() {
+        val left = invalid("RULE_A", "First violation")
+        val right = invalid("RULE_B", "Second violation")
+
+        val result = left + right
+
+        assertFalse(result.isValid)
+        assertEquals(listOf("RULE_A", "RULE_B"), result.violations.map { it.code })
+    }
+}

--- a/docs/rule-validation.md
+++ b/docs/rule-validation.md
@@ -182,13 +182,13 @@ The service should answer:
 - is this set valid as a group?
 - is this set valid as a run?
 - is it invalid as both?
-- is it valid as both and therefore ambiguous?
+- if both interpretations work, should it still be accepted?
 
 A good practical strategy is:
 
 - let `GroupValidationService` validate the set
 - let `RunValidationService` validate the set
-- let `SetValidationService` decide based on those two results
+- let `SetValidationService` decide based on those two results and accept the set if at least one interpretation is valid
 
 This avoids a separate classification pass that duplicates much of the same reasoning.
 
@@ -287,7 +287,7 @@ fun validateRun(set: BoardSet): ValidationResult {
 ### `SetValidationService`
 
 This service should not trust a pre-existing `BoardSetType` from the client.
-Instead, it should validate the set as both a group and a run and then decide the outcome.
+Instead, it should validate the set as both a group and a run and then accept the set if at least one interpretation succeeds.
 
 ### Example
 
@@ -300,13 +300,10 @@ class SetValidationService(
         val groupResult = groupValidationService.validate(set)
         val runResult = runValidationService.validate(set)
 
-        return when {
-            groupResult.isValid && !runResult.isValid -> valid()
-            runResult.isValid && !groupResult.isValid -> valid()
-            groupResult.isValid && runResult.isValid -> invalid(
-                "Set is ambiguous because it is valid as both a group and a run"
-            )
-            else -> invalid(
+        return if (groupResult.isValid || runResult.isValid) {
+            valid()
+        } else {
+            invalid(
                 violations = groupResult.violations + runResult.violations
             )
         }
@@ -314,7 +311,7 @@ class SetValidationService(
 }
 ```
 
-This is the core change from the earlier architecture.
+This is the core change from the earlier architecture: the backend no longer rejects sets just because both interpretations happen to succeed. A set is accepted if at least one interpretation is valid.
 
 ---
 
@@ -914,7 +911,7 @@ If a submitted draft contains the same tile twice, the backend should reject it 
 
 ## 6.3 Invalid end-turn because a set cannot be resolved as a legal group or run
 
-If a final submitted set is neither a legal group nor a legal run, the backend should reject end-turn and return a set-resolution or set-validation error.
+If a final submitted set is neither a legal group nor a legal run, the backend should reject end-turn and return a set-validation error.
 
 ---
 
@@ -947,7 +944,7 @@ If implementing incrementally, a good order is:
 This order works well because:
 
 - draft update safety depends heavily on tile conservation
-- end-turn now depends on trying both group and run validation inside set validation
+- end-turn now depends on trying both group and run validation inside set validation and accepting the set if at least one interpretation works
 - first-move validation depends on board validity already existing
 
 ---


### PR DESCRIPTION
## Summary

Start the backend rule-validation layer with a small foundation PR.

This PR should introduce the basic validation building blocks that later group/run/board validation can use, without already implementing the full rule engine.

- see [rule validation docs](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/blob/docs(game)/api-and-rule-validation-specifications/docs/rule-validation.md)

## Issues 

- Closes #264 
- Closes #265 
- Closes #266 
- Closes #267 
- Closes #268 
- Related to #306 

## Why

The current backend can already:

- load confirmed game state
- persist live draft updates
- enforce active-player ownership
- validate tile conservation

The next missing piece is the rule-validation bootstrap layer that future end-turn validation can build on.

Keeping this PR small helps establish the structure first before adding actual group/run/board rules.

## Scope

This PR should only add the basic rule-validation foundation:

- add `ValidationResult` model
- add `RuleViolation` model
- add small shared rule helper methods
- add `RummikubRuleService` / top-level rule service skeleton

## What to include

### 1. `ValidationResult`

Introduce the shared backend validation result model that later validators can return.

Suggested purpose:

- represent whether validation passed
- carry collected validation problems if needed
- act as the common result type for future rule validators

### 2. `RuleViolation`

Add the base violation model used by rule-validation services.

It should be simple and stable for now, e.g.:

- rule code
- message
- optional context/path if helpful

Do not overdesign it yet.

### 3. Rule helper methods

Add a very small helper layer for common validation result creation / aggregation.

Examples:

- create valid result
- create invalid result
- merge multiple validation results

This keeps later validator implementations cleaner.

### 4. Top-level `RummikubRuleService` skeleton

Add the main rule service as the future orchestration entry point for submitted draft validation.

For this PR, it should mostly be a skeleton with a method shape like:

- `validateSubmittedDraft(...)`

It does not need to call full group/run/board validators yet.

A good initial behavior is:

- accept dependencies or TODO placeholders cleanly
- return a valid result for now, or only very minimal structure checks if you want
- establish the service boundary that later PRs will extend

## Out of scope

Do not include yet:

- group validation
- run validation
- board validation
- first-move validation
- end-turn commit logic
- websocket changes

## Tests to add

Keep tests small and structural:

- `ValidationResult` behavior
- `RuleViolation` creation if useful
- helper method tests
- `RummikubRuleService` basic test / wiring test

## Why this PR is a good next step

This gives the backend a clean rule-validation entry point without mixing in too much real game-rule logic yet.

After this PR, the next focused PRs can be:

1. tile conservation integration into the top-level rule service
2. group validation
3. run validation
4. set/board validation
5. first-move validation
6. submitted draft validation flow in end-turn