### PR TITLE
feat(backend)(game)(websocket): add draw tile service with draft sync and websocket updates

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
@@ -37,6 +37,7 @@ fun TileRequest.toTileDomain(): Tile {
 fun TurnDraft.toEntity(existing: TurnDraftEntity): TurnDraftEntity {
     existing.boardSets.clear()
     existing.version = version
+    existing.drawnTile = drawnTile?.toEmbeddable()
 
     val newBoardSets = boardSets.map { set ->
         TurnDraftBoardSetEntity(
@@ -61,6 +62,7 @@ fun TurnDraftEntity.toDomain(): TurnDraft {
     return TurnDraft(
         gameId = gameId,
         playerUserId = playerUserId,
+        drawnTile = drawnTile?.toDomain(),
         boardSets = boardSets.map { set ->
             BoardSet(
                 boardSetId = set.boardSetId,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
@@ -13,6 +13,24 @@ class TurnDraftEntity(
     var version: Long = 0,
 
     @Embedded
+    @AttributeOverrides(
+        AttributeOverride(
+            name = "tileId",
+            column = Column(name = "drawn_tile_id", nullable = true)
+        ),
+        AttributeOverride(
+            name = "color",
+            column = Column(name = "drawn_tile_color", nullable = true)
+        ),
+        AttributeOverride(
+            name = "number",
+            column = Column(name = "drawn_tile_number", nullable = true)
+        ),
+        AttributeOverride(
+            name = "joker",
+            column = Column(name = "drawn_tile_joker", nullable = true)
+        )
+    )
     var drawnTile: TileEmbeddable? = null,
 
     @ElementCollection

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/TurnDraftEntity.kt
@@ -12,6 +12,9 @@ class TurnDraftEntity(
 
     var version: Long = 0,
 
+    @Embedded
+    var drawnTile: TileEmbeddable? = null,
+
     @ElementCollection
     var rackTiles: MutableList<TileEmbeddable> = mutableListOf(),
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
@@ -40,6 +40,7 @@ class DrawTileService(
         const val NOT_ACTIVE_PLAYER = "User is not the active player"
         const val DRAFT_NOT_FOUND = "Draft not found"
         const val NOT_DRAFT_OWNER = "Draft belongs to a different user"
+        const val TILE_ALREADY_DRAWN = "Player has already drawn a tile this turn"
         const val DRAW_PILE_EMPTY = "Draw pile is empty"
     }
 
@@ -60,10 +61,11 @@ class DrawTileService(
 
         check(draftEntity.playerUserId == playerId) { NOT_DRAFT_OWNER }
 
+        val draft = draftEntity.toDraftDomain()
+        check(draft.drawnTile == null) { TILE_ALREADY_DRAWN }
         check(game.drawPile.isNotEmpty()) { DRAW_PILE_EMPTY }
 
         val drawnTile = game.drawPile.first()
-        val draft = draftEntity.toDraftDomain()
 
         val updatedPlayers = game.players.map { player ->
             if (player.userId == playerId) {
@@ -82,6 +84,7 @@ class DrawTileService(
         val updatedDraft = turnDraftRepository.save(
             draft.copy(
                 rackTiles = draft.rackTiles + drawnTile,
+                drawnTile = drawnTile,
                 version = draftEntity.version + 1
             ).toEntity(draftEntity)
         ).toDraftDomain()

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt
@@ -1,8 +1,10 @@
 package at.se2group.backend.service
 
+import at.se2group.backend.mapper.toDomain as toDraftDomain
 import at.se2group.backend.mapper.toDomain
 import at.se2group.backend.mapper.toEntity
 import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.TurnDraftRepository
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.stereotype.Service
 import shared.models.game.domain.ConfirmedGame
@@ -26,7 +28,9 @@ import shared.models.game.domain.GameStatus
 @Service
 class DrawTileService(
     private val gameRepository: GameRepository,
-    private val gameService: GameService
+    private val turnDraftRepository: TurnDraftRepository,
+    private val gameBroadcastService: GameBroadcastService,
+    private val afterCommitExecutor: AfterCommitExecutor
 ) {
 
     private companion object {
@@ -34,6 +38,8 @@ class DrawTileService(
         const val GAME_NOT_ACTIVE = "Game is not active"
         const val PLAYER_NOT_IN_GAME = "Player is not in the game"
         const val NOT_ACTIVE_PLAYER = "User is not the active player"
+        const val DRAFT_NOT_FOUND = "Draft not found"
+        const val NOT_DRAFT_OWNER = "Draft belongs to a different user"
         const val DRAW_PILE_EMPTY = "Draw pile is empty"
     }
 
@@ -49,9 +55,15 @@ class DrawTileService(
 
         check(game.currentPlayerUserId == playerId) { NOT_ACTIVE_PLAYER }
 
+        val draftEntity = turnDraftRepository.findByGameId(gameId)
+            ?: throw NoSuchElementException(DRAFT_NOT_FOUND)
+
+        check(draftEntity.playerUserId == playerId) { NOT_DRAFT_OWNER }
+
         check(game.drawPile.isNotEmpty()) { DRAW_PILE_EMPTY }
 
         val drawnTile = game.drawPile.first()
+        val draft = draftEntity.toDraftDomain()
 
         val updatedPlayers = game.players.map { player ->
             if (player.userId == playerId) {
@@ -60,11 +72,25 @@ class DrawTileService(
                 player
             }
         }
-            val updatedGame = game.copy(
-                players = updatedPlayers,
-                drawPile = game.drawPile.drop(1),
-                currentPlayerUserId = gameService.nextPlayerId(game)
-            )
-            return gameRepository.save(updatedGame.toEntity()).toDomain()
+
+        val updatedGame = game.copy(
+            players = updatedPlayers,
+            drawPile = game.drawPile.drop(1)
+        )
+
+        val savedGame = gameRepository.save(updatedGame.toEntity()).toDomain()
+        val updatedDraft = turnDraftRepository.save(
+            draft.copy(
+                rackTiles = draft.rackTiles + drawnTile,
+                version = draftEntity.version + 1
+            ).toEntity(draftEntity)
+        ).toDraftDomain()
+
+        afterCommitExecutor.execute {
+            gameBroadcastService.broadcastGameUpdated(savedGame)
+            gameBroadcastService.broadcastDraftUpdated(updatedDraft)
+        }
+
+        return savedGame
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -111,7 +111,10 @@ class TurnDraftService(
             candidateDraft = proposedDraft
         )
         val updatedDraft = turnDraftRepository.save(
-            proposedDraft.copy(version = draftEntity.version + 1).toEntity(draftEntity)
+            proposedDraft.copy(
+                version = draftEntity.version + 1,
+                drawnTile = draftEntity.drawnTile?.toDomain()
+            ).toEntity(draftEntity)
         ).toDomain()
 
         afterCommitExecutor.execute {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
@@ -22,6 +22,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.never
+import org.mockito.ArgumentCaptor
 import java.util.Optional
 import java.time.Instant
 
@@ -101,11 +102,13 @@ class DrawTileServiceTest {
         gameId: String = "game-1",
         playerUserId: String = "user-1",
         version: Long = 0,
+        drawnTile: TileEmbeddable? = null,
         rackTiles: MutableList<TileEmbeddable> = mutableListOf(),
     ) = TurnDraftEntity(
         gameId = gameId,
         playerUserId = playerUserId,
         version = version,
+        drawnTile = drawnTile,
         rackTiles = rackTiles
     )
 
@@ -203,6 +206,23 @@ class DrawTileServiceTest {
         }
 
         assertEquals("Draw pile is empty", exception.message)
+    }
+
+    @Test
+    fun `rejects draw when player already drew a tile this turn`() {
+        val entity = gameEntity(drawPile = mutableListOf(tileEmbeddable("tile-2")))
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity(drawnTile = tileEmbeddable("tile-1")))
+
+        val exception = assertThrows<IllegalStateException> {
+            drawTileService.drawTile("game-1", "user-1")
+        }
+
+        assertEquals("Player has already drawn a tile this turn", exception.message)
+        verify(gameRepository, never()).save(any())
+        verify(turnDraftRepository, never()).save(any())
     }
 
     @Test
@@ -305,6 +325,27 @@ class DrawTileServiceTest {
         drawTileService.drawTile("game-1", "user-1")
 
         verify(turnDraftRepository).save(any())
+    }
+
+    @Test
+    fun `persists drawn tile marker on current draft after successful draw`() {
+        val tile = tileEmbeddable("tile-1")
+        val entity = gameEntity(drawPile = mutableListOf(tile))
+        val currentDraft = draftEntity(version = 3)
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(currentDraft)
+        `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        drawTileService.drawTile("game-1", "user-1")
+
+        val captor = ArgumentCaptor.forClass(TurnDraftEntity::class.java)
+        verify(turnDraftRepository).save(captor.capture())
+        assertEquals("tile-1", captor.value.drawnTile?.tileId)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/DrawTileServiceTest.kt
@@ -1,13 +1,16 @@
 package at.se2group.backend.game.service
 
 import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.service.GameBroadcastService
 import at.se2group.backend.service.DrawTileService
+import at.se2group.backend.service.AfterCommitExecutor
 import at.se2group.backend.persistence.GameEntity
 import at.se2group.backend.persistence.GamePlayerEntity
 import at.se2group.backend.persistence.TileEmbeddable
+import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftRepository
 import shared.models.game.domain.GameStatus
 import shared.models.game.domain.TileColor
-import at.se2group.backend.service.GameService
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
@@ -18,6 +21,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.never
 import java.util.Optional
 import java.time.Instant
 
@@ -27,13 +31,22 @@ class DrawTileServiceTest {
     @Mock
     lateinit var gameRepository: GameRepository
 
-    lateinit var gameService: GameService
+    @Mock
+    lateinit var turnDraftRepository: TurnDraftRepository
+
+    @Mock
+    lateinit var gameBroadcastService: GameBroadcastService
+
     lateinit var drawTileService: DrawTileService
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(gameRepository)
-        drawTileService = DrawTileService(gameRepository, gameService)
+        drawTileService = DrawTileService(
+            gameRepository,
+            turnDraftRepository,
+            gameBroadcastService,
+            AfterCommitExecutor()
+        )
     }
 
 
@@ -82,6 +95,18 @@ class DrawTileServiceTest {
         TileColor.RED,
         5,
         false
+    )
+
+    fun draftEntity(
+        gameId: String = "game-1",
+        playerUserId: String = "user-1",
+        version: Long = 0,
+        rackTiles: MutableList<TileEmbeddable> = mutableListOf(),
+    ) = TurnDraftEntity(
+        gameId = gameId,
+        playerUserId = playerUserId,
+        version = version,
+        rackTiles = rackTiles
     )
 
 
@@ -136,10 +161,42 @@ class DrawTileServiceTest {
     }
 
     @Test
+    fun `rejects draw when draft does not exist`() {
+        val entity = gameEntity(drawPile = mutableListOf(tileEmbeddable("tile-1")))
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(null)
+
+        val exception = assertThrows<NoSuchElementException> {
+            drawTileService.drawTile("game-1", "user-1")
+        }
+
+        assertEquals("Draft not found", exception.message)
+    }
+
+    @Test
+    fun `rejects draw when draft belongs to another user`() {
+        val entity = gameEntity(drawPile = mutableListOf(tileEmbeddable("tile-1")))
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity(playerUserId = "user-2"))
+
+        val exception = assertThrows<IllegalStateException> {
+            drawTileService.drawTile("game-1", "user-1")
+        }
+
+        assertEquals("Draft belongs to a different user", exception.message)
+    }
+
+    @Test
     fun `rejects draw when draw pile is empty`() {
         val entity = gameEntity(drawPile = mutableListOf())
         `when`(gameRepository.findById("game-1"))
             .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
 
         val exception = assertThrows<IllegalStateException> {
             drawTileService.drawTile("game-1", "user-1")
@@ -152,9 +209,14 @@ class DrawTileServiceTest {
     fun `draw tile added to active player's rack`() {
         val tile = tileEmbeddable("tile-1")
         val entity = gameEntity(drawPile = mutableListOf(tile))
+        val draftEntity = draftEntity()
         `when`(gameRepository.findById("game-1"))
             .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
         `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
             .thenAnswer { it.arguments[0] }
 
 
@@ -171,9 +233,14 @@ class DrawTileServiceTest {
         val tile1 = tileEmbeddable("tile-1")
         val tile2 = tileEmbeddable("tile-2")
         val entity = gameEntity(drawPile = mutableListOf(tile1, tile2))
+        val draftEntity = draftEntity()
         `when`(gameRepository.findById("game-1"))
             .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
         `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
             .thenAnswer { it.arguments[0] }
 
 
@@ -183,31 +250,21 @@ class DrawTileServiceTest {
     }
 
     @Test
-    fun `turn goes to next player after successful draw`() {
+    fun `current player stays the same after successful draw`() {
         val tile = tileEmbeddable("tile-1")
         val entity = gameEntity(currentPlayerUserId = "user-1", drawPile = mutableListOf(tile))
+        val draftEntity = draftEntity()
         `when`(gameRepository.findById("game-1"))
             .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
         `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
             .thenAnswer { it.arguments[0] }
 
 
         val result = drawTileService.drawTile("game-1", "user-1")
-
-        assertEquals("user-2", result.currentPlayerUserId)
-    }
-
-    @Test
-    fun `turn wraps around to first player after successful last player's draw`() {
-        val tile = tileEmbeddable("tile-1")
-        val entity = gameEntity(currentPlayerUserId = "user-2", drawPile = mutableListOf(tile))
-        `when`(gameRepository.findById("game-1"))
-            .thenReturn(Optional.of(entity))
-        `when`(gameRepository.save(any()))
-            .thenAnswer { it.arguments[0] }
-
-
-        val result = drawTileService.drawTile("game-1", "user-2")
 
         assertEquals("user-1", result.currentPlayerUserId)
     }
@@ -216,14 +273,59 @@ class DrawTileServiceTest {
     fun `persists game after successful draw`() {
         val tile = tileEmbeddable("tile-1")
         val entity = gameEntity(drawPile = mutableListOf(tile))
+        val draftEntity = draftEntity()
         `when`(gameRepository.findById("game-1"))
             .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
         `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
             .thenAnswer { it.arguments[0] }
 
         drawTileService.drawTile("game-1", "user-1")
 
         verify(gameRepository).save(any())
+    }
+
+    @Test
+    fun `updates current draft rack tiles after successful draw`() {
+        val tile = tileEmbeddable("tile-1")
+        val entity = gameEntity(drawPile = mutableListOf(tile))
+        val draftEntity = draftEntity(version = 3)
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
+        `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        drawTileService.drawTile("game-1", "user-1")
+
+        verify(turnDraftRepository).save(any())
+    }
+
+    @Test
+    fun `broadcasts updated game and draft after successful draw`() {
+        val tile = tileEmbeddable("tile-1")
+        val entity = gameEntity(drawPile = mutableListOf(tile))
+        val draftEntity = draftEntity()
+        `when`(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(entity))
+        `when`(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity)
+        `when`(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        `when`(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = drawTileService.drawTile("game-1", "user-1")
+
+        verify(gameBroadcastService).broadcastGameUpdated(result)
+        verify(gameBroadcastService).broadcastDraftUpdated(any())
+        verify(gameBroadcastService, never()).broadcastTurnChanged(any(), any())
     }
 
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
@@ -147,6 +147,7 @@ class TurnDraftMapperTest {
                     )
                 )
             ),
+            drawnTile = numbered("tile-drawn", TileColor.BLUE, 6),
             rackTiles = listOf(joker("tile-3", TileColor.RED)),
             version = 5
         )
@@ -155,6 +156,7 @@ class TurnDraftMapperTest {
 
         assertSame(existing, mapped)
         assertEquals(5, mapped.version)
+        assertEquals("tile-drawn", mapped.drawnTile?.tileId)
         assertEquals(1, mapped.boardSets.size)
         assertEquals("new-set", mapped.boardSets.single().boardSetId)
         assertEquals(BoardSetType.GROUP, mapped.boardSets.single().type)
@@ -167,7 +169,8 @@ class TurnDraftMapperTest {
         val entity = TurnDraftEntity(
             gameId = "game-1",
             playerUserId = "user-1",
-            version = 11
+            version = 11,
+            drawnTile = TileEmbeddable("tile-drawn", TileColor.ORANGE, null, true)
         )
         entity.boardSets.add(
             TurnDraftBoardSetEntity(
@@ -189,6 +192,7 @@ class TurnDraftMapperTest {
         assertEquals("game-1", draft.gameId)
         assertEquals("user-1", draft.playerUserId)
         assertEquals(11, draft.version)
+        assertEquals(joker("tile-drawn", TileColor.ORANGE), draft.drawnTile)
         assertEquals("set-1", draft.boardSets.single().boardSetId)
         assertEquals(BoardSetType.GROUP, draft.boardSets.single().type)
         assertEquals(numbered("tile-1", TileColor.RED, 10), draft.boardSets.single().tiles[0])


### PR DESCRIPTION
## Summary
Refines the backend draw-tile flow so drawing no longer advances the turn immediately.

Instead, the drawn tile is applied to both the confirmed game state and the active player’s live turn draft, both states are persisted consistently, and the updated game/draft state is broadcast after commit. The PR also adds follow-up protection to prevent multiple draws in the same turn and makes the persisted drawn-tile marker nullable on drafts.

## Issues

- Closes #544 
- Closes #540 
- Closes #528 

## What changed
- updated `DrawTileService` so a draw keeps the same active player instead of advancing the turn immediately
- applies the drawn tile to:
  - the confirmed game rack
  - the active player’s current turn draft rack
- persists the updated confirmed game draw pile and rack state
- persists the updated draft and increments the draft version
- broadcasts the updated confirmed game and draft state over websocket after commit
- adds validation around:
  - draft lookup
  - draft ownership
  - stable turn ownership
  - preventing multiple draws in the same turn
- adjusts draw-tile tests to cover the new backend behavior and websocket emission.

## Why
The draw action should update both backend representations of the current turn consistently:
- the confirmed game state
- the active player’s live draft state

Keeping the turn on the same player after drawing aligns better with the intended turn flow, while syncing both persisted states ensures later draft edits and turn submission continue from a consistent backend source of truth.

## Result
After this PR, drawing a tile:
- does not prematurely advance the turn
- updates both confirmed and draft state together
- prevents repeated draws in the same turn
- emits the correct realtime updates for connected clients.