### PR TITLE
feat(backend)(rules): add RunValidationService for submitted board sets

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -20,17 +20,17 @@ class RunValidationService {
                 )
             }
 
-        if (set.tiles.any { it is JokerTile }) {
-            return invalid(
-                code = "RUN_JOKER_NOT_SUPPORTED",
-                message = "Joker support is not implemented yet",
-                tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
-            )
-        }
+            if (set.tiles.any { it is JokerTile }) {
+                return invalid(
+                    code = "RUN_JOKER_NOT_SUPPORTED",
+                    message = "Joker support is not implemented yet",
+                    tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
+                )
+            }
 
-        val numberedTiles = set.tiles.map { it as NumberedTile }
+            val numberedTiles = set.tiles.map { it as NumberedTile }
 
-        val distinctColors = numberedTiles.map { it.color }.distinct()
+            val distinctColors = numberedTiles.map { it.color }.distinct()
             if (distinctColors.size != 1 ) {
                 return invalid(
                     code = "RUN_COLOR_MISMATCH",
@@ -39,26 +39,26 @@ class RunValidationService {
                 )
             }
 
-        val sortedNumbers = numberedTiles.sortedBy { it.number }.map { it.number }
+            val sortedNumbers = numberedTiles.sortedBy { it.number }.map { it.number }
 
-        if (sortedNumbers.size != sortedNumbers.distinct().size) {
-            return invalid(
-                code = "RUN_DUPLICATE_NUMBER",
-                message = "Run tiles must not have duplicate numbers",
-                tileIds = numberedTiles.map { it.tileId }
-            )
-        }
-
-        for (i in 1 until sortedNumbers.size) {
-            if (sortedNumbers[i] != sortedNumbers[i - 1] + 1) {
+            if (sortedNumbers.size != sortedNumbers.distinct().size) {
                 return invalid(
+                    code = "RUN_DUPLICATE_NUMBER",
+                    message = "Run tiles must not have duplicate numbers",
+                    tileIds = numberedTiles.map { it.tileId }
+                )
+            }
+
+            for (i in 1 until sortedNumbers.size) {
+            if (sortedNumbers[i] != sortedNumbers[i - 1] + 1) {
+                    return invalid(
                     code = "RUN_NOT_CONSECUTIVE",
                     message = "Run tiles must create a consecutive ascending sequence",
                     tileIds = numberedTiles.map { it.tileId }
                 )
             }
         }
-        return valid()
+            return valid()
     }
 
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -49,17 +49,17 @@ class RunValidationService {
                 )
             }
 
-            for (i in 1 until sortedNumbers.size) {
-            if (sortedNumbers[i] != sortedNumbers[i - 1] + 1) {
-                    return invalid(
+            val isConsecutive = sortedNumbers
+                .zipWithNext()
+                .all { (a, b) -> b == a + 1 }
+
+            if (!isConsecutive) {
+                return invalid(
                     code = "RUN_NOT_CONSECUTIVE",
                     message = "Run tiles must create a consecutive ascending sequence",
                     tileIds = numberedTiles.map { it.tileId }
                 )
             }
-        }
             return valid()
+        }
     }
-
-
-}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -2,13 +2,64 @@ package at.se2group.backend.rules.service
 
 import org.springframework.stereotype.Service
 import shared.models.game.domain.BoardSet
