### PR TITLE
feat(backend)(rules): finish top-level submitted-draft validation orchestration

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
@@ -1,10 +1,13 @@
 package at.se2group.backend.rules.service
 
+import at.se2group.backend.service.TileConservationService
 import org.springframework.stereotype.Service
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.TurnDraft
+import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
 import shared.models.game.validation.valid
+import shared.models.game.validation.invalid
 
 /**
  * Top-level orchestration entry point for backend Rummikub rule validation.
@@ -32,7 +35,10 @@ import shared.models.game.validation.valid
  * where top-level validation belongs.
  */
 @Service
-class RummikubRuleService {
+class RummikubRuleService(
+    private val tileConservationService: TileConservationService,
+    private val boardValidationService: BoardValidationService
+) {
 
     /**
      * Validates a submitted draft against the authoritative confirmed game
@@ -61,6 +67,22 @@ class RummikubRuleService {
         actingPlayerUserId: String,
         submittedDraft: TurnDraft
     ): ValidationResult {
-        return valid()
+        val violations = mutableListOf<RuleViolation>()
+
+        try {
+            tileConservationService.validate(confirmedGame, actingPlayerUserId, submittedDraft)
+
+        } catch (e: IllegalArgumentException) {
+            violations += RuleViolation(
+                code = "TILE_CONSERVATION_VIOLATION",
+                message = e.message ?: "Tile conservation check failed"
+            )
+        }
+
+        violations += boardValidationService
+            .validate(submittedDraft.boardSets)
+            .violations
+
+        return if (violations.isEmpty()) valid() else invalid(violations)
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
@@ -69,15 +69,9 @@ class RummikubRuleService(
     ): ValidationResult {
         val violations = mutableListOf<RuleViolation>()
 
-        try {
-            tileConservationService.validate(confirmedGame, actingPlayerUserId, submittedDraft)
-
-        } catch (e: IllegalArgumentException) {
-            violations += RuleViolation(
-                code = "TILE_CONSERVATION_VIOLATION",
-                message = e.message ?: "Tile conservation check failed"
-            )
-        }
+        violations += tileConservationService
+            .validate(confirmedGame, actingPlayerUserId, submittedDraft)
+            .violations
 
         violations += boardValidationService
             .validate(submittedDraft.boardSets)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TileConservationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TileConservationService.kt
@@ -4,6 +4,9 @@ import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.TurnDraft
 import org.springframework.stereotype.Service
 import shared.models.game.domain.Tile
+import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
 
 /**
  * Service responsible for validating that a candidate turn draft conserves the
@@ -34,22 +37,26 @@ class TileConservationService {
      * @param confirmedGame - current game state used to derive the allowed tile multiset
      * @param activePlayerUserId - the unique identifier of the player whose rack tiles are used to create the allowed multiset
      * @param candidateDraft - the proposed turn draft that should be validated
-     * @throws IllegalArgumentException if the proposed turn draft violates the tile conservation rules
      */
 
     fun validate(
         confirmedGame: ConfirmedGame,
         activePlayerUserId: String,
         candidateDraft: TurnDraft
-    ) {
+    ): ValidationResult {
         val allowed = allowedTiles(confirmedGame, activePlayerUserId)
         val candidate = proposedTiles(candidateDraft)
 
         if (allowed != candidate){
             val missingTiles = (allowed - candidate).entries.joinToString { "${it.key} (${it.value})" }
             val extraTiles = (candidate - allowed).entries.joinToString { "${it.key} (${it.value})" }
-            throw IllegalArgumentException("The proposed turn draft violated - missing: [$missingTiles] and extra: [$extraTiles] tile conservation rules!")
+            return invalid(
+                code = "TILE_CONSERVATION_VIOLATION",
+                message = "The proposed turn draft violated - missing: [$missingTiles] and extra: [$extraTiles] tile conservation rules!"
+            )
         }
+
+        return valid()
     }
 
     /**

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -105,11 +105,14 @@ class TurnDraftService(
 
         val proposedDraft = request.toDraftDomain(gameId, userId)
 
-        tileConservationService.validate(
+        val conservationResult = tileConservationService.validate(
             confirmedGame = game,
             activePlayerUserId = userId,
             candidateDraft = proposedDraft
         )
+        require(conservationResult.isValid) {
+            conservationResult.violations.first().message
+        }
         val updatedDraft = turnDraftRepository.save(
             proposedDraft.copy(
                 version = draftEntity.version + 1,

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceUpdateDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceUpdateDraftTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import java.time.Instant
 import java.util.Optional
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
 
 class TurnDraftServiceTest {
 
@@ -73,6 +75,8 @@ class TurnDraftServiceTest {
         whenever(turnDraftRepository.findByGameId("game-1"))
             .thenReturn(draft)
 
+        whenever(tileConservationService.validate(any(), any(), any()))
+            .thenReturn(valid())
         whenever(turnDraftRepository.save(any()))
             .thenReturn(draft)
 
@@ -151,7 +155,8 @@ class TurnDraftServiceTest {
     fun `updateDraft does not persist when tile conservation fails`(){
         whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(gameEntity()))
         whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(TurnDraftEntity(gameId = "game-1", playerUserId = "user-1"))
-        whenever(tileConservationService.validate(any(), any(), any())).thenThrow(IllegalArgumentException("Tile conservation failed!"))
+        whenever(tileConservationService.validate(any(), any(), any()))
+            .thenReturn(invalid("TILE_CONSERVATION_VIOLATION", "Tile conservation failed!"))
 
         runCatching {
             turnDraftService.updateDraft("game-1", "user-1", UpdateDraftRequest(emptyList(), emptyList()))

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TileConservationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TileConservationServiceTest.kt
@@ -11,8 +11,6 @@ import shared.models.game.domain.TileColor
 import shared.models.game.domain.TurnDraft
 import at.se2group.backend.service.TileConservationService
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 
 class TileConservationServiceTest {
@@ -54,22 +52,22 @@ class TileConservationServiceTest {
     @Test
     fun `passes when rack tiles are conserved`() {
         val tiles = listOf(n("tile-1", TileColor.RED, 1), n("tile-2", TileColor.BLUE, 2))
-        assertDoesNotThrow {
-            tileConservationService.validate(
-                game(rackTiles = tiles),
-                "user-1",
-                draft(rackTiles = tiles)
-            )
-        }
+        val result = tileConservationService.validate(
+            game(rackTiles = tiles),
+            "user-1",
+            draft(rackTiles = tiles)
+        )
+
+        assert(result.isValid)
     }
 
     @Test
     fun `passes when tile moved from rack to board`() {
-       val tile = n("tile-3", TileColor.RED, 5)
+        val tile = n("tile-3", TileColor.RED, 5)
         val extra = listOf(n("tile-4", TileColor.BLUE, 3), n("tile-5", TileColor.ORANGE, 4))
         val confirmedGame = game(rackTiles = listOf(tile)+ extra)
         val candidateDraft = draft(boardTiles = listOf(tile) + extra)
-        assertDoesNotThrow { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        assert(tileConservationService.validate(confirmedGame, "user-1", candidateDraft).isValid)
     }
 
     @Test
@@ -78,17 +76,18 @@ class TileConservationServiceTest {
         val extra = listOf(n("tile-7", TileColor.BLUE, 1), n("tile-8", TileColor.RED, 3))
         val confirmedGame = game(boardTiles = listOf(tile) + extra)
         val candidateDraft = draft(rackTiles = listOf(tile) + extra)
-        assertDoesNotThrow { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        assert(tileConservationService.validate(confirmedGame, "user-1", candidateDraft).isValid)
     }
 
     @Test
     fun `rejects when rack tile is missing`() {
-       val tiles = listOf(n("tile-9", TileColor.RED, 1), n("tile-10", TileColor.BLUE, 2))
+        val tiles = listOf(n("tile-9", TileColor.RED, 1), n("tile-10", TileColor.BLUE, 2))
         val confirmedGame = game(rackTiles = tiles)
         val candidateDraft = draft(rackTiles = listOf(n("tile-11", TileColor.RED, 2)))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("missing"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("missing"))
     }
 
     @Test
@@ -97,8 +96,9 @@ class TileConservationServiceTest {
         val rackTile = n("tile-13", TileColor.BLACK, 7)
         val confirmedGame = game(boardTiles = listOf(boardTile), rackTiles = listOf(rackTile))
         val candidateDraft = draft(boardTiles = listOf(boardTile))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
-        assert(exception.message!!.contains("missing"))
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("missing"))
     }
 
     @Test
@@ -106,9 +106,10 @@ class TileConservationServiceTest {
         val tile = n("tile-14", TileColor.RED, 5)
         val confirmedGame = game(rackTiles = listOf(tile))
         val candidateDraft = draft(rackTiles = listOf(tile,tile))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     @Test
@@ -116,9 +117,10 @@ class TileConservationServiceTest {
         val tile = n("tile-15", TileColor.ORANGE, 4)
         val confirmedGame = game(rackTiles = listOf(tile))
         val candidateDraft = draft(boardTiles = listOf(tile),rackTiles = listOf(tile))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
 
     }
 
@@ -127,18 +129,20 @@ class TileConservationServiceTest {
     fun `rejects when draft contains a tile that is not allowed in the game`() {
         val confirmedGame = game(rackTiles = listOf(n("tile-16", TileColor.BLACK, 5)))
         val candidateDraft = draft(rackTiles = listOf(n("tile-17", TileColor.RED, 13)))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     @Test
     fun `rejects when joker is invented in the draft`() {
         val confirmedGame = game(rackTiles = listOf(n("tile-18", TileColor.BLACK, 5)))
         val candidateDraft = draft(rackTiles = listOf(j("tile-19", TileColor.BLUE)))
-        val exception = assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     private fun n(tileId: String, color: TileColor, number: Int) =

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileConservationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileConservationServiceTest.kt
@@ -2,10 +2,7 @@ package at.se2group.backend.lobby.service
 
 import shared.models.game.domain.*
 import at.se2group.backend.service.TileConservationService
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.Instant
 
 class TileConservationServiceTest {
@@ -37,7 +34,7 @@ class TileConservationServiceTest {
     @Test
     fun `passes when rack tiles are conserved`() {
         val tiles = listOf(n("tile-1", TileColor.RED, 1), n("tile-2", TileColor.BLUE, 2))
-        assertDoesNotThrow { tileConservationService.validate(game(rackTiles = tiles), "user-1", draft(rackTiles = tiles)) }
+        assert(tileConservationService.validate(game(rackTiles = tiles), "user-1", draft(rackTiles = tiles)).isValid)
     }
 
     @Test
@@ -46,7 +43,7 @@ class TileConservationServiceTest {
         val extra = listOf(n("tile-4", TileColor.BLUE, 3), n("tile-5", TileColor.ORANGE, 4))
         val confirmedGame = game(rackTiles = listOf(tile)+ extra)
         val candidateDraft = draft(boardTiles = listOf(tile) + extra)
-        assertDoesNotThrow { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        assert(tileConservationService.validate(confirmedGame, "user-1", candidateDraft).isValid)
     }
 
     @Test
@@ -55,7 +52,7 @@ class TileConservationServiceTest {
         val extra = listOf(n("tile-7", TileColor.BLUE, 1), n("tile-8", TileColor.RED, 3))
         val confirmedGame = game(boardTiles = listOf(tile) + extra)
         val candidateDraft = draft(rackTiles = listOf(tile) + extra)
-        assertDoesNotThrow { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        assert(tileConservationService.validate(confirmedGame, "user-1", candidateDraft).isValid)
     }
 
     @Test
@@ -63,9 +60,10 @@ class TileConservationServiceTest {
        val tiles = listOf(n("tile-9", TileColor.RED, 1), n("tile-10", TileColor.BLUE, 2))
         val confirmedGame = game(rackTiles = tiles)
         val candidateDraft = draft(rackTiles = listOf(n("tile-11", TileColor.RED, 2)))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("missing"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("missing"))
     }
 
     @Test
@@ -74,8 +72,9 @@ class TileConservationServiceTest {
         val rackTile = n("tile-13", TileColor.BLACK, 7)
         val confirmedGame = game(boardTiles = listOf(boardTile), rackTiles = listOf(rackTile))
         val candidateDraft = draft(boardTiles = listOf(boardTile))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
-        assert(exception.message!!.contains("missing"))
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("missing"))
     }
 
     @Test
@@ -83,9 +82,10 @@ class TileConservationServiceTest {
         val tile = n("tile-14", TileColor.RED, 5)
         val confirmedGame = game(rackTiles = listOf(tile))
         val candidateDraft = draft(rackTiles = listOf(tile,tile))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     @Test
@@ -93,9 +93,10 @@ class TileConservationServiceTest {
         val tile = n("tile-15", TileColor.ORANGE, 4)
         val confirmedGame = game(rackTiles = listOf(tile))
         val candidateDraft = draft(boardTiles = listOf(tile),rackTiles = listOf(tile))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
 
     }
 
@@ -104,18 +105,20 @@ class TileConservationServiceTest {
     fun `rejects when draft contains a tile that is not allowed in the game`() {
         val confirmedGame = game(rackTiles = listOf(n("tile-16", TileColor.BLACK, 5)))
         val candidateDraft = draft(rackTiles = listOf(n("tile-17", TileColor.RED, 13)))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     @Test
     fun `rejects when joker is invented in the draft`() {
         val confirmedGame = game(rackTiles = listOf(n("tile-18", TileColor.BLACK, 5)))
         val candidateDraft = draft(rackTiles = listOf(j("tile-19", TileColor.BLUE)))
-        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> { tileConservationService.validate(confirmedGame, "user-1", candidateDraft) }
+        val result = tileConservationService.validate(confirmedGame, "user-1", candidateDraft)
 
-        assert(exception.message!!.contains("extra"))
+        assert(!result.isValid)
+        assert(result.violations.single().message.contains("extra"))
     }
 
     private fun n(tileId: String, color: TileColor, number: Int) =

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -9,12 +9,13 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import shared.models.game.domain.*
 import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
 import java.time.Instant
 
 
@@ -56,7 +57,8 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `returns valid when both tile conservation and board validation pass`() {
-        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
 
         val result = ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -70,7 +72,8 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `invokes tile conservation service`() {
-        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
 
         ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -83,7 +86,8 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `invokes board validation service`() {
-        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
 
         ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -96,8 +100,9 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `returns invalid when tile conservation fails`() {
-        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
-        doThrow(IllegalArgumentException("tile mismatch")).whenever(tileConservationService).validate(any(), any(), any())
+        whenever(tileConservationService.validate(any(), any(), any()))
+            .thenReturn(invalid("TILE_CONSERVATION_VIOLATION", "tile mismatch"))
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
 
         val result = ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -112,6 +117,7 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `returns invalid when board validation fails`() {
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
         val boardViolation = RuleViolation(
             code = "RUN_MIN_SIZE",
             message = "Run must have at least 3 tiles",
@@ -133,14 +139,14 @@ class RummikubRuleServiceTest {
 
     @Test
     fun `returns invalid when both tile conservation and board validation fail`() {
+        whenever(tileConservationService.validate(any(), any(), any()))
+            .thenReturn(invalid("TILE_CONSERVATION_VIOLATION", "tile mismatch"))
         val boardViolation = RuleViolation(
             code = "RUN_MIN_SIZE",
             message = "Run must have at least 3 tiles",
         )
         whenever(boardValidationService.validate(any()))
             .thenReturn(ValidationResult(violations = listOf(boardViolation)))
-        doThrow(IllegalArgumentException("tile mismatch"))
-            .whenever(tileConservationService).validate(any(), any(), any())
 
 
         val result = ruleService.validateSubmittedDraft(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -1,34 +1,62 @@
 package at.se2group.backend.rules.service
 
+import at.se2group.backend.service.TileConservationService
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
-import shared.models.game.domain.ConfirmedGame
-import shared.models.game.domain.GamePlayer
-import shared.models.game.domain.GameStatus
-import shared.models.game.domain.TurnDraft
+import org.mockito.junit.jupiter.MockitoExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import shared.models.game.domain.*
+import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.ValidationResult
+import java.time.Instant
 
+
+
+@ExtendWith(MockitoExtension::class)
 class RummikubRuleServiceTest {
 
-    private val ruleService = RummikubRuleService()
+    @Mock
+    lateinit var tileConservationService: TileConservationService
+
+    @Mock
+    lateinit var boardValidationService: BoardValidationService
+
+    private val ruleService by lazy {
+        RummikubRuleService(tileConservationService, boardValidationService)
+    }
+
+    private val player = GamePlayer(
+        userId = "user-1",
+        displayName = "Alice",
+        turnOrder = 0,
+        joinedAt = Instant.now()
+    )
+
+    private val confirmedGame = ConfirmedGame(
+        gameId = "game-1",
+        lobbyId = "lobby-1",
+        players = listOf(player),
+        currentPlayerUserId = "user-1",
+        status = GameStatus.ACTIVE
+    )
+
+    private val submittedDraft = TurnDraft(
+        gameId = "game-1",
+        playerUserId = "user-1"
+    )
+
+
 
     @Test
-    fun `validateSubmittedDraft returns valid empty result for foundation skeleton`() {
-        val player = GamePlayer(
-            userId = "user-1",
-            displayName = "Alice",
-            turnOrder = 0
-        )
-        val confirmedGame = ConfirmedGame(
-            gameId = "game-1",
-            lobbyId = "lobby-1",
-            players = listOf(player),
-            currentPlayerUserId = "user-1",
-            status = GameStatus.ACTIVE
-        )
-        val submittedDraft = TurnDraft(
-            gameId = "game-1",
-            playerUserId = "user-1"
-        )
+    fun `returns valid when both tile conservation and board validation pass`() {
+        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
 
         val result = ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -39,4 +67,95 @@ class RummikubRuleServiceTest {
         assertTrue(result.isValid)
         assertTrue(result.violations.isEmpty())
     }
+
+    @Test
+    fun `invokes tile conservation service`() {
+        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+
+        ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        verify(tileConservationService).validate(confirmedGame, "user-1", submittedDraft)
+    }
+
+    @Test
+    fun `invokes board validation service`() {
+        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+
+        ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        verify(boardValidationService).validate(submittedDraft.boardSets)
+    }
+
+    @Test
+    fun `returns invalid when tile conservation fails`() {
+        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult())
+        doThrow(IllegalArgumentException("tile mismatch")).whenever(tileConservationService).validate(any(), any(), any())
+
+        val result = ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("TILE_CONSERVATION_VIOLATION", result.violations.single().code)
+        assertEquals("tile mismatch", result.violations.single().message)
+    }
+
+    @Test
+    fun `returns invalid when board validation fails`() {
+        val boardViolation = RuleViolation(
+            code = "RUN_MIN_SIZE",
+            message = "Run must have at least 3 tiles",
+        )
+        whenever(boardValidationService.validate(any())).thenReturn(ValidationResult(violations = listOf(boardViolation)))
+
+
+        val result = ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_MIN_SIZE", result.violations.single().code)
+
+    }
+
+
+    @Test
+    fun `returns invalid when both tile conservation and board validation fail`() {
+        val boardViolation = RuleViolation(
+            code = "RUN_MIN_SIZE",
+            message = "Run must have at least 3 tiles",
+        )
+        whenever(boardValidationService.validate(any()))
+            .thenReturn(ValidationResult(violations = listOf(boardViolation)))
+        doThrow(IllegalArgumentException("tile mismatch"))
+            .whenever(tileConservationService).validate(any(), any(), any())
+
+
+        val result = ruleService.validateSubmittedDraft(
+            confirmedGame = confirmedGame,
+            actingPlayerUserId = "user-1",
+            submittedDraft = submittedDraft
+        )
+
+        assertFalse(result.isValid)
+        assertEquals(2, result.violations.size)
+        assertEquals("TILE_CONSERVATION_VIOLATION", result.violations[0].code)
+        assertEquals("RUN_MIN_SIZE", result.violations[1].code)
+
+    }
+
+
+
 }


### PR DESCRIPTION
## Summary

This PR finishes `RummikubRuleService` as the top-level submitted-draft validator. It stays strictly inside the rule layer and does not yet implement the actual end-turn commit flow.

This PR builds directly on the existing validation services:

- `TileConservationService`
- `GroupValidationService`
- `RunValidationService`
- `SetValidationService`
- `BoardValidationService`

The core question for this PR is:

> "Can the backend validate a submitted draft through one top-level rule entry point without committing any game state yet?"

In other words, this PR turns `RummikubRuleService` into the single backend entry point for strict submitted-draft validation, while keeping all actual state mutation for a later end-turn integration PR.

## Issues

- Related to #277 
- Related to #286 
- Closes #287 
- Closes #288 
- Related to #306 
- Closes #307 
- Closes #308 
- Closes #309 
- Related to #310 
- Closes #311 
- Related to #314 
- Related to #363 
- Closes #364 
- Closes #365 
- Closes #366 
- Closes #367 
- Closes #368 
- Closes #370 
- Closes #371 
- Related to #372 

## Scope

Included:

- finish `RummikubRuleService`
- orchestrate tile conservation and board validation
- normalize the top-level validation contract for submitted drafts
- focused rule-service tests

Not included:

- `POST /api/games/{gameId}/end-turn`
- commit from draft to confirmed game
- next-turn draft creation
- websocket emission
- first-move validation
- initial-meld progression

## Main design decisions

### 1. Keep RummikubRuleService orchestration-only

`RummikubRuleService` should coordinate validators. It should not duplicate group, run, set, board, or tile-conservation rule logic.

### 2. Aggregate violations in one top-level result

The rule-validation docs already define the intended top-level shape:

- collect violations from each validator
- return `valid()` when the list stays empty
- return `invalid(violations)` otherwise

For this PR, the same pattern is used, just without first-move validation for now.

### 3. Return a single top-level ValidationResult

The service exposes one submitted-draft validation method that later end-turn code can call directly.

That method is easy for application services to consume:

- input: confirmed game, submitted draft, acting player
- output: one `ValidationResult`
- side effects: none

## Service finished

### RummikubRuleService

Recommended dependencies:

```kotlin
class RummikubRuleService(
    private val tileConservationService: TileConservationService,
    private val boardValidationService: BoardValidationService
)
```

Recommended implementation shape:

```kotlin
fun validateSubmittedDraft(
    confirmedGame: ConfirmedGame,
    submittedDraft: TurnDraft,
    actingPlayer: GamePlayer
): ValidationResult {
    val violations = mutableListOf<RuleViolation>()

    violations += tileConservationService
        .validate(confirmedGame, actingPlayer.userId, submittedDraft)
        .violations

    violations += boardValidationService
        .validate(submittedDraft.boardSets)
        .violations

    return if (violations.isEmpty()) valid() else invalid(violations)
}
```

This keeps the orchestration explicit:

- validate tile integrity against confirmed state
- validate the final submitted board shape
- merge all collected violations into one top-level result

Important points:

- this mirrors the rule-validation docs shape
- first-move validation is the only omitted part for now
- tile conservation and board validation both contribute violations
- the orchestration method stays small and direct

What this service should not do:

- load games or drafts from repositories
- perform ownership or lifecycle checks
- commit state
- emit websocket events

## Tests included

### RummikubRuleServiceTest

- invokes tile conservation service
- invokes board validation service
- returns valid when both layers pass
- returns invalid when tile conservation fails
- returns invalid when board validation fails
- returns invalid when tile conservation and board validation both fail

## Expected outcome

After this PR:

- the backend has one real top-level rule entry point
- submitted-draft validation is no longer a placeholder
- later end-turn integration can depend on `RummikubRuleService` directly
