### PR TITLE
feat(backend)(game): add draw tile endpoint and confirmed game update flow

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
@@ -1,0 +1,25 @@
+package at.se2group.backend.service
+
+import org.springframework.stereotype.Service
+
+/**
+ * Service responsible for handling draw tile action during a player's turn.
+ *
+ * When a player draws a tile, the tile is removed from the draw pile and added
+ * to the player's hand.
+ *
+ * This service handles the actions by:
+ * - verifying that the player is allowed to draw a tile
+ * - removing the tile from the draw pile
+ * - adding the tile to the player's rack
+ * - advancing the turn to the next player in the game
+ * - persisting the updated confirmed game state
+ */
+
+@Service
+class DrawTileService {
+
+    fun drawTile(gameId: String, playerId: String) {
+        throw UnsupportedOperationException("Draw tile is not implemented yet.")
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
@@ -1,0 +1,18 @@
+package at.se2group.backend.game.service
+import at.se2group.backend.service.DrawTileService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+
+
+class DrawTileServiceTest {
+    private val drawTileService = DrawTileService()
+
+    @Test
+    fun `drawTile throws now implemented exception`() {
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            drawTileService.drawTile("game-1", "user-1")
+        }
+        assertEquals("Draw tile is not implemented yet.", exception.message)
+    }
+}


### PR DESCRIPTION
## Summary

Add the backend **draw tile** endpoint and confirmed game update flow for `POST /api/games/{gameId}/draw`.

This PR should implement the REST command that lets the **current active player** draw exactly one tile from the draw pile, updates the confirmed game state accordingly, advances the turn, and returns the updated confirmed game response.

## Why

The current game API already defines the draw action as one of the core REST game commands. Adding this endpoint completes another important part of the documented turn flow and gives the frontend a clean backend path for the "cannot / does not want to play, so draw a tile" case.

This PR should stay focused on the confirmed-game draw flow only:

- only the **active player** may draw
- the game must exist
- the draw pile must contain at least one tile
- exactly one tile is moved from the draw pile to the active player's rack
- the turn advances to the next player after a successful draw
- the updated confirmed game state is persisted and returned
- if the draw pile is empty, the draw action is rejected cleanly

## What should be implemented

- add `POST /api/games/{gameId}/draw` to `GameController`
- add `drawTile(...)` service logic in the backend game service layer
- add request handling for `DrawTileRequest`
- update confirmed game persistence after drawing
- return the updated `GameResponse`
- add tests for controller and service behavior
- add clean error handling for invalid draw attempts such as:
  - missing game
  - malformed / invalid request body
  - missing or blank `playerId`
  - acting user is not the current turn player
  - acting user is not part of the game
  - game is not in a drawable state (for example not `ACTIVE`)
  - draw pile is empty
  - invalid or corrupted persisted game state that makes drawing impossible

## Expected backend flow

A clean implementation flow for this PR should look like this:

1. load the confirmed game by `gameId`
2. verify that `game.currentTurnPlayerId == request.playerId`
3. verify that the game is in a drawable state
4. verify that the draw pile is not empty
5. remove exactly one tile from the draw pile
6. append that tile to the active player's `rackTiles`
7. advance `currentTurnPlayerId` to the next player
8. update turn timing / deadline if that already exists in the current model
9. persist the updated confirmed game
10. return the updated confirmed game response

Important implementation detail:

- this PR should update **confirmed game state directly**, not draft state
- the draw action should not modify the live turn draft flow in this PR
- the draw action should not silently succeed when the draw pile is empty

## Example service shape

```kotlin
@Transactional
fun drawTile(gameId: String, playerId: String): ConfirmedGame {
    val game = gameRepository.findById(gameId)
        .orElseThrow { NoSuchElementException(GAME_NOT_FOUND) }
        .toDomain()

    check(game.currentTurnPlayerId == playerId) { NOT_ACTIVE_PLAYER }
    check(game.drawPile.isNotEmpty()) { DRAW_PILE_EMPTY }

    val drawnTile = game.drawPile.first()

    val updatedPlayers = game.players.map { player ->
        if (player.userId == playerId) {
            player.copy(rackTiles = player.rackTiles + drawnTile)
        } else {
            player
        }
    }

    val updatedGame = game.copy(
        players = updatedPlayers,
        drawPile = game.drawPile.drop(1),
        currentTurnPlayerId = nextPlayerId(game, playerId)
    )

    val saved = gameRepository.save(updatedGame.toEntity()).toDomain()
    return saved
}
```

## Controller shape

```kotlin
@PostMapping("/api/games/{gameId}/draw")
fun drawTile(
    @PathVariable gameId: String,
    @RequestBody @Valid request: DrawTileRequest
): GameResponse {
    return gameService.drawTile(gameId, request.playerId).toResponse()
}
```

## Important behavior decision

If the draw pile is empty, this PR should **reject the draw action cleanly** instead of ending the game automatically.

A good failure shape is:

- `409 Conflict` or `400 Bad Request`
- error message like `"Draw pile is empty"`

That keeps the behavior simple and consistent with the current API error model.

## Tests to include

### Service tests

- draws one tile for the active player successfully
- removes exactly one tile from the draw pile
- adds the drawn tile to the player's rack
- advances the turn to the next player
- rejects draw when the acting player is not the current turn player
- rejects draw when the draw pile is empty
- rejects draw when the game does not exist
- rejects draw when the player is not part of the game
- rejects draw when the game is not in an active / drawable state
- rejects draw when the confirmed game state is inconsistent and drawing cannot be completed safely
- persists the updated confirmed game after a successful draw

### Controller tests

- `POST /api/games/{gameId}/draw` returns `200 OK` with `GameResponse`
- returns the correct error response for:
  - missing game
  - malformed / invalid request body
  - missing or blank `playerId`
  - wrong player
  - player not part of the game
  - game not in drawable state
  - empty draw pile

## Related issues

- `feat(backend)(game): add draw tile request dto`
- `feat(backend)(game): add draw tile endpoint`
- `feat(backend)(game): add draw tile service method`
- `feat(backend)(game): remove drawn tile from draw pile`
- `feat(backend)(game): add drawn tile to active player rack`
- `feat(backend)(game): advance turn after draw action`
- `feat(backend)(game): persist confirmed game after draw action`
- `feat(backend)(game): add draw pile empty-state handling`
- `test(backend)(game): add draw tile service tests`
- `test(backend)(game)(rest-api): add draw tile controller tests`

## Out of scope

- websocket broadcasting changes
- timeout behavior changes
- end-turn validation logic
- draft reset changes