+import shared.models.game.domain.JokerTile
+import shared.models.game.domain.NumberedTile
 import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
 
 @Service
 class RunValidationService {
 
     fun validate(set: BoardSet): ValidationResult {
-        throw UnsupportedOperationException("Run validation is not implemented yet.")
+            if (set.tiles.size < 3) {
+                return invalid(
+                    code = "RUN_MIN_SIZE",
+                    message = "Run must contain at least 3 tiles",
+                    tileIds = set.tiles.map { it.tileId }
+                )
+            }
+
+        if (set.tiles.any { it is JokerTile }) {
+            return invalid(
+                code = "RUN_JOKER_NOT_SUPPORTED",
+                message = "Joker support is not implemented yet",
+                tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
+            )
+        }
+
+        val numberedTiles = set.tiles.map { it as NumberedTile }
+
+        val distinctColors = numberedTiles.map { it.color }.distinct()
+            if (distinctColors.size != 1 ) {
+                return invalid(
+                    code = "RUN_COLOR_MISMATCH",
+                    message = "All run tiles must have the same color",
+                    tileIds = numberedTiles.map { it.tileId }
+                )
+            }
+
+        val sortedNumbers = numberedTiles.sortedBy { it.number }.map { it.number }
+
+        if (sortedNumbers.size != sortedNumbers.distinct().size) {
+            return invalid(
+                code = "RUN_DUPLICATE_NUMBER",
+                message = "Run tiles must not have duplicate numbers",
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        for (i in 1 until sortedNumbers.size) {
+            if (sortedNumbers[i] != sortedNumbers[i - 1] + 1) {
+                return invalid(
+                    code = "RUN_NOT_CONSECUTIVE",
+                    message = "Run tiles must create a consecutive ascending sequence",
+                    tileIds = numberedTiles.map { it.tileId }
+                )
+            }
+        }
+        return valid()
     }
+
 
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -1,0 +1,14 @@
+package at.se2group.backend.rules.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.BoardSet
+import shared.models.game.validation.ValidationResult
+
+@Service
+class RunValidationService {
+
+    fun validate(set: BoardSet): ValidationResult {
+        throw UnsupportedOperationException("Run validation is not implemented yet.")
+    }
+
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -16,6 +16,7 @@ class RunValidationService {
                 return invalid(
                     code = "RUN_MIN_SIZE",
                     message = "Run must contain at least 3 tiles",
+                    setIndex = 0,
                     tileIds = set.tiles.map { it.tileId }
                 )
             }
@@ -24,6 +25,7 @@ class RunValidationService {
                 return invalid(
                     code = "RUN_JOKER_NOT_SUPPORTED",
                     message = "Joker support is not implemented yet",
+                    setIndex = 0,
                     tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
                 )
             }
@@ -35,6 +37,7 @@ class RunValidationService {
                 return invalid(
                     code = "RUN_COLOR_MISMATCH",
                     message = "All run tiles must have the same color",
+                    setIndex = 0,
                     tileIds = numberedTiles.map { it.tileId }
                 )
             }
@@ -45,6 +48,7 @@ class RunValidationService {
                 return invalid(
                     code = "RUN_DUPLICATE_NUMBER",
                     message = "Run tiles must not have duplicate numbers",
+                    setIndex = 0,
                     tileIds = numberedTiles.map { it.tileId }
                 )
             }
@@ -57,6 +61,7 @@ class RunValidationService {
                 return invalid(
                     code = "RUN_NOT_CONSECUTIVE",
                     message = "Run tiles must create a consecutive ascending sequence",
+                    setIndex = 0,
                     tileIds = numberedTiles.map { it.tileId }
                 )
             }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -57,57 +57,71 @@ class RunValidationServiceTest {
 
     @Test
     fun `reject run if tiles are less than 3`() {
-        val result = service.validate(
-            set(
+        val boardSet = set(
                 tile("tile-1", TileColor.RED, 7),
                 tile("tile-2", TileColor.RED, 8)
             )
-        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
         assertFalse(result.isValid)
-        assertEquals("RUN_MIN_SIZE", result.violations.single().code)
-        assertEquals("Run must contain at least 3 tiles", result.violations.single().message)
+        assertEquals("RUN_MIN_SIZE", violation.code)
+        assertEquals("Run must contain at least 3 tiles", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(boardSet.tiles.map { it.tileId}, violation.tileIds)
     }
 
     @Test
     fun `rejects runs if tiles colors are mixed`() {
-        val result = service.validate(
-            set(
+        val boardSet = set(
                 tile("tile-1", TileColor.RED, 3),
                 tile("tile-2", TileColor.BLUE, 4),
                 tile("tile-3", TileColor.RED, 5)
             )
-        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
         assertFalse(result.isValid)
-        assertEquals("RUN_COLOR_MISMATCH", result.violations.single().code)
-        assertEquals("All run tiles must have the same color", result.violations.single().message)
+        assertEquals("RUN_COLOR_MISMATCH", violation.code)
+        assertEquals("All run tiles must have the same color", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(boardSet.tiles.map { it.tileId}, violation.tileIds)
     }
 
     @Test
     fun`rejects run containing duplicate numbers`() {
-        val result = service.validate(
-            set(
+        val boardSet = set(
                 tile("tile-1", TileColor.RED, 7),
                 tile("tile-2", TileColor.RED, 7),
                 tile("tile-3", TileColor.RED, 8)
             )
-        )
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
         assertFalse(result.isValid)
-        assertEquals("RUN_DUPLICATE_NUMBER", result.violations.single().code)
-        assertEquals("Run tiles must not have duplicate numbers", result.violations.single().message)
+        assertEquals("RUN_DUPLICATE_NUMBER", violation.code)
+        assertEquals("Run tiles must not have duplicate numbers", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(boardSet.tiles.map { it.tileId}, violation.tileIds)
     }
 
     @Test
     fun `rejects run with a gap in the sequence`() {
-        val result = service.validate(
-            set(
+        val boardSet = set(
                 tile("tile-1", TileColor.RED, 3),
                 tile("tile-2", TileColor.RED, 5),
                 tile("tile-3", TileColor.RED, 6)
             )
-        )
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
         assertFalse(result.isValid)
-        assertEquals("RUN_NOT_CONSECUTIVE", result.violations.single().code)
-        assertEquals("Run tiles must create a consecutive ascending sequence", result.violations.single().message)
+        assertEquals("RUN_NOT_CONSECUTIVE", violation.code)
+        assertEquals("Run tiles must create a consecutive ascending sequence", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(boardSet.tiles.map { it.tileId}, violation.tileIds)
     }
 
 
@@ -139,7 +153,7 @@ class RunValidationServiceTest {
 
     @Test
     fun `rejects run containing joker`() {
-        val result = service.validate(
+        val result  = service.validate(
             set(
                 tile("tile-1", TileColor.RED, 3),
                 tile("tile-2", TileColor.RED, 4),
@@ -147,9 +161,15 @@ class RunValidationServiceTest {
             )
         )
 
+
+        val violation = result.violations.single()
+
         assertFalse(result.isValid)
-        assertEquals("RUN_JOKER_NOT_SUPPORTED", result.violations.single().code)
-        assertEquals("Joker support is not implemented yet", result.violations.single().message)
+        assertEquals("RUN_JOKER_NOT_SUPPORTED", violation.code)
+        assertEquals("Joker support is not implemented yet", violation.message)
+        assertEquals(0, violation.setIndex)
+        assertEquals(listOf("tile-3"), violation.tileIds)
+
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -1,0 +1,30 @@
+package at.se2group.backend.rules.service
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import shared.models.game.domain.BoardSet
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+
+
+class RunValidationServiceTest {
+    private val service = RunValidationService()
+
+    @Test
+    fun `throws not implemented exception`() {
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            service.validate(
+                BoardSet(
+                    boardSetId = "set-1",
+                    tiles = listOf(
+                        NumberedTile("tile-1", TileColor.RED, 5),
+                        NumberedTile("tile-2", TileColor.BLUE, 6),
+                        NumberedTile("tile-3", TileColor.RED, 7 )
+                    )
+                )
+            )
+        }
+        assertEquals("Run validation is not implemented yet.", exception.message)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -152,4 +152,17 @@ class RunValidationServiceTest {
         assertEquals("Joker support is not implemented yet", result.violations.single().message)
     }
 
+    @Test
+    fun `reject duplicate number violation before non-consecutive validation`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 3),
+                tile("tile-2", TileColor.RED, 3),
+                tile("tile-3", TileColor.RED, 5)
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_DUPLICATE_NUMBER", result.violations.single().code)
+    }
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -115,9 +115,9 @@ class RunValidationServiceTest {
     fun `accept run if tiles are submitted with mixed order numbers`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.RED, 5),
-                tile("tile-2", TileColor.RED, 4),
-                tile("tile-3", TileColor.RED, 3)
+                tile("tile-1", TileColor.RED, 4),
+                tile("tile-2", TileColor.RED, 6),
+                tile("tile-3", TileColor.RED, 5)
             )
         )
         assertTrue(result.isValid)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -1,30 +1,155 @@
 package at.se2group.backend.rules.service
 
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import shared.models.game.domain.BoardSet
 import shared.models.game.domain.NumberedTile
 import shared.models.game.domain.TileColor
+import shared.models.game.domain.Tile
+import shared.models.game.domain.JokerTile
 
 
 class RunValidationServiceTest {
     private val service = RunValidationService()
 
+    private fun set(vararg tiles: Tile): BoardSet =
+        BoardSet(
+            boardSetId = "set-1",
+            tiles = tiles.toList()
+        )
+
+    private fun tile(id: String, color: TileColor, number: Int): NumberedTile =
+        NumberedTile(tileId = id, color = color, number = number)
+
+    private fun joker(id: String, color: TileColor): JokerTile =
+        JokerTile(tileId = id, color = color)
+
+
     @Test
-    fun `throws not implemented exception`() {
-        val exception = assertThrows(UnsupportedOperationException::class.java) {
-            service.validate(
-                BoardSet(
-                    boardSetId = "set-1",
-                    tiles = listOf(
-                        NumberedTile("tile-1", TileColor.RED, 5),
-                        NumberedTile("tile-2", TileColor.BLUE, 6),
-                        NumberedTile("tile-3", TileColor.RED, 7 )
-                    )
-                )
+    fun `validate 3 tile run with consecutive numbers and same color`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 1),
+                tile("tile-2", TileColor.BLUE, 2),
+                tile("tile-3", TileColor.BLUE, 3)
+
             )
-        }
-        assertEquals("Run validation is not implemented yet.", exception.message)
+        )
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
     }
+
+    @Test
+    fun `validate 4 tile run with consecutive numbers and same color`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 8),
+                tile("tile-2", TileColor.BLUE, 9),
+                tile("tile-3", TileColor.BLUE, 10),
+                tile("tile-4", TileColor.BLUE, 11)
+            )
+        )
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `reject run if tiles are less than 3`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 1),
+                tile("tile-2", TileColor.BLUE, 2),
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_MIN_SIZE", result.violations.single().code)
+        assertEquals("Run must contain at least 3 tiles", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects runs if tiles colors are mixed`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 1),
+                tile("tile-2", TileColor.BLUE, 2),
+                tile("tile-3", TileColor.BLACK, 3),
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_COLOR_MISMATCH", result.violations.single().code)
+        assertEquals("All run tiles must have the same color", result.violations.single().message)
+    }
+
+    @Test
+    fun`rejects run containing duplicate numbers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 4),
+                tile("tile-2", TileColor.BLUE, 4),
+                tile("tile-3", TileColor.BLUE, 5),
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_DUPLICATE_NUMBER", result.violations.single().code)
+        assertEquals("Run tiles must not have duplicate numbers", result.violations.single().message)
+    }
+
+    @Test
+    fun `rejects run with non consecutive numbers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 6),
+                tile("tile-2", TileColor.BLUE, 8),
+                tile("tile-3", TileColor.BLUE, 9),
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_NOT_CONSECUTIVE", result.violations.single().code)
+        assertEquals("Run tiles must create a consecutive ascending sequence", result.violations.single().message)
+    }
+
+
+    @Test
+    fun `accept run if tiles are submitted with mixed sequence numbers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 3),
+                tile("tile-2", TileColor.BLUE, 1),
+                tile("tile-3", TileColor.BLUE, 2),
+            )
+        )
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `rejects run if consecutive sequence number fails after sorting`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 4),
+                tile("tile-2", TileColor.BLUE, 7),
+                tile("tile-3", TileColor.BLUE, 8),
+            )
+        )
+        assertFalse(result.isValid)
+        assertEquals("RUN_NOT_CONSECUTIVE", result.violations.single().code)
+    }
+
+    @Test
+    fun `rejects run containing joker`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLUE, 1),
+                tile("tile-2", TileColor.BLUE, 2),
+                joker("tile-3", TileColor.BLACK),
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_JOKER_NOT_SUPPORTED", result.violations.single().code)
+        assertEquals("Joker support is not implemented yet", result.violations.single().message)
+    }
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -31,9 +31,9 @@ class RunValidationServiceTest {
     fun `validate 3 tile run with consecutive numbers and same color`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 1),
-                tile("tile-2", TileColor.BLUE, 2),
-                tile("tile-3", TileColor.BLUE, 3)
+                tile("tile-1", TileColor.RED, 3),
+                tile("tile-2", TileColor.RED, 4),
+                tile("tile-3", TileColor.RED, 5)
 
             )
         )
