### PR TITLE
ci(android)(sonar): set up dedicated frontend sonar cloud analysis and scope cleanup

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,19 +60,20 @@ jobs:
         run: ./gradlew :apps:android:app:testDebugUnitTest
 
       - name: Run frontend Sonar analysis
-        run: >
-          ./gradlew sonar
-          -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
-          -Dsonar.organization=se2-gruppenprojekt
-          -Dsonar.host.url=https://sonarcloud.io
-          -Dsonar.projectBaseDir=apps/android/app
-          -Dsonar.sources=src/main/java
-          -Dsonar.tests=src/test
-          -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
-          -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
+            -Dsonar.organization=se2-gruppenprojekt
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.projectBaseDir=apps/android/app
+            -Dsonar.sources=src/main/java
+            -Dsonar.tests=src/test
+            -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
+            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
 
   frontend-required:
     name: frontend-required

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: android-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -65,12 +65,13 @@ jobs:
           -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
           -Dsonar.organization=se2-gruppenprojekt
           -Dsonar.host.url=https://sonarcloud.io
-          -Dsonar.sources=apps/android/app/src/main/java
-          -Dsonar.tests=apps/android/app/src/test
-          -Dsonar.java.binaries=apps/android/app/build/tmp/kotlin-classes/debug
-          -Dsonar.coverage.jacoco.xmlReportPaths=apps/android/app/build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
+          -Dsonar.projectBaseDir=apps/android/app
+          -Dsonar.sources=src/main/java
+          -Dsonar.tests=src/test
+          -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
+          -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   frontend-required:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: android-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: frontend-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   changes:
@@ -23,12 +23,6 @@ jobs:
           filters: |
             frontend:
               - 'apps/android/**'
