### PR TITLE
feat(backend)(rules): add GroupValidationService for submitted board sets

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
@@ -1,0 +1,62 @@
+package at.se2group.backend.rules.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.BoardSet
+import shared.models.game.domain.JokerTile
+import shared.models.game.domain.NumberedTile
+import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
+
+@Service
+class GroupValidationService {
+
+    fun validate(set: BoardSet): ValidationResult {
+        if (set.tiles.size < 3) {
+            return invalid(
+                code = "GROUP_MIN_SIZE",
+                message = "Group must contain at least 3 tiles",
+                tileIds = set.tiles.map { it.tileId }
+            )
+        }
+
+        if (set.tiles.size > 4) {
+            return invalid(
+                code = "GROUP_MAX_SIZE",
+                message = "Group must contain at most 4 tiles",
+                tileIds = set.tiles.map { it.tileId }
+            )
+        }
+
+        if (set.tiles.any { it is JokerTile }) {
+            return invalid(
+                code = "GROUP_JOKER_NOT_SUPPORTED",
+                message = "Joker support is not implemented yet",
+                tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
+            )
+        }
+
+        // JokerTile is the only non-numbered tile type right now and is rejected above.
+        val numberedTiles = set.tiles.map { it as NumberedTile }
+
+        val distinctNumbers = numberedTiles.map { it.number }.distinct()
+        if (distinctNumbers.size != 1) {
+            return invalid(
+                code = "GROUP_NUMBER_MISMATCH",
+                message = "All group tiles must have the same number",
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        val colors = numberedTiles.map { it.color }
+        if (colors.size != colors.distinct().size) {
+            return invalid(
+                code = "GROUP_DUPLICATE_COLOR",
+                message = "Group tiles must have unique colors",
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        return valid()
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
@@ -16,6 +16,7 @@ class GroupValidationService {
             return invalid(
                 code = "GROUP_MIN_SIZE",
                 message = "Group must contain at least 3 tiles",
+                setIndex = 0,
                 tileIds = set.tiles.map { it.tileId }
             )
         }
@@ -24,6 +25,7 @@ class GroupValidationService {
             return invalid(
                 code = "GROUP_MAX_SIZE",
                 message = "Group must contain at most 4 tiles",
+                setIndex = 0,
                 tileIds = set.tiles.map { it.tileId }
             )
         }
@@ -32,6 +34,7 @@ class GroupValidationService {
             return invalid(
                 code = "GROUP_JOKER_NOT_SUPPORTED",
                 message = "Joker support is not implemented yet",
+                setIndex = 0,
                 tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
             )
         }
@@ -44,6 +47,7 @@ class GroupValidationService {
             return invalid(
                 code = "GROUP_NUMBER_MISMATCH",
                 message = "All group tiles must have the same number",
+                setIndex = 0,
                 tileIds = numberedTiles.map { it.tileId }
             )
         }
@@ -53,6 +57,7 @@ class GroupValidationService {
             return invalid(
                 code = "GROUP_DUPLICATE_COLOR",
                 message = "Group tiles must have unique colors",
+                setIndex = 0,
                 tileIds = numberedTiles.map { it.tileId }
             )
         }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
@@ -1,0 +1,147 @@
+package at.se2group.backend.rules.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import shared.models.game.domain.BoardSet
+import shared.models.game.domain.JokerTile
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.Tile
+import shared.models.game.domain.TileColor
+
+class GroupValidationServiceTest {
+
+    private val service = GroupValidationService()
+
+    private fun set(vararg tiles: Tile): BoardSet =
+        BoardSet(
+            boardSetId = "set-1",
+            tiles = tiles.toList()
+        )
+
+    private fun tile(
+        id: String,
+        color: TileColor,
+        number: Int
+    ): NumberedTile =
+        NumberedTile(
+            tileId = id,
+            color = color,
+            number = number
+        )
+
+    private fun joker(
+        id: String,
+        color: TileColor
+    ): JokerTile =
+        JokerTile(
+            tileId = id,
+            color = color
+        )
+
+    @Test
+    fun `validates 3 tile group with same number and unique colors`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7),
+                tile("tile-3", TileColor.BLACK, 7)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `validates 4 tile group with same number and unique colors`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 10),
+                tile("tile-2", TileColor.BLUE, 10),
+                tile("tile-3", TileColor.BLACK, 10),
+                tile("tile-4", TileColor.ORANGE, 10)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `rejects group with fewer than 3 tiles`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7)
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_MIN_SIZE", result.violations.single().code)
+        assertEquals("Group must contain at least 3 tiles", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects group with more than 4 tiles`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7),
+                tile("tile-3", TileColor.BLACK, 7),
+                tile("tile-4", TileColor.ORANGE, 7),
+                tile("tile-5", TileColor.RED, 7)
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_MAX_SIZE", result.violations.single().code)
+        assertEquals("Group must contain at most 4 tiles", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects group with mixed tile numbers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7),
+                tile("tile-3", TileColor.BLACK, 8)
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_NUMBER_MISMATCH", result.violations.single().code)
+        assertEquals("All group tiles must have the same number", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects group with duplicate colors`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.RED, 7),
+                tile("tile-3", TileColor.BLUE, 7)
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_DUPLICATE_COLOR", result.violations.single().code)
+        assertEquals("Group tiles must have unique colors", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects group containing jokers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7),
+                joker("tile-3", TileColor.BLACK)
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("GROUP_JOKER_NOT_SUPPORTED", result.violations.single().code)
+        assertEquals("Joker support is not implemented yet", result.violations.single().message)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
@@ -71,77 +71,95 @@ class GroupValidationServiceTest {
 
     @Test
     fun `rejects group with fewer than 3 tiles`() {
-        val result = service.validate(
-            set(
-                tile("tile-1", TileColor.RED, 7),
-                tile("tile-2", TileColor.BLUE, 7)
-            )
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 7)
         )
 
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_MIN_SIZE", result.violations.single().code)
-        assertEquals("Group must contain at least 3 tiles", result.violations.single().message)
+        assertEquals("GROUP_MIN_SIZE", violation.code)
+        assertEquals("Group must contain at least 3 tiles", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
     }
 
     @Test
     fun `rejects group with more than 4 tiles`() {
-        val result = service.validate(
-            set(
-                tile("tile-1", TileColor.RED, 7),
-                tile("tile-2", TileColor.BLUE, 7),
-                tile("tile-3", TileColor.BLACK, 7),
-                tile("tile-4", TileColor.ORANGE, 7),
-                tile("tile-5", TileColor.RED, 7)
-            )
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 7),
+            tile("tile-3", TileColor.BLACK, 7),
+            tile("tile-4", TileColor.ORANGE, 7),
+            tile("tile-5", TileColor.RED, 7)
         )
 
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_MAX_SIZE", result.violations.single().code)
-        assertEquals("Group must contain at most 4 tiles", result.violations.single().message)
+        assertEquals("GROUP_MAX_SIZE", violation.code)
+        assertEquals("Group must contain at most 4 tiles", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
     }
 
     @Test
     fun `rejects group with mixed tile numbers`() {
-        val result = service.validate(
-            set(
-                tile("tile-1", TileColor.RED, 7),
-                tile("tile-2", TileColor.BLUE, 7),
-                tile("tile-3", TileColor.BLACK, 8)
-            )
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 7),
+            tile("tile-3", TileColor.BLACK, 8)
         )
 
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_NUMBER_MISMATCH", result.violations.single().code)
-        assertEquals("All group tiles must have the same number", result.violations.single().message)
+        assertEquals("GROUP_NUMBER_MISMATCH", violation.code)
+        assertEquals("All group tiles must have the same number", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
     }
 
     @Test
     fun `rejects group with duplicate colors`() {
-        val result = service.validate(
-            set(
-                tile("tile-1", TileColor.RED, 7),
-                tile("tile-2", TileColor.RED, 7),
-                tile("tile-3", TileColor.BLUE, 7)
-            )
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.RED, 7),
+            tile("tile-3", TileColor.BLUE, 7)
         )
 
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_DUPLICATE_COLOR", result.violations.single().code)
-        assertEquals("Group tiles must have unique colors", result.violations.single().message)
+        assertEquals("GROUP_DUPLICATE_COLOR", violation.code)
+        assertEquals("Group tiles must have unique colors", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
     }
 
     @Test
     fun `rejects group containing jokers`() {
-        val result = service.validate(
-            set(
-                tile("tile-1", TileColor.RED, 7),
-                tile("tile-2", TileColor.BLUE, 7),
-                joker("tile-3", TileColor.BLACK)
-            )
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 7),
+            joker("tile-3", TileColor.BLACK)
         )
 
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_JOKER_NOT_SUPPORTED", result.violations.single().code)
-        assertEquals("Joker support is not implemented yet", result.violations.single().message)
+        assertEquals("GROUP_JOKER_NOT_SUPPORTED", violation.code)
+        assertEquals("Joker support is not implemented yet", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(
+            set.tiles.filterIsInstance<JokerTile>().map { it.tileId },
+            violation.tileIds
+        )
     }
 }


### PR DESCRIPTION
## Summary

This PR should stay very focused: only **groups**, no runs, no full board validation, and no end-turn integration yet.

## Related Issues

- Related to #269 
- Closes #270
- Closes #271
- Closes #272
- Closes #273 
- Closes #274 
- Related to #275 
- Related to #276
- Related to #364 
- Related to #269 
- Related to #275 
- Related to #276 
- Related to #286 
- Related to #293
- Related to #289 

## Why this is the best next step

So this PR should establish one thing only:

> “Is this submitted `BoardSet` a valid group?”
> 

## Scope

Included:

- `GroupValidationService`
- group-validation checks for non-joker sets
- clear `ValidationResult` / violation handling using the existing rule-validation foundation
- focused unit tests for valid and invalid group cases

Not included:

- run validation
- set validation that tries both group and run
- board validation
- joker-aware group validation
- first-move validation
- end-turn integration
- websocket changes

## What a valid group means in this PR

For this first version, keep the rules strict and simple.

A submitted `BoardSet` counts as a valid **group** only if:

1. it contains at least **3 tiles**
2. it contains at most **4 tiles**
3. all tiles are **numbered tiles** (no jokers in this PR)
4. all tiles have the **same number**
5. all tiles have **different colors**
6. there are no duplicate colors

### Valid examples

- `Red 7, Blue 7, Black 7`
- `Red 10, Blue 10, Black 10, Orange 10`

### Invalid examples

- `Red 7, Blue 7` → too small
- `Red 7, Blue 7, Black 7, Orange 7, Red 7` → too large
- `Red 7, Blue 7, Black 8` → mixed numbers
- `Red 7, Red 7, Blue 7` → duplicate color
- any set containing a joker → reject for now

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / setup
- [x] Test