@@ -45,10 +45,10 @@ class RunValidationServiceTest {
     fun `validate 4 tile run with consecutive numbers and same color`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 8),
-                tile("tile-2", TileColor.BLUE, 9),
-                tile("tile-3", TileColor.BLUE, 10),
-                tile("tile-4", TileColor.BLUE, 11)
+                tile("tile-1", TileColor.BLUE, 10),
+                tile("tile-2", TileColor.BLUE, 11),
+                tile("tile-3", TileColor.BLUE, 12),
+                tile("tile-4", TileColor.BLUE, 13)
             )
         )
         assertTrue(result.isValid)
@@ -59,8 +59,8 @@ class RunValidationServiceTest {
     fun `reject run if tiles are less than 3`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 1),
-                tile("tile-2", TileColor.BLUE, 2),
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.RED, 8)
             )
         )
         assertFalse(result.isValid)
@@ -72,9 +72,9 @@ class RunValidationServiceTest {
     fun `rejects runs if tiles colors are mixed`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.RED, 1),
-                tile("tile-2", TileColor.BLUE, 2),
-                tile("tile-3", TileColor.BLACK, 3),
+                tile("tile-1", TileColor.RED, 3),
+                tile("tile-2", TileColor.BLUE, 4),
+                tile("tile-3", TileColor.RED, 5)
             )
         )
         assertFalse(result.isValid)
