### PR TITLE
feat(backend)(rules): add BoardValidationService for submitted board state

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/BoardValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/BoardValidationService.kt
@@ -1,0 +1,29 @@
+package at.se2group.backend.rules.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.BoardSet
+import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
+
+@Service
+class BoardValidationService(
+    private val setValidationService: SetValidationService
+) {
+
+    fun validate(boardSets: List<BoardSet>): ValidationResult {
+        val violations = mutableListOf<RuleViolation>()
+
+        boardSets.forEach { set ->
+            val result = setValidationService.validate(set)
+            violations += result.violations
+        }
+
+        return if (violations.isEmpty()) {
+            valid()
+        } else {
+            invalid(violations)
+        }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/BoardValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/BoardValidationService.kt
@@ -2,7 +2,6 @@ package at.se2group.backend.rules.service
 
 import org.springframework.stereotype.Service
 import shared.models.game.domain.BoardSet
-import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
 import shared.models.game.validation.invalid
 import shared.models.game.validation.valid
@@ -13,17 +12,7 @@ class BoardValidationService(
 ) {
 
     fun validate(boardSets: List<BoardSet>): ValidationResult {
-        val violations = mutableListOf<RuleViolation>()
-
-        boardSets.forEach { set ->
-            val result = setValidationService.validate(set)
-            violations += result.violations
-        }
-
-        return if (violations.isEmpty()) {
-            valid()
-        } else {
-            invalid(violations)
-        }
+        val violations = boardSets.flatMap { setValidationService.validate(it).violations }
+        return if (violations.isEmpty()) valid() else invalid(violations)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
@@ -69,13 +69,15 @@ class BoardValidationServiceTest {
     fun `returns invalid when multiple board sets are invalid`() {
         val firstSet = boardSet("set-1", 1)
         val secondSet = boardSet("set-2", 4)
-        whenever(setValidationService.validate(firstSet)).thenReturn(invalid(violation("FIRST_INVALID", "tile-1")))
-        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(violation("SECOND_INVALID", "tile-4")))
+        val firstViolation = violation("FIRST_INVALID", "tile-1")
+        val secondViolation = violation("SECOND_INVALID", "tile-4")
+        whenever(setValidationService.validate(firstSet)).thenReturn(invalid(firstViolation))
+        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(secondViolation))
 
         val result = service.validate(listOf(firstSet, secondSet))
 
         assertFalse(result.isValid)
-        assertEquals(2, result.violations.size)
+        assertEquals(listOf(firstViolation, secondViolation), result.violations)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
@@ -56,21 +56,22 @@ class BoardValidationServiceTest {
     @Test
     fun `returns invalid when one board set is invalid`() {
         val boardSet = boardSet("set-1", 1)
-        val violation = violation("SET_INVALID", "tile-1")
+        val violation = violation("SET_INVALID", "set-1", "tile-1")
         whenever(setValidationService.validate(boardSet)).thenReturn(invalid(violation))
 
         val result = service.validate(listOf(boardSet))
 
         assertFalse(result.isValid)
         assertEquals(listOf(violation), result.violations)
+        assertEquals("set-1", result.violations.single().boardSetId)
     }
 
     @Test
     fun `returns invalid when multiple board sets are invalid`() {
         val firstSet = boardSet("set-1", 1)
         val secondSet = boardSet("set-2", 4)
-        val firstViolation = violation("FIRST_INVALID", "tile-1")
-        val secondViolation = violation("SECOND_INVALID", "tile-4")
+        val firstViolation = violation("FIRST_INVALID", "set-1", "tile-1")
+        val secondViolation = violation("SECOND_INVALID", "set-2", "tile-4")
         whenever(setValidationService.validate(firstSet)).thenReturn(invalid(firstViolation))
         whenever(setValidationService.validate(secondSet)).thenReturn(invalid(secondViolation))
 
@@ -78,15 +79,16 @@ class BoardValidationServiceTest {
 
         assertFalse(result.isValid)
         assertEquals(listOf(firstViolation, secondViolation), result.violations)
+        assertEquals(listOf("set-1", "set-2"), result.violations.map { it.boardSetId })
     }
 
     @Test
     fun `aggregates all violations from invalid sets`() {
         val firstSet = boardSet("set-1", 1)
         val secondSet = boardSet("set-2", 4)
-        val firstViolation = violation("FIRST_INVALID", "tile-1")
-        val secondViolation = violation("SECOND_INVALID", "tile-4")
-        val thirdViolation = violation("THIRD_INVALID", "tile-5")
+        val firstViolation = violation("FIRST_INVALID", "set-1", "tile-1")
+        val secondViolation = violation("SECOND_INVALID", "set-2", "tile-4")
+        val thirdViolation = violation("THIRD_INVALID", "set-2", "tile-5")
         whenever(setValidationService.validate(firstSet)).thenReturn(invalid(firstViolation))
         whenever(setValidationService.validate(secondSet)).thenReturn(invalid(listOf(secondViolation, thirdViolation)))
 
@@ -94,6 +96,7 @@ class BoardValidationServiceTest {
 
         assertFalse(result.isValid)
         assertEquals(listOf(firstViolation, secondViolation, thirdViolation), result.violations)
+        assertEquals(listOf("set-1", "set-2", "set-2"), result.violations.map { it.boardSetId })
     }
 
     @Test
@@ -102,7 +105,7 @@ class BoardValidationServiceTest {
         val secondSet = boardSet("set-2", 4)
         val thirdSet = boardSet("set-3", 7)
         whenever(setValidationService.validate(firstSet)).thenReturn(valid())
-        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(violation("SET_INVALID", "tile-4")))
+        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(violation("SET_INVALID", "set-2", "tile-4")))
         whenever(setValidationService.validate(thirdSet)).thenReturn(valid())
 
         service.validate(listOf(firstSet, secondSet, thirdSet))
@@ -122,11 +125,11 @@ class BoardValidationServiceTest {
             )
         )
 
-    private fun violation(code: String, tileId: String): RuleViolation =
+    private fun violation(code: String, boardSetId: String, tileId: String): RuleViolation =
         RuleViolation(
             code = code,
             message = "$code failed",
-            setIndex = 0,
+            boardSetId = boardSetId,
             tileIds = listOf(tileId)
         )
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
@@ -1,0 +1,130 @@
+package at.se2group.backend.rules.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import shared.models.game.domain.BoardSet
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
+
+class BoardValidationServiceTest {
+
+    private val setValidationService = mock<SetValidationService>()
+    private val service = BoardValidationService(setValidationService)
+
+    @Test
+    fun `returns valid when all board sets are valid`() {
+        val boardSet = boardSet("set-1", 1)
+        whenever(setValidationService.validate(boardSet)).thenReturn(valid())
+
+        val result = service.validate(listOf(boardSet))
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `returns valid for multiple valid board sets`() {
+        val firstSet = boardSet("set-1", 1)
+        val secondSet = boardSet("set-2", 4)
+        whenever(setValidationService.validate(firstSet)).thenReturn(valid())
+        whenever(setValidationService.validate(secondSet)).thenReturn(valid())
+
+        val result = service.validate(listOf(firstSet, secondSet))
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `returns valid for an empty board`() {
+        val result = service.validate(emptyList())
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+        verifyNoInteractions(setValidationService)
+    }
+
+    @Test
+    fun `returns invalid when one board set is invalid`() {
+        val boardSet = boardSet("set-1", 1)
+        val violation = violation("SET_INVALID", "tile-1")
+        whenever(setValidationService.validate(boardSet)).thenReturn(invalid(violation))
+
+        val result = service.validate(listOf(boardSet))
+
+        assertFalse(result.isValid)
+        assertEquals(listOf(violation), result.violations)
+    }
+
+    @Test
+    fun `returns invalid when multiple board sets are invalid`() {
+        val firstSet = boardSet("set-1", 1)
+        val secondSet = boardSet("set-2", 4)
+        whenever(setValidationService.validate(firstSet)).thenReturn(invalid(violation("FIRST_INVALID", "tile-1")))
+        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(violation("SECOND_INVALID", "tile-4")))
+
+        val result = service.validate(listOf(firstSet, secondSet))
+
+        assertFalse(result.isValid)
+        assertEquals(2, result.violations.size)
+    }
+
+    @Test
+    fun `aggregates all violations from invalid sets`() {
+        val firstSet = boardSet("set-1", 1)
+        val secondSet = boardSet("set-2", 4)
+        val firstViolation = violation("FIRST_INVALID", "tile-1")
+        val secondViolation = violation("SECOND_INVALID", "tile-4")
+        val thirdViolation = violation("THIRD_INVALID", "tile-5")
+        whenever(setValidationService.validate(firstSet)).thenReturn(invalid(firstViolation))
+        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(listOf(secondViolation, thirdViolation)))
+
+        val result = service.validate(listOf(firstSet, secondSet))
+
+        assertFalse(result.isValid)
+        assertEquals(listOf(firstViolation, secondViolation, thirdViolation), result.violations)
+    }
+
+    @Test
+    fun `verifies each board set is passed to SetValidationService`() {
+        val firstSet = boardSet("set-1", 1)
+        val secondSet = boardSet("set-2", 4)
+        val thirdSet = boardSet("set-3", 7)
+        whenever(setValidationService.validate(firstSet)).thenReturn(valid())
+        whenever(setValidationService.validate(secondSet)).thenReturn(invalid(violation("SET_INVALID", "tile-4")))
+        whenever(setValidationService.validate(thirdSet)).thenReturn(valid())
+
+        service.validate(listOf(firstSet, secondSet, thirdSet))
+
+        verify(setValidationService).validate(firstSet)
+        verify(setValidationService).validate(secondSet)
+        verify(setValidationService).validate(thirdSet)
+    }
+
+    private fun boardSet(boardSetId: String, firstNumber: Int): BoardSet =
+        BoardSet(
+            boardSetId = boardSetId,
+            tiles = listOf(
+                NumberedTile("tile-$firstNumber", TileColor.RED, firstNumber),
+                NumberedTile("tile-${firstNumber + 1}", TileColor.RED, firstNumber + 1),
+                NumberedTile("tile-${firstNumber + 2}", TileColor.RED, firstNumber + 2)
+            )
+        )
+
+    private fun violation(code: String, tileId: String): RuleViolation =
+        RuleViolation(
+            code = code,
+            message = "$code failed",
+            setIndex = 0,
+            tileIds = listOf(tileId)
+        )
+}


### PR DESCRIPTION
## Summary

Add the next rule-validation layer after `SetValidationService`: a dedicated `BoardValidationService` that validates the full submitted board by iterating over all board sets and aggregating the results.

This PR should stay focused. It should not handle first-move rules, turn-level game context, or end-turn integration yet. It should only answer one question:

> “Is the submitted board valid as a whole, based on validating every set on it?”
> 

According to the current rule-validation design, board validation is the next clean step after set validation. It should mainly orchestrate and aggregate set-level validation across the submitted board.

## Issues

- Related to #286 
- Closes #289 
- Closes #290 
- Closes #291 
- Closes #292 
- Closes #293 
- Related to #309 
- Related to #310 
- Related to #306 

## Why this is the best next step

The previous PRs established the lower validation layers:

- `GroupValidationService`
- `RunValidationService`
- `SetValidationService`

The next clean step is to validate the entire board state by reusing `SetValidationService` for each board set.

This is the smallest useful next integration step because it:

- reuses the set-level validation that already exists
- keeps first-move and turn-level validation out of scope for now
- aligns directly with the documented backend rule-validation flow
- gives later top-level orchestration a clean board-level dependency

So this PR should establish one thing only:

> “The backend can validate the submitted board by validating each set and aggregating the violations.”
> 

## Scope

Included:

- `BoardValidationService`
- iteration over all submitted board sets
- composition of `SetValidationService`
- aggregation of violations across the whole board
- focused unit tests for valid and invalid board combinations

## Validation behavior in this PR

`BoardValidationService` should validate the submitted board like this:

1. iterate over all `BoardSet`s on the board
2. call `SetValidationService.validate(set)` for each one
3. collect all violations from invalid sets
4. return:
    - valid if all sets are valid
    - invalid if one or more sets are invalid

Important rule decision for this PR:

- `BoardValidationService` should not add new game-rule logic of its own
- it should mainly act as an aggregation/orchestration layer on top of `SetValidationService`

## What to implement

### 1. Add `BoardValidationService`

Create a dedicated backend service responsible for validating the submitted board state.

A good method shape is:

```kotlin
fun validate(boardSets: List<BoardSet>): ValidationResult
```

This service should not know how to validate groups or runs directly. It should only delegate each set to `SetValidationService` and aggregate the results.

### 2. Keep the service thin

This service should stay small and compositional.

It should:

- iterate over all board sets
- call `SetValidationService`
- collect violations
- return one final `ValidationResult`

It should not yet:

- calculate first-move points
- inspect player state or game state
- decide whether a submitted turn is legal in full context
- own persistence or commit logic

### 3. Suggested implementation shape

```kotlin
class BoardValidationService(
    private val setValidationService: SetValidationService
) {
    fun validate(boardSets: List<BoardSet>): ValidationResult {
        val violations = mutableListOf<RuleViolation>()

        boardSets.forEach { set ->
            val result = setValidationService.validate(set)
            violations += result.violations
        }

        return if (violations.isEmpty()) {
            ValidationResult.valid()
        } else {
            ValidationResult.invalid(violations = violations)
        }
    }
}
```

This is intentionally small.

The main point of this PR is not to invent new rule logic, but to establish the correct board-level aggregation behavior on top of the set validator that already exists.

### 4. Invalid result behavior

If one or more sets fail validation, `BoardValidationService` should return an invalid result.

A good default for this PR is:

- preserve the individual violations returned by `SetValidationService`
- aggregate them into one final invalid `ValidationResult`
- keep the underlying set-specific context intact

That gives later callers more context about *which* set(s) failed and *why*.

If your current validation model already uses set identifiers or `boardSetId` on violations, make sure those are preserved all the way through aggregation.

## Joker handling

Joker logic should stay explicitly out of scope in this PR.

`BoardValidationService` should not add any new joker-specific behavior. It should simply delegate to `SetValidationService` and use its results as-is.

So if the underlying validators still reject joker-containing sets for now, then `BoardValidationService` should also reject them implicitly through those validator results.

## Tests to include

Add focused unit tests for `BoardValidationService`.

At minimum:

### Valid cases

- returns valid when all board sets are valid
- returns valid for a board with multiple valid sets
- returns valid for an empty board if your rules currently allow an empty board input at this layer

### Invalid cases

- returns invalid when one board set is invalid
- returns invalid when multiple board sets are invalid
- returns all aggregated violations from all invalid sets
- preserves set-specific context such as `boardSetId` / `setIndex` if present in `RuleViolation`

### Delegation / composition behavior

- verifies that each board set is passed to `SetValidationService`
- verifies that the final result is derived from aggregated set results rather than duplicated rule logic inside `BoardValidationService`

If you use mocks/fakes for these tests, keep them simple. The goal is not to retest set-level legality here, but to test the orchestration behavior of `BoardValidationService`.