-              - 'gradle/**'
-              - 'gradlew'
-              - 'gradlew.bat'
-              - 'settings.gradle.kts'
-              - 'build.gradle.kts'
-              - '.github/workflows/**'
 
   frontend-build:
     needs: changes

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: frontend-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: android-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   changes:
@@ -23,6 +23,12 @@ jobs:
           filters: |
             frontend:
               - 'apps/android/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - '.github/workflows/**'
 
   frontend-build:
     needs: changes

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,6 +71,7 @@ jobs:
           args: >
             -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
             -Dsonar.organization=se2-gruppenprojekt
+            -Dsonar.projectName="frontend"
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.projectBaseDir=apps/android/app
             -Dsonar.sources=src/main/java

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
               - 'build.gradle.kts'
               - '.github/workflows/**'
 
-  frontend-build-sonar:
+  frontend-build:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -56,15 +56,26 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Run frontend tests + Sonar
-        run: ./gradlew :apps:android:app:testDebugUnitTest sonar
+      - name: Run frontend tests
+        run: ./gradlew :apps:android:app:testDebugUnitTest
+
+      - name: Run frontend Sonar analysis
+        run: >
+          ./gradlew sonar
+          -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
+          -Dsonar.organization=se2-gruppenprojekt
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.sources=apps/android/app/src/main/java
+          -Dsonar.tests=apps/android/app/src/test
+          -Dsonar.java.binaries=apps/android/app/build/tmp/kotlin-classes/debug
+          -Dsonar.coverage.jacoco.xmlReportPaths=apps/android/app/build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   frontend-required:
     name: frontend-required
-    needs: [changes, frontend-build-sonar]
+    needs: [changes, frontend-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -73,9 +84,9 @@ jobs:
         run: echo "No frontend-related changes."
 
       - name: Fail if frontend job failed
-        if: needs.changes.outputs.frontend == 'true' && needs.frontend-build-sonar.result != 'success'
+        if: needs.changes.outputs.frontend == 'true' && needs.frontend-build.result != 'success'
         run: exit 1
 
       - name: Pass if frontend job succeeded
-        if: needs.changes.outputs.frontend == 'true' && needs.frontend-build-sonar.result == 'success'
+        if: needs.changes.outputs.frontend == 'true' && needs.frontend-build.result == 'success'
         run: echo "Frontend checks passed."

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: android-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: frontend-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   changes:
@@ -23,12 +23,6 @@ jobs:
           filters: |
             frontend:
               - 'apps/android/**'
-              - 'gradle/**'
-              - 'gradlew'
-              - 'gradlew.bat'
-              - 'settings.gradle.kts'
-              - 'build.gradle.kts'
-              - '.github/workflows/**'
 
   frontend-build:
     needs: changes
@@ -62,7 +56,8 @@ jobs:
       - name: Run frontend tests
         run: ./gradlew :apps:android:app:testDebugUnitTest
 
-      - name: Run frontend Sonar analysis
+      - name: Run frontend Sonar analysis (PR)
+        if: github.event_name == 'pull_request'
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
@@ -77,6 +72,28 @@ jobs:
             -Dsonar.tests=src/test
             -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
             -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.base_ref }}
+            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+
+      - name: Run frontend Sonar analysis (branch)
+        if: github.event_name != 'pull_request'
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
+            -Dsonar.organization=se2-gruppenprojekt
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.projectBaseDir=apps/android/app
+            -Dsonar.sources=src/main/java
+            -Dsonar.tests=src/test
+            -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
+            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
+            -Dsonar.scm.revision=${{ github.sha }}
 
   frontend-required:
     name: frontend-required

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: frontend-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: android-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   changes:
@@ -23,6 +23,12 @@ jobs:
           filters: |
             frontend:
               - 'apps/android/**'
+              - 'gradle/**'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - '.github/workflows/**'
 
   frontend-build:
     needs: changes
@@ -56,8 +62,7 @@ jobs:
       - name: Run frontend tests
         run: ./gradlew :apps:android:app:testDebugUnitTest
 
-      - name: Run frontend Sonar analysis (PR)
-        if: github.event_name == 'pull_request'
+      - name: Run frontend Sonar analysis
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
@@ -72,28 +77,6 @@ jobs:
             -Dsonar.tests=src/test
             -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
             -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-            -Dsonar.pullrequest.branch=${{ github.head_ref }}
-            -Dsonar.pullrequest.base=${{ github.base_ref }}
-            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
-
-      - name: Run frontend Sonar analysis (branch)
-        if: github.event_name != 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: >
-            -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
-            -Dsonar.organization=se2-gruppenprojekt
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.projectBaseDir=apps/android/app
-            -Dsonar.sources=src/main/java
-            -Dsonar.tests=src/test
-            -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
-            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/testDebugUnitTestCoverage/testDebugUnitTestCoverage.xml
-            -Dsonar.scm.revision=${{ github.sha }}
 
   frontend-required:
     name: frontend-required

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,6 +30,7 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
+              - '.github/workflows/**'
 
   backend-build-sonar:
     needs: changes
@@ -63,23 +64,8 @@ jobs:
       - name: Build backend tests and coverage
         run: ./gradlew :apps:backend:test :apps:backend:jacocoTestReport --info
 
-      - name: Analyze backend with SonarQube (PR)
-        if: github.event_name == 'pull_request'
-        run: >
-          ./gradlew :apps:backend:sonar
-          -Dsonar.qualitygate.wait=true
-          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-          -Dsonar.pullrequest.branch=${{ github.head_ref }}
-          -Dsonar.pullrequest.base=${{ github.base_ref }}
-          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
-          --info
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Analyze backend with SonarQube (branch)
-        if: github.event_name != 'pull_request'
-        run: ./gradlew :apps:backend:sonar -Dsonar.qualitygate.wait=true -Dsonar.scm.revision=${{ github.sha }} --info
+      - name: Analyze backend with SonarQube
+        run: ./gradlew :apps:backend:sonar -Dsonar.qualitygate.wait=true --info
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,7 +30,6 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
-              - '.github/workflows/**'
 
   backend-build-sonar:
     needs: changes

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,6 +30,7 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
+              - '.github/workflows/**'
 
   backend-build-sonar:
     needs: changes

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -30,7 +30,6 @@ jobs:
               - 'gradlew.bat'
               - 'settings.gradle.kts'
               - 'build.gradle.kts'
-              - '.github/workflows/**'
 
   backend-build-sonar:
     needs: changes
@@ -64,8 +63,23 @@ jobs:
       - name: Build backend tests and coverage
         run: ./gradlew :apps:backend:test :apps:backend:jacocoTestReport --info
 
-      - name: Analyze backend with SonarQube
-        run: ./gradlew :apps:backend:sonar -Dsonar.qualitygate.wait=true --info
+      - name: Analyze backend with SonarQube (PR)
+        if: github.event_name == 'pull_request'
+        run: >
+          ./gradlew :apps:backend:sonar
+          -Dsonar.qualitygate.wait=true
+          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+          -Dsonar.pullrequest.branch=${{ github.head_ref }}
+          -Dsonar.pullrequest.base=${{ github.base_ref }}
+          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          --info
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Analyze backend with SonarQube (branch)
+        if: github.event_name != 'pull_request'
+        run: ./gradlew :apps:backend:sonar -Dsonar.qualitygate.wait=true -Dsonar.scm.revision=${{ github.sha }} --info
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -86,4 +86,4 @@ jobs:
 
       - name: Pass if backend job succeeded
         if: needs.changes.outputs.backend == 'true' && needs.backend-build-sonar.result == 'success'
-        run: echo "Backend checks passed."
+        run: echo "Backend checks passed!"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: backend-sonar-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Sets up dedicated SonarCloud analysis for the Android frontend and cleans up the CI scope so frontend checks only target the Android app.

This PR introduces a separate Android/frontend Sonar workflow with its own frontend project key and token, scopes the analysis to the Android app module, and updates the workflow triggers so the frontend pipeline only runs for `apps/android/**` changes. In addition, it narrows the Gradle / Sonar analysis scope by excluding files and folders that are not meaningfully testable in the GitHub workflow or should not count against Android frontend coverage.

## What changed

- added a dedicated Android/frontend SonarCloud workflow
- configured the workflow to use the frontend Sonar project key:
  - `se2-gruppenprojekt_se2-group-codebase_frontend`
- switched frontend Sonar analysis away from the backend/root Sonar task flow
- scoped Sonar analysis to the Android app module only
- restricted the frontend workflow trigger to Android-only changes under `apps/android/**`
- cleaned up analysis/test scope in `build.gradle.kts` so unnecessary Android files/folders are excluded from workflow/Sonar coverage expectations

## Why

Previously, frontend Sonar analysis was mixed into the broader repository setup and effectively behaved like backend/root analysis. That caused confusing results and made it hard to get a clean Android-specific Sonar project and dashboard.

This PR fixes that by:

- giving the Android frontend its own Sonar pipeline
- ensuring the frontend workflow only reacts to Android changes
- reducing false-negative coverage noise from files that are not realistically testable in CI/Sonar for the Android frontend

## Scope

Included:

- Android-specific SonarCloud workflow setup
- Android-only workflow triggering
- frontend Sonar project configuration
- Gradle/Sonar scope cleanup for untestable or irrelevant frontend files

Not included:

- backend Sonar changes
- frontend feature/UI changes
- new Android tests beyond what is needed for CI/Sonar setup

## Result

After this PR:

- the Android frontend has its own SonarCloud analysis path
- frontend CI is no longer triggered by unrelated repository changes
- Sonar coverage expectations are better aligned with what can actually be tested in the Android GitHub workflow
- the project is in a cleaner state for future frontend quality-gate improvements