@@ -86,9 +86,9 @@ class RunValidationServiceTest {
     fun`rejects run containing duplicate numbers`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 4),
-                tile("tile-2", TileColor.BLUE, 4),
-                tile("tile-3", TileColor.BLUE, 5),
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.RED, 7),
+                tile("tile-3", TileColor.RED, 8)
             )
         )
         assertFalse(result.isValid)
@@ -97,12 +97,12 @@ class RunValidationServiceTest {
     }
 
     @Test
-    fun `rejects run with non consecutive numbers`() {
+    fun `rejects run with a gap in the sequence`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 6),
-                tile("tile-2", TileColor.BLUE, 8),
-                tile("tile-3", TileColor.BLUE, 9),
+                tile("tile-1", TileColor.RED, 3),
+                tile("tile-2", TileColor.RED, 5),
+                tile("tile-3", TileColor.RED, 6)
             )
         )
         assertFalse(result.isValid)
@@ -112,12 +112,12 @@ class RunValidationServiceTest {
 
 
     @Test
-    fun `accept run if tiles are submitted with mixed sequence numbers`() {
+    fun `accept run if tiles are submitted with mixed order numbers`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 3),
-                tile("tile-2", TileColor.BLUE, 1),
-                tile("tile-3", TileColor.BLUE, 2),
+                tile("tile-1", TileColor.RED, 5),
+                tile("tile-2", TileColor.RED, 4),
+                tile("tile-3", TileColor.RED, 3)
             )
         )
         assertTrue(result.isValid)
@@ -130,7 +130,7 @@ class RunValidationServiceTest {
             set(
                 tile("tile-1", TileColor.BLUE, 4),
                 tile("tile-2", TileColor.BLUE, 7),
-                tile("tile-3", TileColor.BLUE, 8),
+                tile("tile-3", TileColor.BLUE, 8)
             )
         )
         assertFalse(result.isValid)
@@ -141,8 +141,8 @@ class RunValidationServiceTest {
     fun `rejects run containing joker`() {
         val result = service.validate(
             set(
-                tile("tile-1", TileColor.BLUE, 1),
-                tile("tile-2", TileColor.BLUE, 2),
+                tile("tile-1", TileColor.RED, 3),
+                tile("tile-2", TileColor.RED, 4),
                 joker("tile-3", TileColor.BLACK),
             )
         )


### PR DESCRIPTION
## Summary

Add the first concrete rule validator in the backend rule-validation flow: a dedicated `RunValidationService` that validates whether one submitted `BoardSet` is a legal **run**. This PR should stay very focused: only **runs**, no groups, no full board validation, and no end-turn integration yet.

## Why this is the best next step

So this PR should establish one thing only:

> "Is this submitted `BoardSet` a valid run?"

## Related Issues

- Related to #277 
- Closes #278 
- Closes #279 
- Closes #280 
- Closes #281 
- Closes #282 
- Closes #283 
- Related to #284 
- Related to #285 
- Related to #286  
- Related to #293
- Related to #289 
- 

## Scope

Included:

- `RunValidationService`
- run-validation checks for non-joker sets
- clear `ValidationResult` / violation handling using the existing rule-validation foundation
- focused unit tests for valid and invalid run cases

Not included:

- group validation
- set validation that tries both group and run
- board validation
- joker-aware run validation
- first-move validation
- end-turn integration
- websocket changes

## What a valid run means in this PR

For this first version, keep the rules strict and simple.

A submitted `BoardSet` counts as a valid **run** only if:

1. it contains at least **3 tiles**
2. all tiles are **numbered tiles** (no jokers in this PR)
3. all tiles have the **same color**
4. all tile numbers are **unique**
5. the numbers form one **strictly ascending consecutive sequence** with no gaps

### Valid examples

- `Red 3, Red 4, Red 5`
- `Blue 10, Blue 11, Blue 12, Blue 13`

### Invalid examples

- `Red 7, Red 8` → too small
- `Red 3, Blue 4, Red 5` → mixed colors
- `Red 3, Red 5, Red 6` → gap in sequence
- `Red 7, Red 7, Red 8` → duplicate number
- `Red 5, Red 4, Red 3` → wrong order if submitted order is expected to already be normalized
- any set containing a joker → reject for now

## What to implement

### 1. Add `RunValidationService`

Create a dedicated backend service that validates exactly one `BoardSet` as a run.

A good method shape is:

```kotlin
fun validate(set: BoardSet): ValidationResult
```

The method should check each run rule and return a result using the existing rule-validation model.

### 2. Keep jokers out of scope

For this PR:

- if the set contains one or more jokers, return invalid
- do not try to substitute joker values yet
- leave joker-aware run validation to a later PR

### 3. Decide how to treat order

For this PR, the run validator should **not trust** the stored tile order inside the `BoardSet`.

Instead:

- the validator should extract the numbered tiles
- sort them by tile number first
- then validate the run rules on that sorted sequence

This means a run should still be accepted even if the tiles were persisted in a mixed order, as long as sorting reveals one valid consecutive same-color sequence.

### 4. Suggested implementation shape

```kotlin
class RunValidationService {
    fun validate(set: BoardSet): ValidationResult {
        if (set.tiles.size < 3) {
            return ValidationResult.invalid("Run must contain at least 3 tiles")
        }

        if (set.tiles.any { it is JokerTile }) {
            return ValidationResult.invalid("Joker support is not implemented yet")
        }

        val numberedTiles = set.tiles.map { it as NumberedTile }

        val distinctColors = numberedTiles.map { it.color }.distinct()
        if (distinctColors.size != 1) {
            return ValidationResult.invalid("All run tiles must have the same color")
        }

        val sortedTiles = numberedTiles.sortedBy { it.number }
        val numbers = sortedTiles.map { it.number }
        if (numbers.size != numbers.distinct().size) {
            return ValidationResult.invalid("Run tiles must not contain duplicate numbers")
        }

        for (i in 1 until numbers.size) {
            if (numbers[i] != numbers[i - 1] + 1) {
                return ValidationResult.invalid("Run tiles must form a consecutive ascending sequence")
            }
        }

        return ValidationResult.valid()
    }
}
```

If your current rule-validation foundation already uses `RuleViolation` objects, prefer structured violations over plain string-only invalid results.

## Checks this validator should perform

In a readable order:

1. minimum size
2. joker not supported yet
3. all numbered tiles share the same color
4. all numbers are unique
5. after sorting by number, the tiles form a strictly ascending consecutive sequence

## Tests to include

Add focused unit tests for `RunValidationService`.

At minimum:

- valid 3-tile run with same color and consecutive ascending numbers
- valid longer run with same color and consecutive ascending numbers
- rejects run with fewer than 3 tiles
- rejects run with mixed colors
- rejects run with duplicate numbers
- rejects run with a gap in the number sequence
- rejects run containing jokers
- accepts a valid run even if the tiles are submitted in a mixed order
- rejects a mixed-order set if sorting still does not produce a valid consecutive run

## Expected outcome of this PR

After this PR, the backend should be able to validate one submitted `BoardSet` as a possible **run** and clearly answer:

- valid run
- invalid run, with a clear failure reason

That gives the next PR a clean base for:

- later `SetValidationService`
- later `BoardValidationService`