### PR TITLE
refactor(android)(game): architecture unification and UI turn control

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,25 +59,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Run frontend tests
-        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport
-
-      - name: Run frontend Sonar analysis
-        uses: SonarSource/sonarqube-scan-action@v5
+      - name: Run frontend tests and Sonar analysis
+        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport :apps:android:app:sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: >
-            -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
-            -Dsonar.organization=se2-gruppenprojekt
-            -Dsonar.projectName=frontend
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.projectBaseDir=apps/android/app
-            -Dsonar.sources=src/main/java
-            -Dsonar.tests=src/test
-            -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
-            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacoco.xml
 
   frontend-required:
     name: frontend-required

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,11 +59,26 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Run frontend tests and Sonar analysis
-        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport :apps:android:app:sonar
+      - name: Run frontend tests
+        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport
+
+      - name: Run frontend Sonar analysis
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_ANDROID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=se2-gruppenprojekt_se2-group-codebase_frontend
+            -Dsonar.organization=se2-gruppenprojekt
+            -Dsonar.projectName=frontend
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.projectBaseDir=apps/android/app
+            -Dsonar.sources=src/main/java
+            -Dsonar.tests=src/test/java,src/androidTest/java
+            -Dsonar.java.binaries=build/tmp/kotlin-classes/debug
+            -Dsonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/jacoco.xml
+            -Dsonar.coverage.exclusions=**/*Screen*.kt,**/components/**/*.kt,**/navigation/**/*.kt,**/theme/**/*.kt
 
   frontend-required:
     name: frontend-required

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -173,11 +173,19 @@ sonar {
     properties {
         property("sonar.projectKey", "se2-gruppenprojekt_se2-group-codebase_frontend")
         property("sonar.organization", "se2-gruppenprojekt")
+        property("sonar.projectName", "frontend")
+        property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.sources", "src/main/java")
         property("sonar.tests", "src/test/java, src/androidTest/java")
+        property("sonar.java.binaries", "build/tmp/kotlin-classes/debug")
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacoco.xml")
+
         property(
-            "sonar.coverage.jacoco.xmlReportPaths",
-            "build/reports/jacoco/jacoco.xml"
+            "sonar.coverage.exclusions",
+            "**/*Screen*.kt," +
+            "**/components/**/*.kt," +
+            "**/navigation/**/*.kt," +
+            "**/theme/**/*.kt"
         )
     }
 }

--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
@@ -22,6 +22,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import shared.models.game.domain.BoardSet
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
 import shared.models.game.domain.NumberedTile
 import shared.models.game.domain.TileColor
 
@@ -268,5 +270,106 @@ class GameScreenTest {
         composeRule
             .onNodeWithText("3 Your Tiles")
             .assertExists()
+    }
+
+    // --- player bar ---
+
+    @Test
+    fun gameScreen_showsPlayerBar_whenGameStateHasPlayers() {
+
+        val p1 = GamePlayer(userId = "u1", displayName = "Alice", turnOrder = 0)
+        val p2 = GamePlayer(userId = "u2", displayName = "Bob", turnOrder = 1)
+
+        stateFlow.value = stateFlow.value.copy(
+            gameState = ConfirmedGame(
+                gameId = "g1",
+                lobbyId = "l1",
+                players = listOf(p1, p2),
+                currentPlayerUserId = "u1"
+            )
+        )
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule.onNodeWithTag(GameTestTags.PLAYER_BAR).assertExists()
+        composeRule.onNodeWithText("Alice").assertExists()
+        composeRule.onNodeWithText("Bob").assertExists()
+    }
+
+    @Test
+    fun gameScreen_noPlayerBar_whenGameStateIsNull() {
+
+        stateFlow.value = stateFlow.value.copy(gameState = null)
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule.onNodeWithTag(GameTestTags.HEADER).assertExists()
+        assert(
+            composeRule
+                .onAllNodes(hasTestTag(GameTestTags.PLAYER_BAR))
+                .fetchSemanticsNodes()
+                .isEmpty()
+        )
+    }
+
+    @Test
+    fun gameScreen_activePlayerIsInPlayerBar() {
+
+        val active = GamePlayer(userId = "u1", displayName = "Charlie", turnOrder = 0)
+        val other  = GamePlayer(userId = "u2", displayName = "Dana",    turnOrder = 1)
+
+        stateFlow.value = stateFlow.value.copy(
+            gameState = ConfirmedGame(
+                gameId = "g1",
+                lobbyId = "l1",
+                players = listOf(active, other),
+                currentPlayerUserId = "u1"
+            )
+        )
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule.onNodeWithText("Charlie").assertExists()
+        composeRule.onNodeWithText("Dana").assertExists()
+    }
+
+    // --- ViewModel fallback when callbacks are null ---
+
+    @Test
+    fun gameScreen_callsViewModelOnBack_whenNoCallback() {
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule
+            .onAllNodes(hasClickAction())
+            .onFirst()
+            .performClick()
+
+        verify { viewModel.onUIEvent(GameUIEvent.OnBack) }
+    }
+
+    @Test
+    fun gameScreen_callsViewModelOnSettings_whenNoCallback() {
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule
+            .onNode(hasClickAction() and hasAnyAncestor(hasTestTag(GameTestTags.HEADER)))
+            .onChildren()
+            .filter(hasClickAction())
+            .onLast()
+            .performClick()
+
+        verify { viewModel.onUIEvent(GameUIEvent.OnSettings) }
     }
 }

--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/components/PlayerChipTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/components/PlayerChipTest.kt
@@ -1,0 +1,97 @@
+package at.aau.serg.android.ui.screens.game.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import at.aau.serg.android.ui.theme.ThemeState
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import shared.models.game.domain.GamePlayer
+
+class PlayerChipTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @After
+    fun teardown() {
+        ThemeState.isDarkMode.value = false
+    }
+
+    private val player = GamePlayer(
+        userId = "user-1",
+        displayName = "Alice",
+        turnOrder = 0
+    )
+
+    // --- inactive player ---
+
+    @Test
+    fun playerChip_displaysName_inactive() {
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = false)
+        }
+        composeRule.onNodeWithText("Alice").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerChip_displaysInitial_inactive() {
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = false)
+        }
+        composeRule.onNodeWithText("A").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerChip_rendersDarkMode_inactive() {
+        ThemeState.isDarkMode.value = true
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = false)
+        }
+        composeRule.onNodeWithText("Alice").assertIsDisplayed()
+    }
+
+    // --- active player ---
+
+    @Test
+    fun playerChip_displaysName_active() {
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = true)
+        }
+        composeRule.onNodeWithText("Alice").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerChip_displaysInitial_active() {
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = true)
+        }
+        composeRule.onNodeWithText("A").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerChip_rendersDarkMode_active() {
+        ThemeState.isDarkMode.value = true
+        composeRule.setContent {
+            PlayerChip(player = player, isActive = true)
+        }
+        composeRule.onNodeWithText("Alice").assertIsDisplayed()
+    }
+
+    // --- multiple players side-by-side ---
+
+    @Test
+    fun playerChip_twoChips_bothVisible() {
+        val p1 = GamePlayer(userId = "u1", displayName = "Bob", turnOrder = 0)
+        val p2 = GamePlayer(userId = "u2", displayName = "Carol", turnOrder = 1)
+
+        composeRule.setContent {
+            PlayerChip(player = p1, isActive = true)
+            PlayerChip(player = p2, isActive = false)
+        }
+
+        composeRule.onNodeWithText("Bob").assertIsDisplayed()
+        composeRule.onNodeWithText("Carol").assertIsDisplayed()
+    }
+}

--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/components/TileRowTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/components/TileRowTest.kt
@@ -1,0 +1,101 @@
+package at.aau.serg.android.ui.screens.game.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import org.junit.Rule
+import org.junit.Test
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+
+class TileRowTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val tiles = listOf(
+        NumberedTile("t1", TileColor.RED, 5),
+        NumberedTile("t2", TileColor.BLUE, 7)
+    )
+
+    // --- borderColor branches ---
+
+    @Test
+    fun tileRow_renders_withBorderColor() {
+        composeRule.setContent {
+            TileRow(
+                onEvent = {},
+                tiles = tiles,
+                tileSize = 44,
+                selectedTiles = emptySet(),
+                borderColor = Color.Gray
+            )
+        }
+        composeRule.onRoot().assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRow_renders_withNoBorderColor() {
+        composeRule.setContent {
+            TileRow(
+                onEvent = {},
+                tiles = tiles,
+                tileSize = 44,
+                selectedTiles = emptySet(),
+                borderColor = null
+            )
+        }
+        composeRule.onRoot().assertIsDisplayed()
+    }
+
+    // --- moveHack branches (selectedTiles non-empty, rowId matches / doesn't match) ---
+
+    @Test
+    fun tileRow_renders_selectedTile_differentRow() {
+        val selected = tiles.first()
+        composeRule.setContent {
+            TileRow(
+                onEvent = {},
+                tiles = tiles,
+                tileSize = 44,
+                selectedTiles = setOf(selected),
+                borderColor = Color.Blue,
+                rowId = "row1",
+                selectedRow = "row2"      // moveHack = true
+            )
+        }
+        composeRule.onRoot().assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRow_renders_selectedTile_sameRow() {
+        val selected = tiles.first()
+        composeRule.setContent {
+            TileRow(
+                onEvent = {},
+                tiles = tiles,
+                tileSize = 44,
+                selectedTiles = setOf(selected),
+                borderColor = Color.Blue,
+                rowId = "row1",
+                selectedRow = "row1"      // moveHack = false
+            )
+        }
+        composeRule.onRoot().assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRow_renders_emptyTiles_noBorderColor() {
+        composeRule.setContent {
+            TileRow(
+                onEvent = {},
+                tiles = emptyList(),
+                tileSize = 44,
+                selectedTiles = emptySet(),
+                borderColor = null
+            )
+        }
+        composeRule.onRoot().assertIsDisplayed()
+    }
+}

--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateScreenTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateScreenTest.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import at.aau.serg.android.core.errors.AppError
 import at.aau.serg.android.ui.state.LoadState
 import org.junit.Assert.*
 import org.junit.Rule
@@ -191,5 +193,21 @@ class LobbyCreateScreenTest {
         composeRule
             .onNodeWithTag(LobbyCreateTestTags.CREATE_BUTTON)
             .assertIsEnabled()
+    }
+
+    @Test
+    fun errorState_displaysErrorMessage() {
+        composeRule.setContent {
+            LobbyCreateScreenContent(
+                uiState = LobbyCreateUiState(
+                    loadState = LoadState.Error(AppError.Rest.Network)
+                ),
+                onEvent = {}
+            )
+        }
+
+        composeRule
+            .onNodeWithText("Network error")
+            .assertIsDisplayed()
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/core/network/RetrofitProvider.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/core/network/RetrofitProvider.kt
@@ -8,8 +8,9 @@ import java.util.concurrent.TimeUnit
 object RetrofitProvider {
 
     private val client = OkHttpClient.Builder()
-        .connectTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(10, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
         .build()
 
     val retrofit: Retrofit by lazy {

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/navigation/HomeGraph.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/navigation/HomeGraph.kt
@@ -16,7 +16,9 @@ import at.aau.serg.android.ui.screens.auth.AuthEffect
 import at.aau.serg.android.ui.screens.auth.AuthMode
 import at.aau.serg.android.ui.screens.auth.AuthScreen
 import at.aau.serg.android.ui.screens.auth.AuthViewModel
+import at.aau.serg.android.ui.screens.game.GameEffect
 import at.aau.serg.android.ui.screens.game.GameScreen
+import at.aau.serg.android.ui.screens.game.GameUIEvent
 import at.aau.serg.android.ui.screens.game.GameViewModel
 import at.aau.serg.android.ui.screens.home.HomeEffect
 import at.aau.serg.android.ui.screens.home.HomeScreen
@@ -124,18 +126,31 @@ fun NavGraphBuilder.homeGraph(
             AuthScreen(viewModel = vm)
         }
 
-        composable("${Routes.GAME}/{matchId}") {
+        composable("${Routes.GAME}/{gameId}") {
+            val gameId = it.arguments?.getString("gameId")!!
             val userStore = remember { provider.getStore<User>() }
 
             val vm: GameViewModel = viewModel(
                 factory = GenericViewModelFactory { GameViewModel(userStore) }
             )
 
-            GameScreen(
-                viewModel = vm,
-                onBack = { navController.popBackStack() },
-                onSettings = { navController.navigate(Routes.SETTINGS) }
-            )
+            LaunchedEffect(gameId) {
+                vm.onUIEvent(GameUIEvent.OnLoadGame(gameId))
+            }
+
+            LaunchedEffect(Unit) {
+                vm.effects.collect { effect ->
+                    when (effect) {
+                        GameEffect.NavigateToSettings ->
+                            navController.navigate(Routes.SETTINGS)
+
+                        GameEffect.NavigateBack ->
+                            navController.popBackStack()
+                    }
+                }
+            }
+
+            GameScreen(viewModel = vm)
         }
 
         composable(Routes.CREATE_LOBBY_FANCY) {

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/auth/AuthScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/auth/AuthScreen.kt
@@ -53,64 +53,10 @@ import at.aau.serg.android.ui.components.BackButton
 import at.aau.serg.android.ui.screens.auth.components.SuggestionChip
 import at.aau.serg.android.ui.theme.AuthButtonGradientEnd
 import at.aau.serg.android.ui.theme.AuthButtonGradientStart
-import at.aau.serg.android.ui.theme.AuthColors
-import at.aau.serg.android.ui.theme.AuthDarkBackground
-import at.aau.serg.android.ui.theme.AuthDarkBorderBlue
-import at.aau.serg.android.ui.theme.AuthDarkBorderGreen
-import at.aau.serg.android.ui.theme.AuthDarkBorderPurple
-import at.aau.serg.android.ui.theme.AuthDarkCard
-import at.aau.serg.android.ui.theme.AuthDarkCardBlue
-import at.aau.serg.android.ui.theme.AuthDarkCardGreen
-import at.aau.serg.android.ui.theme.AuthDarkCardPurple
-import at.aau.serg.android.ui.theme.AuthDarkInput
-import at.aau.serg.android.ui.theme.AuthDarkPrimaryText
-import at.aau.serg.android.ui.theme.AuthDarkSecondaryText
 import at.aau.serg.android.ui.theme.AuthGradientEnd
 import at.aau.serg.android.ui.theme.AuthGradientStart
-import at.aau.serg.android.ui.theme.AuthLightBackground
-import at.aau.serg.android.ui.theme.AuthLightBorderBlue
-import at.aau.serg.android.ui.theme.AuthLightBorderGreen
-import at.aau.serg.android.ui.theme.AuthLightBorderPurple
-import at.aau.serg.android.ui.theme.AuthLightCard
-import at.aau.serg.android.ui.theme.AuthLightCardBlue
-import at.aau.serg.android.ui.theme.AuthLightCardGreen
-import at.aau.serg.android.ui.theme.AuthLightCardPurple
-import at.aau.serg.android.ui.theme.AuthLightInput
-import at.aau.serg.android.ui.theme.AuthLightPrimaryText
-import at.aau.serg.android.ui.theme.AuthLightSecondaryText
 import at.aau.serg.android.ui.theme.AccentYellow
-import at.aau.serg.android.ui.theme.ThemeState
-
-
-private fun authColors(darkMode: Boolean): AuthColors = if (darkMode) {
-    AuthColors(
-        background = AuthDarkBackground,
-        card = AuthDarkCard,
-        input = AuthDarkInput,
-        primaryText = AuthDarkPrimaryText,
-        secondaryText = AuthDarkSecondaryText,
-        cardBlue = AuthDarkCardBlue,
-        borderBlue = AuthDarkBorderBlue,
-        cardPurple = AuthDarkCardPurple,
-        borderPurple = AuthDarkBorderPurple,
-        cardGreen = AuthDarkCardGreen,
-        borderGreen = AuthDarkBorderGreen,
-    )
-} else {
-    AuthColors(
-        background = AuthLightBackground,
-        card = AuthLightCard,
-        input = AuthLightInput,
-        primaryText = AuthLightPrimaryText,
-        secondaryText = AuthLightSecondaryText,
-        cardBlue = AuthLightCardBlue,
-        borderBlue = AuthLightBorderBlue,
-        cardPurple = AuthLightCardPurple,
-        borderPurple = AuthLightBorderPurple,
-        cardGreen = AuthLightCardGreen,
-        borderGreen = AuthLightBorderGreen,
-    )
-}
+import at.aau.serg.android.ui.theme.appColors
 
 @Composable
 fun AuthScreen(
@@ -133,8 +79,7 @@ fun AuthScreenContent(
     val validation = uiState.validation
 
     val isValid = validation.isValid
-    val darkMode = ThemeState.isDarkMode.value
-    val colors = authColors(darkMode)
+    val colors = appColors().auth
 
     val titleGradient = Brush.horizontalGradient(listOf(AuthGradientStart, AuthGradientEnd))
     val buttonGradient = Brush.horizontalGradient(listOf(AuthButtonGradientStart, AuthButtonGradientEnd))

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameEffect.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameEffect.kt
@@ -1,0 +1,6 @@
+package at.aau.serg.android.ui.screens.game
+
+sealed class GameEffect {
+    object NavigateToSettings : GameEffect()
+    object NavigateBack : GameEffect()
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import at.aau.serg.android.ui.components.BackButton
 import at.aau.serg.android.ui.screens.game.components.TileRow
 import at.aau.serg.android.ui.screens.game.components.TileRowPlaceholder
-import at.aau.serg.android.ui.theme.ThemeState
+import at.aau.serg.android.ui.theme.appColors
 
 @Composable
 fun GameScreen(
@@ -43,16 +43,12 @@ fun GameScreenContent(
     uiState: GameUiState,
     onEvent: (GameUIEvent) -> Unit
 ) {
-    val dark = ThemeState.isDarkMode.value
-
-    val boardBorder = if (dark) Color.White.copy(alpha = 0.2f) else Color(0xFF86EFAC)
-    val iconBtnBg = if (dark) Color(0xFF334155) else Color(0xFFE2E8F0)
-    val iconBtnTint = if (dark) Color.White else Color(0xFF475569)
+    val c = appColors()
 
     Box(
         Modifier
             .fillMaxSize()
-            .background(if (dark) Color(0xFF0F172A) else Color(0xFFF1F5F9))
+            .background(c.game.background)
             .testTag(GameTestTags.SCREEN)
     ) {
         Column(Modifier.fillMaxSize()) {
@@ -61,7 +57,7 @@ fun GameScreenContent(
             Box(
                 Modifier
                     .fillMaxWidth()
-                    .background(if (dark) Color(0xFF1E293B) else Color.White)
+                    .background(c.game.surface)
                     .padding(12.dp)
                     .testTag(GameTestTags.HEADER)
             ) {
@@ -85,7 +81,7 @@ fun GameScreenContent(
                 Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .background(Color.White)
+                    .background(c.game.background)
             ) {
                 Column(Modifier.fillMaxSize()) {
                     // BOARD
@@ -95,7 +91,7 @@ fun GameScreenContent(
                             .weight(1f)
                             .padding(12.dp)
                             .clip(RoundedCornerShape(16.dp))
-                            .background(if (dark) Color(0xFF1E293B) else Color.White)
+                            .background(c.game.surface)
                             .padding(12.dp)
                             .testTag(GameTestTags.BOARD),
                         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -105,7 +101,7 @@ fun GameScreenContent(
                                 onEvent,
                                 tiles = boardSet.tiles,
                                 tileSize = 60,
-                                borderColor = boardBorder,
+                                borderColor = c.game.boardBorder,
                                 selectedTiles = uiState.selectedTiles,
                                 selectedRow = uiState.activeSelectionRow,
                                 rowId = boardSet.boardSetId,
@@ -126,7 +122,7 @@ fun GameScreenContent(
                     Box(
                         Modifier
                             .fillMaxWidth()
-                            .background(if (dark) Color(0xFF1E293B) else Color.White)
+                            .background(c.game.surface)
                             .padding(16.dp)
                             .testTag(GameTestTags.RACK)
                     ) {
@@ -140,7 +136,7 @@ fun GameScreenContent(
                                 onEvent,
                                 tiles = uiState.rackTiles,
                                 tileSize = 44,
-                                borderColor = boardBorder,
+                                borderColor = c.game.boardBorder,
                                 selectedTiles = uiState.selectedTiles,
                                 selectedRow = uiState.activeSelectionRow,
                                 rowId = null
@@ -164,7 +160,7 @@ fun GameScreenContent(
                                         .height(52.dp)
                                         .testTag(GameTestTags.ACTION_END_TURN),
                                     shape = RoundedCornerShape(14.dp),
-                                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF9D3CFF))
+                                    colors = ButtonDefaults.buttonColors(containerColor = c.game.endTurnButton)
                                 ) {
                                     Icon(Icons.Filled.Check, contentDescription = null, tint = Color.White)
                                     Spacer(Modifier.width(6.dp))
@@ -179,10 +175,10 @@ fun GameScreenContent(
                                     modifier = Modifier
                                         .size(52.dp)
                                         .clip(RoundedCornerShape(14.dp))
-                                        .background(iconBtnBg)
+                                        .background(c.game.iconBtnBg)
                                         .testTag(GameTestTags.ACTION_ADD)
                                 ) {
-                                    Icon(Icons.Filled.Add, contentDescription = "Add", tint = iconBtnTint)
+                                    Icon(Icons.Filled.Add, contentDescription = "Add", tint = c.game.iconBtnTint)
                                 }
 
                                 IconButton(
@@ -193,10 +189,10 @@ fun GameScreenContent(
                                     modifier = Modifier
                                         .size(52.dp)
                                         .clip(RoundedCornerShape(14.dp))
-                                        .background(iconBtnBg)
+                                        .background(c.game.iconBtnBg)
                                         .testTag(GameTestTags.ACTION_RESET)
                                 ) {
-                                    Icon(Icons.Filled.Refresh, contentDescription = "Reset", tint = iconBtnTint)
+                                    Icon(Icons.Filled.Refresh, contentDescription = "Reset", tint = c.game.iconBtnTint)
                                 }
                             }
                         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -97,7 +97,8 @@ fun GameScreenContent(
                     LazyRow(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 10.dp),
+                            .padding(vertical = 10.dp)
+                            .testTag(GameTestTags.PLAYER_BAR),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(players) { player ->

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -28,17 +28,26 @@ import at.aau.serg.android.ui.theme.ThemeState
 
 @Composable
 fun GameScreen(
-    viewModel: GameViewModel = viewModel(),
-    onBack: () -> Unit = {},
-    onSettings: () -> Unit = {}
+    viewModel: GameViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    GameScreenContent(
+        uiState = uiState,
+        onEvent = viewModel::onUIEvent
+    )
+}
+
+@Composable
+fun GameScreenContent(
+    uiState: GameUiState,
+    onEvent: (GameUIEvent) -> Unit
 ) {
     val dark = ThemeState.isDarkMode.value
 
     val boardBorder = if (dark) Color.White.copy(alpha = 0.2f) else Color(0xFF86EFAC)
     val iconBtnBg = if (dark) Color(0xFF334155) else Color(0xFFE2E8F0)
     val iconBtnTint = if (dark) Color.White else Color(0xFF475569)
-
-    val uiState by viewModel.uiState.collectAsState()
 
     Box(
         Modifier
@@ -56,7 +65,7 @@ fun GameScreen(
                     .padding(12.dp)
                     .testTag(GameTestTags.HEADER)
             ) {
-                BackButton(onBack = onBack)
+                BackButton(onBack = { onEvent(GameUIEvent.OnBack) })
 
                 Column(Modifier.align(Alignment.Center)) {
                     Text("Game #4821", fontWeight = FontWeight.Bold)
@@ -65,7 +74,7 @@ fun GameScreen(
 
                 Row(Modifier.align(Alignment.CenterEnd)) {
                     Text("3:45")
-                    IconButton(onClick = onSettings) {
+                    IconButton(onClick = { onEvent(GameUIEvent.OnSettings) }) {
                         Icon(Icons.Default.Settings, null)
                     }
                 }
@@ -78,9 +87,7 @@ fun GameScreen(
                     .weight(1f)
                     .background(Color.White)
             ) {
-
                 Column(Modifier.fillMaxSize()) {
-
                     // BOARD
                     LazyColumn(
                         modifier = Modifier
@@ -95,19 +102,13 @@ fun GameScreen(
                     ) {
                         items(uiState.boardSets) { boardSet ->
                             TileRow(
-                                viewModel = viewModel,
+                                onEvent,
                                 tiles = boardSet.tiles,
                                 tileSize = 60,
                                 borderColor = boardBorder,
                                 selectedTiles = uiState.selectedTiles,
                                 selectedRow = uiState.activeSelectionRow,
                                 rowId = boardSet.boardSetId,
-                                onSelectionChange = { tile, selected, rowId ->
-                                    viewModel.onTileSelected(tile, selected, rowId)
-                                },
-                                onRowClick = { clickedRowId ->
-                                    viewModel.moveTiles(boardSetId = clickedRowId)
-                                }
                             )
                         }
 
@@ -115,7 +116,7 @@ fun GameScreen(
                             item {
                                 TileRowPlaceholder(
                                     tileSize = 60,
-                                    onClick = { viewModel.addRow() }
+                                    onClick = { onEvent(GameUIEvent.AddRow) }
                                 )
                             }
                         }
@@ -136,22 +137,13 @@ fun GameScreen(
                             Spacer(Modifier.height(12.dp))
 
                             TileRow(
-                                viewModel = viewModel,
+                                onEvent,
                                 tiles = uiState.rackTiles,
                                 tileSize = 44,
                                 borderColor = boardBorder,
                                 selectedTiles = uiState.selectedTiles,
                                 selectedRow = uiState.activeSelectionRow,
-                                rowId = null,
-                                onSelectionChange = { tile, selected, rowId ->
-                                    viewModel.onTileSelected(
-                                        tile = tile,
-                                        selected = selected
-                                    )
-                                },
-                                onRowClick = { clickedRowId ->
-                                    viewModel.moveTiles(boardSetId = clickedRowId)
-                                }
+                                rowId = null
                             )
 
                             Spacer(Modifier.height(14.dp))
@@ -164,8 +156,9 @@ fun GameScreen(
 
                                 Button(
                                     onClick = {
-                                        viewModel.endTurn()
+                                        onEvent(GameUIEvent.EndTurn)
                                     },
+                                    enabled = uiState.isActivePlayer,
                                     modifier = Modifier
                                         .weight(1f)
                                         .height(52.dp)
@@ -180,8 +173,9 @@ fun GameScreen(
 
                                 IconButton(
                                     onClick = {
-                                        viewModel.drawTile()
+                                        onEvent(GameUIEvent.DrawTile)
                                     },
+                                    enabled = uiState.isActivePlayer,
                                     modifier = Modifier
                                         .size(52.dp)
                                         .clip(RoundedCornerShape(14.dp))
@@ -193,8 +187,9 @@ fun GameScreen(
 
                                 IconButton(
                                     onClick = {
-                                        viewModel.resetSelection()
+                                        onEvent(GameUIEvent.ResetSelection)
                                     },
+                                    enabled = uiState.isActivePlayer,
                                     modifier = Modifier
                                         .size(52.dp)
                                         .clip(RoundedCornerShape(14.dp))

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -3,6 +3,7 @@ package at.aau.serg.android.ui.screens.game
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -22,19 +23,28 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.aau.serg.android.ui.components.BackButton
+import at.aau.serg.android.ui.screens.game.components.PlayerChip
 import at.aau.serg.android.ui.screens.game.components.TileRow
 import at.aau.serg.android.ui.screens.game.components.TileRowPlaceholder
 import at.aau.serg.android.ui.theme.appColors
 
 @Composable
 fun GameScreen(
-    viewModel: GameViewModel = viewModel()
+    viewModel: GameViewModel = viewModel(),
+    onBack: (() -> Unit)? = null,
+    onSettings: (() -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     GameScreenContent(
         uiState = uiState,
-        onEvent = viewModel::onUIEvent
+        onEvent = { event ->
+            when (event) {
+                GameUIEvent.OnBack -> onBack?.invoke() ?: viewModel.onUIEvent(event)
+                GameUIEvent.OnSettings -> onSettings?.invoke() ?: viewModel.onUIEvent(event)
+                else -> viewModel.onUIEvent(event)
+            }
+        }
     )
 }
 
@@ -54,25 +64,51 @@ fun GameScreenContent(
         Column(Modifier.fillMaxSize()) {
 
             // HEADER
-            Box(
+            Column(
                 Modifier
                     .fillMaxWidth()
                     .background(c.game.surface)
-                    .padding(12.dp)
+                    .padding(horizontal = 12.dp)
+                    .padding(top = 12.dp)
                     .testTag(GameTestTags.HEADER)
             ) {
-                BackButton(onBack = { onEvent(GameUIEvent.OnBack) })
+                Box(Modifier.fillMaxWidth()) {
+                    BackButton(onBack = { onEvent(GameUIEvent.OnBack) })
 
-                Column(Modifier.align(Alignment.Center)) {
-                    Text("Game #4821", fontWeight = FontWeight.Bold)
-                    Text("Round 2 of 3", fontSize = 12.sp)
+                    Column(Modifier.align(Alignment.Center)) {
+                        Text("Game #4821", fontWeight = FontWeight.Bold)
+                        Text("Round 2 of 3", fontSize = 12.sp)
+                    }
+
+                    Row(Modifier.align(Alignment.CenterEnd)) {
+                        Text("3:45")
+                        IconButton(onClick = { onEvent(GameUIEvent.OnSettings) }) {
+                            Icon(Icons.Default.Settings, null)
+                        }
+                    }
                 }
 
-                Row(Modifier.align(Alignment.CenterEnd)) {
-                    Text("3:45")
-                    IconButton(onClick = { onEvent(GameUIEvent.OnSettings) }) {
-                        Icon(Icons.Default.Settings, null)
+                // player bar — sorted by turn order, active player highlighted
+                val players = uiState.gameState?.players.orEmpty()
+                    .sortedBy { it.turnOrder }
+                val currentPlayerId = uiState.gameState?.currentPlayerUserId
+
+                if (players.isNotEmpty()) {
+                    LazyRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(players) { player ->
+                            PlayerChip(
+                                player = player,
+                                isActive = player.userId == currentPlayerId
+                            )
+                        }
                     }
+                } else {
+                    Spacer(Modifier.height(12.dp))
                 }
             }
 

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameTestTags.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameTestTags.kt
@@ -3,6 +3,7 @@ package at.aau.serg.android.ui.screens.game
 object GameTestTags {
     const val SCREEN = "game_screen"
     const val HEADER = "game_header"
+    const val PLAYER_BAR = "game_player_bar"
     const val BOARD = "game_board"
     const val RACK = "game_rack"
     const val ACTION_ADD = "game_action_add"

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUIEvent.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUIEvent.kt
@@ -1,0 +1,24 @@
+package at.aau.serg.android.ui.screens.game
+
+import shared.models.game.domain.Tile
+
+sealed interface GameUIEvent {
+    val requiresActivePlayer: Boolean get() = true
+
+    object AddRow : GameUIEvent
+    object DrawTile : GameUIEvent
+    object ResetSelection : GameUIEvent
+    data class MoveTiles(val rowId: String?) : GameUIEvent
+    data class MoveInSameRow(val rowId: String?, val from: Int, val to: Int) : GameUIEvent
+    data class OnTileSelected(val tile: Tile, val selected: Boolean, val rowId: String?) : GameUIEvent
+    object EndTurn : GameUIEvent
+    data class OnLoadGame(val gameId: String) : GameUIEvent {
+        override val requiresActivePlayer = false
+    }
+    data object OnSettings : GameUIEvent {
+        override val requiresActivePlayer = false
+    }
+    data object OnBack : GameUIEvent {
+        override val requiresActivePlayer = false
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
@@ -15,8 +15,6 @@ data class GameUiState(
     val selectedTiles: Set<Tile> = emptySet(),
     val activeSelectionRow: String? = null,
     val gameState: ConfirmedGame? = null,
-    val winnerUserId: String? = null
-) {
-    val isActivePlayer: Boolean
-        get() = user != null && gameState?.currentPlayerUserId == user.uid
-}
+    val winnerUserId: String? = null,
+    val isActivePlayer: Boolean = false
+)

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
@@ -15,4 +15,7 @@ data class GameUiState(
     val selectedTiles: Set<Tile> = emptySet(),
     val activeSelectionRow: String? = null,
     val gameState: ConfirmedGame? = null
-)
+) {
+    val isActivePlayer: Boolean
+        get() = user != null && gameState?.currentPlayerUserId == user.uid
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -115,8 +115,8 @@ class GameViewModel(
     internal fun onUIEvent(event: GameUIEvent) {
         val state = _uiState.value
         try {
-            if (event.requiresActivePlayer && !state.isActivePlayer) {
-                throw IllegalStateException("You can only perform this action during your turn.")
+            check(!(event.requiresActivePlayer && !state.isActivePlayer)) {
+                "You can only perform this action during your turn."
             }
             when (event) {
                 GameUIEvent.AddRow ->
@@ -323,11 +323,14 @@ class GameViewModel(
             }
             try {
                 val gameState = gameService.drawTile(user.gameId, user.uid).toDomain()
-                applyGameState(gameState)
-                _uiState.update {
-                    it.copy(
+                val player = gameState.players.firstOrNull { it.userId == user.uid }
+                val newTile = player?.rackTiles?.lastOrNull()
+
+                _uiState.update { currentState ->
+                    currentState.copy(
                         loadState = LoadState.Success,
                         gameState = gameState,
+                        rackTiles = if (newTile != null) currentState.rackTiles + newTile else currentState.rackTiles
                     )
                 }
             } catch (e: Throwable) {
@@ -446,7 +449,8 @@ class GameViewModel(
                 }
 
                 is GameEvent.Updated -> {
-                    applyGameState(event.payload.game.toDomain())
+                    if (!_uiState.value.isActivePlayer)
+                        applyGameState(event.payload.game.toDomain())
                 }
 
             }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -140,7 +140,7 @@ class GameViewModel(
         }
     }
 
-    private fun onTileSelected(tile: Tile, selected: Boolean, rowId: String? = null) {
+    private fun onTileSelected(tile: Tile, selected: Boolean, rowId: String?) {
         _uiState.update { state ->
             val currentRow = state.activeSelectionRow
             val selectedTiles = state.selectedTiles.toMutableSet()
@@ -189,7 +189,7 @@ class GameViewModel(
         sendTurnDraft()
     }
 
-    private fun moveTiles(boardSetId: String? = null) {
+    private fun moveTiles(boardSetId: String?) {
         _uiState.update { state ->
             val selected = state.selectedTiles
             if (selected.isEmpty()) return@update state

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.android.ui.screens.game
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.aau.serg.android.core.datastore.ProtoStore
@@ -11,9 +12,12 @@ import at.aau.serg.android.core.network.mapper.toDomain
 import at.aau.serg.android.core.network.mapper.toRequest
 import at.aau.serg.android.datastore.proto.User
 import at.aau.serg.android.ui.state.LoadState
+import at.aau.serg.android.ui.util.ErrorUiMapper
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import shared.models.game.domain.BoardSet
@@ -28,27 +32,28 @@ class GameViewModel(
     private val userStore: ProtoStore<User>,
     private val gameService: GameService = GameService(
         RetrofitProvider.retrofit.create(GameAPI::class.java)
-    ),
+    )
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(GameUiState())
     val uiState: StateFlow<GameUiState> = _uiState
+
+    private val _effect = MutableSharedFlow<GameEffect>()
+    val effects: SharedFlow<GameEffect> = _effect.asSharedFlow()
 
     init {
         viewModelScope.launch {
             userStore.data.collect { user ->
                 _uiState.update { it.copy(user = user) }
-                loadGame()
             }
         }
     }
 
-    fun applyGameState(game: ConfirmedGame) {
-        val currentUserId = _uiState.value.user?.uid
-
+    @VisibleForTesting
+    internal fun applyGameState(game: ConfirmedGame) {
+        val user = uiState.value.user ?: throw IllegalStateException("User must not be null when applyGameState is called.")
         val newRack = game.players
-            .firstOrNull { it.userId == currentUserId }
+            .firstOrNull { it.userId == user.uid }
             ?.rackTiles ?: emptyList()
-
         val newBoard = game.boardSets
 
         _uiState.update { old ->
@@ -60,15 +65,67 @@ class GameViewModel(
         }
     }
 
-    fun loadGame() {
+    @VisibleForTesting
+    internal fun onUIEvent(event: GameUIEvent) {
+        val state = _uiState.value
+        try {
+            if (event.requiresActivePlayer && !state.isActivePlayer) {
+                throw IllegalStateException("You can only perform this action during your turn.")
+            }
+            when (event) {
+                GameUIEvent.AddRow ->
+                    addRow()
+                GameUIEvent.DrawTile ->
+                    drawTile()
+                GameUIEvent.EndTurn ->
+                    endTurn()
+                is GameUIEvent.MoveInSameRow -> {
+                    moveInSameRow(
+                        srcRowId = event.rowId,
+                        from = event.from,
+                        to = event.to
+                    )
+                }
+                is GameUIEvent.MoveTiles -> moveTiles(event.rowId)
+                is GameUIEvent.OnLoadGame -> {
+                    loadGame(event.gameId)
+                }
+                is GameUIEvent.OnTileSelected -> {
+                    onTileSelected(
+                        tile = event.tile,
+                        selected = event.selected,
+                        rowId = event.rowId
+                    )
+                }
+                GameUIEvent.ResetSelection -> resetSelection()
+                GameUIEvent.OnSettings -> {
+                    viewModelScope.launch {
+                        _effect.emit(GameEffect.NavigateToSettings)
+                    }
+                }
+                GameUIEvent.OnBack -> {
+                    viewModelScope.launch {
+                        _effect.emit(GameEffect.NavigateBack)
+                    }
+                }
+            }
+        } catch (e : Exception) {
+            val appError = ErrorUiMapper.map(e)
+
+            _uiState.update {
+                it.copy(loadState = LoadState.Error(appError))
+            }
+        }
+    }
+
+    private fun loadGame(gameId: String) {
         viewModelScope.launch {
             _uiState.update {
                 it.copy(loadState = LoadState.Loading)
             }
-            val user = userStore.data.first()
 
             try {
-                val gameState = gameService.loadGame(user.gameId).toDomain()
+                val gameState = gameService.loadGame(gameId).toDomain()
                 applyGameState(gameState)
                 _uiState.update {
                     it.copy(loadState = LoadState.Success)
@@ -83,7 +140,7 @@ class GameViewModel(
         }
     }
 
-    fun onTileSelected(tile: Tile, selected: Boolean, rowId: String? = null) {
+    private fun onTileSelected(tile: Tile, selected: Boolean, rowId: String? = null) {
         _uiState.update { state ->
             val currentRow = state.activeSelectionRow
             val selectedTiles = state.selectedTiles.toMutableSet()
@@ -104,7 +161,7 @@ class GameViewModel(
         }
     }
 
-    fun addRow() {
+    private fun addRow() {
         _uiState.update { state ->
             val selected = state.selectedTiles
 
@@ -132,7 +189,7 @@ class GameViewModel(
         sendTurnDraft()
     }
 
-    fun moveTiles(boardSetId: String? = null) {
+    private fun moveTiles(boardSetId: String? = null) {
         _uiState.update { state ->
             val selected = state.selectedTiles
             if (selected.isEmpty()) return@update state
@@ -170,7 +227,7 @@ class GameViewModel(
         sendTurnDraft()
     }
 
-    fun moveInSameRow(srcRowId: String?, from: Int, to: Int) {
+    private fun moveInSameRow(srcRowId: String?, from: Int, to: Int) {
         _uiState.update { state ->
             val (list, boardIndex) = if (srcRowId == null) {
                 state.rackTiles.toMutableList() to null
@@ -196,24 +253,26 @@ class GameViewModel(
         sendTurnDraft()
     }
 
-    fun resetSelection() {
-        _uiState.value.gameState?.let { applyGameState(it) }
+    @VisibleForTesting
+    internal fun resetSelection() {
+        val gameState = _uiState.value.gameState ?: throw IllegalStateException("GameState must not be null resetBoard is attempted.")
+        applyGameState(gameState)
         _uiState.update { state ->
             state.copy(
                 selectedTiles = emptySet(),
                 activeSelectionRow = null
             )
         }
-        println("RESET clicked")
+        sendTurnDraft()
     }
 
-    fun drawTile() {
+    @VisibleForTesting
+    internal fun drawTile() {
         viewModelScope.launch {
+            val user = uiState.value.user ?: throw IllegalStateException("User must not be null when drawTile is called.")
             _uiState.update {
                 it.copy(loadState = LoadState.Loading)
             }
-            val user = userStore.data.first()
-
             try {
                 val gameState = gameService.drawTile(user.gameId, user.uid).toDomain()
                 applyGameState(gameState)
@@ -233,12 +292,13 @@ class GameViewModel(
         }
     }
 
-    fun endTurn() {
+    @VisibleForTesting
+    internal fun endTurn() {
         viewModelScope.launch {
+            val user = uiState.value.user ?: throw IllegalStateException("User must not be null when endTurn is called.")
             _uiState.update {
                 it.copy(loadState = LoadState.Loading)
             }
-            val user = userStore.data.first()
 
             try {
                 val gameState = gameService.endTurn(
@@ -264,9 +324,10 @@ class GameViewModel(
         }
     }
 
-    fun sendTurnDraft() {
+    @VisibleForTesting
+    internal fun sendTurnDraft() {
         viewModelScope.launch {
-            val user = userStore.data.first()
+            val user = uiState.value.user ?: throw IllegalStateException("User must not be null when sendTurnDraft is called.")
 
             _uiState.update {
                 it.copy(loadState = LoadState.Success
@@ -292,7 +353,8 @@ class GameViewModel(
         }
     }
 
-    fun setUiStateForTest(state: GameUiState) {
+    @VisibleForTesting
+    internal fun setUiStateForTest(state: GameUiState) {
         _uiState.value = state
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -54,7 +54,6 @@ class GameViewModel(
         viewModelScope.launch {
             userStore.data.collect { user ->
                 _uiState.update { it.copy(user = user) }
-                loadGame(user.gameId)
             }
         }
     }
@@ -74,7 +73,7 @@ class GameViewModel(
     }
 
     @VisibleForTesting
-    internal fun applyGameState(game: ConfirmedGame) {
+    internal fun applyGameState(game: ConfirmedGame, refreshView: Boolean) {
         val user = _uiState.value.user
             ?: throw IllegalStateException("User must not be null when applyGameState is called.")
 
@@ -88,8 +87,9 @@ class GameViewModel(
         _uiState.update { old ->
             old.copy(
                 gameState = game,
-                rackTiles = mergedRack,
-                boardSets = game.boardSets
+                rackTiles = if (refreshView) mergedRack else old.rackTiles,
+                boardSets = if (refreshView) game.boardSets else old.boardSets,
+                isActivePlayer = game.currentPlayerUserId == user.uid
             )
         }
     }
@@ -165,19 +165,17 @@ class GameViewModel(
     }
 
     private fun loadGame(gameId: String) {
-        val user = _uiState.value.user
-            ?: throw IllegalStateException("User must not be null when loadGame is called.")
         viewModelScope.launch {
             _uiState.update {
                 it.copy(loadState = LoadState.Loading)
             }
             try {
                 val gameState = gameService.loadGame(gameId).toDomain()
-                applyGameState(gameState)
+                applyGameState(gameState, true)
                 _uiState.update {
                     it.copy(loadState = LoadState.Success)
                 }
-                startSocket(user.gameId)
+                startSocket(gameId)
             } catch (e: Throwable) {
                 val appError = NetworkErrorMapper.map(e)
 
@@ -304,7 +302,7 @@ class GameViewModel(
     @VisibleForTesting
     internal fun resetSelection() {
         val gameState = _uiState.value.gameState ?: throw IllegalStateException("GameState must not be null resetBoard is attempted.")
-        applyGameState(gameState)
+        applyGameState(gameState, true)
         _uiState.update { state ->
             state.copy(
                 selectedTiles = emptySet(),
@@ -325,11 +323,10 @@ class GameViewModel(
                 val gameState = gameService.drawTile(user.gameId, user.uid).toDomain()
                 val player = gameState.players.firstOrNull { it.userId == user.uid }
                 val newTile = player?.rackTiles?.lastOrNull()
-
+                applyGameState(gameState, false)
                 _uiState.update { currentState ->
                     currentState.copy(
                         loadState = LoadState.Success,
-                        gameState = gameState,
                         rackTiles = if (newTile != null) currentState.rackTiles + newTile else currentState.rackTiles
                     )
                 }
@@ -427,15 +424,13 @@ class GameViewModel(
                 }
 
                 is GameEvent.TurnChanged -> {
-                    val newPlayerId = event.payload.currentTurnPlayerId
-                    _uiState.update { state ->
-                        val updatedGameState = state.gameState?.let { game ->
-                            if (game.players.any { it.userId == newPlayerId }) {
-                                game.copy(currentPlayerUserId = newPlayerId)
-                            } else game
+                    _uiState.value.gameState?.let { game ->
+                        if (game.players.any { it.userId == event.payload.currentTurnPlayerId }) {
+                            val updated = game.copy(currentPlayerUserId = event.payload.currentTurnPlayerId)
+                            applyGameState(updated, false)
                         }
-                        state.copy(gameState = updatedGameState)
                     }
+                    _uiState.value
                 }
 
                 is GameEvent.TurnTimedOut -> {
@@ -450,7 +445,7 @@ class GameViewModel(
 
                 is GameEvent.Updated -> {
                     if (!_uiState.value.isActivePlayer)
-                        applyGameState(event.payload.game.toDomain())
+                        applyGameState(event.payload.game.toDomain(), true)
                 }
 
             }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/PlayerChip.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/PlayerChip.kt
@@ -1,0 +1,105 @@
+package at.aau.serg.android.ui.screens.game.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import at.aau.serg.android.ui.theme.AccentGreen
+import at.aau.serg.android.ui.theme.AccentPurple
+import at.aau.serg.android.ui.theme.appColors
+import shared.models.game.domain.GamePlayer
+
+@Composable
+fun PlayerChip(
+    player: GamePlayer,
+    isActive: Boolean
+) {
+    val c = appColors()
+
+    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+    val pulseScale by infiniteTransition.animateFloat(
+        initialValue = 0.7f,
+        targetValue = 1.3f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(700, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "pulse_scale"
+    )
+
+    val chipBg = if (isActive) AccentPurple.copy(alpha = 0.18f) else Color.Transparent
+    val chipBorder = if (isActive) AccentPurple.copy(alpha = 0.55f) else c.game.boardBorder
+    val avatarBg = if (isActive) AccentPurple.copy(alpha = 0.85f) else c.game.iconBtnBg
+    val avatarTextColor = if (isActive) Color.White else c.game.iconBtnTint
+    val nameColor = if (isActive) MaterialTheme.colorScheme.onSurface else c.game.iconBtnTint
+    val nameFontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal
+
+    Row(
+        modifier = Modifier
+            .background(chipBg, RoundedCornerShape(50.dp))
+            .border(1.dp, chipBorder, RoundedCornerShape(50.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        // avatar circle with pulsing dot overlay for active player
+        Box(modifier = Modifier.size(22.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .background(avatarBg, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = player.displayName.first().uppercaseChar().toString(),
+                    color = avatarTextColor,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            if (isActive) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .align(Alignment.BottomEnd)
+                        .graphicsLayer {
+                            scaleX = pulseScale
+                            scaleY = pulseScale
+                        }
+                        .background(AccentGreen, CircleShape)
+                        .border(1.dp, Color.White, CircleShape)
+                )
+            }
+        }
+
+        Text(
+            text = player.displayName,
+            color = nameColor,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = nameFontWeight,
+            maxLines = 1
+        )
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/TileRow.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/TileRow.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
-import at.aau.serg.android.ui.screens.game.GameViewModel
+import at.aau.serg.android.ui.screens.game.GameUIEvent
 import shared.models.game.domain.Tile
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import sh.calvin.reorderable.*
@@ -22,19 +22,17 @@ import sh.calvin.reorderable.*
 
 @Composable
 fun TileRow(
-    viewModel: GameViewModel,
+    onEvent: (GameUIEvent) -> Unit,
     tiles: List<Tile>,
     tileSize: Int,
     selectedTiles: Set<Tile>,
     selectedRow: String? = null,
     borderColor: Color? = null,
-    rowId: String? = null,
-    onSelectionChange: (Tile, Boolean, String?) -> Unit,
-    onRowClick: (String?) -> Unit
+    rowId: String? = null
 ) {
     val lazyListState = rememberLazyListState()
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
-        viewModel.moveInSameRow(rowId, from.index, to.index)
+        onEvent(GameUIEvent.MoveInSameRow(rowId, from.index, to.index))
     }
     val shape = RoundedCornerShape(12.dp)
 
@@ -48,7 +46,7 @@ fun TileRow(
                 Modifier
             }
         )
-        .clickable { onRowClick(rowId) }
+        .clickable { onEvent(GameUIEvent.MoveTiles(rowId)) }
         .padding(8.dp)
 
     LazyRow(
@@ -70,10 +68,10 @@ fun TileRow(
                     selected = it in selectedTiles,
                     moveHack = selectedTiles.isNotEmpty() && rowId != selectedRow,
                     onSelectedChange = { selected ->
-                        onSelectionChange(it, selected, rowId)
+                        onEvent(GameUIEvent.OnTileSelected(it, selected, rowId))
                     },
                     onMoveRequest = {
-                        onRowClick(rowId)
+                        onEvent(GameUIEvent.MoveTiles(rowId))
                     },
                     modifier = Modifier
                         .longPressDraggableHandle()

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/home/HomeScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Person
@@ -94,6 +96,7 @@ fun HomeScreenContent(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 28.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/browse/LobbyBrowseScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/browse/LobbyBrowseScreen.kt
@@ -78,131 +78,132 @@ fun LobbyBrowseScreenContent(
             .testTag(LobbyBrowseTestTags.SCREEN)
             .fillMaxSize()
             .background(backgroundGradient)
-            .padding(16.dp)
+            .padding(horizontal = 16.dp)
     ) {
-        TopBar(
-            subtitle = "Available Lobbies",
-            onBack = { onEvent(LobbyBrowseEvent.OnBack) },
-            onSettings = { onEvent(LobbyBrowseEvent.OnSettings) },
-            backButtonModifier = Modifier.testTag(LobbyBrowseTestTags.BACK_BUTTON),
-            titleModifier = Modifier.testTag(LobbyBrowseTestTags.TITLE),
-            subtitleModifier = Modifier.testTag(LobbyBrowseTestTags.SUBTITLE),
-            settingsButtonModifier = Modifier.testTag(LobbyBrowseTestTags.SETTINGS_BUTTON)
-        )
-
-        Spacer(modifier = Modifier.height(18.dp))
-
-        // direct join row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            OutlinedTextField(
-                value = uiState.lobbyIdInput,
-                onValueChange = { onEvent(LobbyBrowseEvent.OnLobbyIdChanged(it)) },
-                modifier = Modifier
-                    .weight(1f)
-                    .testTag(LobbyBrowseTestTags.LOBBY_ID_INPUT),
-                singleLine = true,
-                label = { Text("Lobby ID", color = c.screen.secondaryText) },
-                placeholder = { Text("Enter lobby ID to join...", color = c.screen.secondaryText) },
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.Tag,
-                        contentDescription = null,
-                        tint = c.screen.secondaryText
-                    )
-                },
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    capitalization = KeyboardCapitalization.Characters,
-                    imeAction = ImeAction.Done
-                ),
-                shape = RoundedCornerShape(18.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = c.screen.primaryText,
-                    unfocusedTextColor = c.screen.primaryText,
-                    focusedContainerColor = c.screen.card,
-                    unfocusedContainerColor = c.screen.card,
-                    focusedBorderColor = c.screen.cardBorder,
-                    unfocusedBorderColor = c.screen.cardBorder
-                )
-            )
-
-            Button(
-                onClick = { onEvent(LobbyBrowseEvent.OnJoinLobby(enteredLobbyId)) },
-                enabled = enteredLobbyId.isNotEmpty(),
-                shape = RoundedCornerShape(16.dp),
-                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = c.screen.actionButton,
-                    contentColor = Color.White
-                ),
-                modifier = Modifier.testTag(LobbyBrowseTestTags.JOIN_BUTTON)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.PersonAdd,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Join", fontWeight = FontWeight.Bold)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(18.dp))
-
-        // list header
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = "Open Games",
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.88f)
-            )
-            Text(
-                text = "${uiState.lobbies.size} available",
-                style = MaterialTheme.typography.labelMedium,
-                color = c.screen.secondaryText
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        if (uiState.loadState == LoadState.Loading) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 24.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(color = AccentPurple)
-            }
-        }
-
-        when (val state = uiState.loadState) {
-            is LoadState.Error -> {
-                Text(
-                    text = ErrorUiMapper.toMessage(state.error),
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(bottom = 12.dp)
-                )
-            }
-
-            else -> Unit
-        }
-
         // lobby list
         LazyColumn(
             modifier = Modifier
                 .weight(1f)
                 .testTag(LobbyBrowseTestTags.LOBBY_LIST),
+            contentPadding = PaddingValues(vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            item {
+                TopBar(
+                    subtitle = "Available Lobbies",
+                    onBack = { onEvent(LobbyBrowseEvent.OnBack) },
+                    onSettings = { onEvent(LobbyBrowseEvent.OnSettings) },
+                    backButtonModifier = Modifier.testTag(LobbyBrowseTestTags.BACK_BUTTON),
+                    titleModifier = Modifier.testTag(LobbyBrowseTestTags.TITLE),
+                    subtitleModifier = Modifier.testTag(LobbyBrowseTestTags.SUBTITLE),
+                    settingsButtonModifier = Modifier.testTag(LobbyBrowseTestTags.SETTINGS_BUTTON)
+                )
+            }
+
+            // direct join row
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = uiState.lobbyIdInput,
+                        onValueChange = { onEvent(LobbyBrowseEvent.OnLobbyIdChanged(it)) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .testTag(LobbyBrowseTestTags.LOBBY_ID_INPUT),
+                        singleLine = true,
+                        label = { Text("Lobby ID", color = c.screen.secondaryText) },
+                        placeholder = { Text("Enter lobby ID to join...", color = c.screen.secondaryText) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Filled.Tag,
+                                contentDescription = null,
+                                tint = c.screen.secondaryText
+                            )
+                        },
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            capitalization = KeyboardCapitalization.Characters,
+                            imeAction = ImeAction.Done
+                        ),
+                        shape = RoundedCornerShape(18.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = c.screen.primaryText,
+                            unfocusedTextColor = c.screen.primaryText,
+                            focusedContainerColor = c.screen.card,
+                            unfocusedContainerColor = c.screen.card,
+                            focusedBorderColor = c.screen.cardBorder,
+                            unfocusedBorderColor = c.screen.cardBorder
+                        )
+                    )
+
+                    Button(
+                        onClick = { onEvent(LobbyBrowseEvent.OnJoinLobby(enteredLobbyId)) },
+                        enabled = enteredLobbyId.isNotEmpty(),
+                        shape = RoundedCornerShape(16.dp),
+                        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = c.screen.actionButton,
+                            contentColor = Color.White
+                        ),
+                        modifier = Modifier.testTag(LobbyBrowseTestTags.JOIN_BUTTON)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.PersonAdd,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Join", fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+
+            // list header
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "Open Games",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.88f)
+                    )
+                    Text(
+                        text = "${uiState.lobbies.size} available",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = c.screen.secondaryText
+                    )
+                }
+            }
+
+            if (uiState.loadState == LoadState.Loading) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = AccentPurple)
+                    }
+                }
+            }
+
+            if (uiState.loadState is LoadState.Error) {
+                item {
+                    Text(
+                        text = ErrorUiMapper.toMessage((uiState.loadState as LoadState.Error).error),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(bottom = 4.dp)
+                    )
+                }
+            }
+
             items(uiState.lobbies) { lobby ->
                 LobbyBrowseCard(
                     lobby = lobby,
@@ -212,13 +213,7 @@ fun LobbyBrowseScreenContent(
                     onJoinLobby = { onEvent(LobbyBrowseEvent.OnJoinLobby(it)) }
                 )
             }
-
-            item {
-                Spacer(modifier = Modifier.height(8.dp))
-            }
         }
-
-        Spacer(modifier = Modifier.height(14.dp))
 
         // create button
         Button(
@@ -226,6 +221,7 @@ fun LobbyBrowseScreenContent(
             modifier = Modifier
                 .testTag(LobbyBrowseTestTags.CREATE_BUTTON)
                 .fillMaxWidth()
+                .padding(vertical = 14.dp)
                 .height(58.dp),
             shape = RoundedCornerShape(18.dp),
             colors = ButtonDefaults.buttonColors(

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/browse/components/LobbyBrowseCard.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/browse/components/LobbyBrowseCard.kt
@@ -34,9 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.aau.serg.android.ui.screens.lobby.browse.LobbyBrowseItem
 import at.aau.serg.android.ui.screens.lobby.browse.LobbyBrowseTestTags
-import at.aau.serg.android.ui.theme.DisabledButtonDark
-import at.aau.serg.android.ui.theme.DisabledButtonLight
-import at.aau.serg.android.ui.theme.ThemeState
+import at.aau.serg.android.ui.theme.appColors
 
 @Composable
 fun LobbyBrowseCard(
@@ -48,7 +46,7 @@ fun LobbyBrowseCard(
 ) {
     val accentColor = lobby.accentColor
     val subtleCardColor = accentColor.copy(alpha = 0.14f).compositeOver(cardColor)
-    val disabledButtonColor = if (ThemeState.isDarkMode.value) DisabledButtonDark else DisabledButtonLight
+    val disabledButtonColor = appColors().screen.disabledButton
     val buttonColor = if (lobby.isOpen) accentColor else disabledButtonColor
     val buttonText = if (lobby.isOpen) "Join" else "Full"
     val metaColor = secondaryText.copy(alpha = 0.75f)

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateScreen.kt
@@ -92,111 +92,168 @@ fun LobbyCreateScreenContent(
                     colors = listOf(c.screen.bgTop, c.screen.bgBottom)
                 )
             )
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp)
     ) {
-        TopBar(
-            subtitle = "Create New Lobby",
-            onBack = { onEvent(LobbyCreateEvent.OnBack) },
-            onSettings = { onEvent(LobbyCreateEvent.OnSettings) },
-            backButtonModifier = Modifier.testTag(LobbyCreateTestTags.BACK_BUTTON),
-            titleModifier = Modifier.testTag(LobbyCreateTestTags.TITLE),
-            subtitleModifier = Modifier.testTag(LobbyCreateTestTags.SUBTITLE),
-            settingsButtonModifier = Modifier.testTag(LobbyCreateTestTags.SETTINGS_BUTTON)
-        )
 
-        Spacer(modifier = Modifier.height(18.dp))
-
-        Card(
+        // scrollable content
+        Column(
             modifier = Modifier
-                .testTag(LobbyCreateTestTags.ROOM_CODE_CARD)
-                .fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = c.screen.card
-            ),
-            shape = RoundedCornerShape(20.dp)
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
         ) {
-            Row(
+            TopBar(
+                subtitle = "Create New Lobby",
+                onBack = { onEvent(LobbyCreateEvent.OnBack) },
+                onSettings = { onEvent(LobbyCreateEvent.OnSettings) },
+                backButtonModifier = Modifier.testTag(LobbyCreateTestTags.BACK_BUTTON),
+                titleModifier = Modifier.testTag(LobbyCreateTestTags.TITLE),
+                subtitleModifier = Modifier.testTag(LobbyCreateTestTags.SUBTITLE),
+                settingsButtonModifier = Modifier.testTag(LobbyCreateTestTags.SETTINGS_BUTTON)
+            )
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            Card(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .testTag(LobbyCreateTestTags.ROOM_CODE_CARD)
+                    .fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = c.screen.card
+                ),
+                shape = RoundedCornerShape(20.dp)
             ) {
-                Column {
-                    Text(
-                        text = "#  ROOM CODE",
-                        color = c.screen.secondaryText,
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.SemiBold
-                    )
-
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
                         Text(
-                            text = roomCode,
-                            modifier = Modifier.testTag(LobbyCreateTestTags.ROOM_CODE_TEXT),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = c.screen.primaryText,
-                            fontWeight = FontWeight.Bold
+                            text = "#  ROOM CODE",
+                            color = c.screen.secondaryText,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold
                         )
 
-                        Spacer(modifier = Modifier.width(6.dp))
+                        Spacer(modifier = Modifier.height(4.dp))
 
-                        IconButton(
-                            onClick = {
-                                val clipboardManager =
-                                    context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                                val clip = ClipData.newPlainText("Room Code", roomCode)
-                                clipboardManager.setPrimaryClip(clip)
-
-                                Toast.makeText(
-                                    context,
-                                    "Room code copied",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            },
-                            modifier = Modifier
-                                .testTag(LobbyCreateTestTags.COPY_ROOM_CODE_BUTTON)
-                                .size(28.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.ContentCopy,
-                                contentDescription = "Copy Room Code",
-                                tint = c.screen.primaryText,
-                                modifier = Modifier.size(14.dp)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = roomCode,
+                                modifier = Modifier.testTag(LobbyCreateTestTags.ROOM_CODE_TEXT),
+                                style = MaterialTheme.typography.titleMedium,
+                                color = c.screen.primaryText,
+                                fontWeight = FontWeight.Bold
                             )
+
+                            Spacer(modifier = Modifier.width(6.dp))
+
+                            IconButton(
+                                onClick = {
+                                    val clipboardManager =
+                                        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                    val clip = ClipData.newPlainText("Room Code", roomCode)
+                                    clipboardManager.setPrimaryClip(clip)
+                                    Toast.makeText(
+                                        context,
+                                        "Room code copied",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                },
+                                modifier = Modifier
+                                    .testTag(LobbyCreateTestTags.COPY_ROOM_CODE_BUTTON)
+                                    .size(28.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.ContentCopy,
+                                    contentDescription = "Copy Room Code",
+                                    tint = c.screen.primaryText,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
 
-        Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-        SectionTitle(
-            icon = { Icon(Icons.Filled.Groups, null, tint = AccentPurple.copy(alpha = 0.61f)) },
-            title = "Maximum Players"
-        )
+            SectionTitle(
+                icon = { Icon(Icons.Filled.Groups, null, tint = AccentPurple.copy(alpha = 0.61f)) },
+                title = "Maximum Players"
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            listOf(2, 4, 6, 8).forEach { count ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                listOf(2, 4, 6, 8).forEach { count ->
+                    SelectableBox(
+                        text = count.toString(),
+                        selected = uiState.maxPlayers == count,
+                        onClick = {
+                            onEvent(LobbyCreateEvent.SetMaxPlayers(count))
+                                  },
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(40.dp)
+                            .testTag("${LobbyCreateTestTags.MaxPlayers.OPTION_PREFIX}_$count"),
+                        cardColor = c.screen.card,
+                        selectedColor = c.screen.selectedBox,
+                        borderColor = c.screen.cardBorder,
+                        selectedBorder = c.screen.selectedBorder,
+                        textColor = c.screen.primaryText,
+                        selectedTextColor = Color.White
+                    )
+                }
+            }
 
-                SelectableBox(
-                    text = count.toString(),
-                    selected = uiState.maxPlayers == count,
+            Spacer(modifier = Modifier.height(20.dp))
+
+            SectionTitle(
+                icon = { Icon(Icons.Filled.Lock, null, tint = AccentPurple.copy(alpha = 0.62f)) },
+                title = "Privacy"
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                LargeSelectableBox(
+                    title = "Public",
+                    icon = { tint -> Icon(Icons.Filled.Public, null, tint = tint) },
+                    selected = !uiState.isPrivate,
                     onClick = {
-                        onEvent(LobbyCreateEvent.SetMaxPlayers(count))
-                    },
+                        onEvent(LobbyCreateEvent.SetIsPrivate(false))
+                              },
                     modifier = Modifier
+                        .testTag(LobbyCreateTestTags.PRIVACY_PUBLIC)
                         .weight(1f)
-                        .height(40.dp)
-                        .testTag("${LobbyCreateTestTags.MaxPlayers.OPTION_PREFIX}_$count"),
+                        .height(72.dp),
+                    cardColor = c.screen.card,
+                    selectedColor = c.screen.selectedBox,
+                    borderColor = c.screen.cardBorder,
+                    selectedBorder = c.screen.selectedBorder,
+                    textColor = c.screen.primaryText,
+                    selectedTextColor = Color.White
+                )
+
+                LargeSelectableBox(
+                    title = "Private",
+                    icon = { tint -> Icon(Icons.Filled.Lock, null, tint = tint) },
+                    selected = uiState.isPrivate,
+                    onClick = {
+                        onEvent(LobbyCreateEvent.SetIsPrivate(true))
+                              },
+                    modifier = Modifier
+                        .testTag(LobbyCreateTestTags.PRIVACY_PRIVATE)
+                        .weight(1f)
+                        .height(72.dp),
                     cardColor = c.screen.card,
                     selectedColor = c.screen.selectedBox,
                     borderColor = c.screen.cardBorder,
@@ -205,200 +262,150 @@ fun LobbyCreateScreenContent(
                     selectedTextColor = Color.White
                 )
             }
-        }
 
-        Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-        SectionTitle(
-            icon = { Icon(Icons.Filled.Lock, null, tint = AccentPurple.copy(alpha = 0.62f)) },
-            title = "Privacy"
-        )
+            SectionTitle(
+                icon = { Icon(Icons.Filled.Timer, null, tint = AccentPurple) },
+                title = "Game Settings"
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            LargeSelectableBox(
-                title = "Public",
-                icon = { tint -> Icon(Icons.Filled.Public, null, tint = tint) },
-                selected = !uiState.isPrivate,
-                onClick = {
-                    onEvent(LobbyCreateEvent.SetIsPrivate(false))
-                },
+            NumericSettingRow(
+                icon = { Icon(Icons.Filled.Timer, null, tint = c.screen.primaryText) },
+                title = "Turn Timer",
+                value = "${uiState.turnTimer}s",
+                onMinus = {
+                    onEvent(LobbyCreateEvent.ChangeTurnTimer(-10))
+                          },
+                onPlus = {
+                    onEvent(LobbyCreateEvent.ChangeTurnTimer(10))
+                         },
                 modifier = Modifier
-                    .testTag(LobbyCreateTestTags.PRIVACY_PUBLIC)
-                    .weight(1f)
-                    .height(72.dp),
+                    .testTag(LobbyCreateTestTags.TURN_TIMER_ROW)
+                    .padding(bottom = 4.dp),
                 cardColor = c.screen.card,
-                selectedColor = c.screen.selectedBox,
-                borderColor = c.screen.cardBorder,
-                selectedBorder = c.screen.selectedBorder,
                 textColor = c.screen.primaryText,
-                selectedTextColor = Color.White
+                buttonColor = c.screen.actionButton,
+                valueTag = LobbyCreateTestTags.TURN_TIMER_VALUE,
+                minusTag = LobbyCreateTestTags.TURN_TIMER_MINUS,
+                plusTag = LobbyCreateTestTags.TURN_TIMER_PLUS,
             )
 
-            LargeSelectableBox(
-                title = "Private",
-                icon = { tint -> Icon(Icons.Filled.Lock, null, tint = tint) },
-                selected = uiState.isPrivate,
-                onClick = {
-                    onEvent(LobbyCreateEvent.SetIsPrivate(true))
-                },
+            NumericSettingRow(
+                icon = { Icon(Icons.Filled.Groups, null, tint = c.screen.primaryText) },
+                title = "Starting Tiles",
+                value = uiState.startingTiles.toString(),
+                onMinus = {
+                    onEvent(LobbyCreateEvent.ChangeStartingTiles(-10))
+                          },
+                onPlus = {
+                    onEvent(LobbyCreateEvent.ChangeStartingTiles(10))
+                         },
                 modifier = Modifier
-                    .testTag(LobbyCreateTestTags.PRIVACY_PRIVATE)
-                    .weight(1f)
-                    .height(72.dp),
+                    .testTag(LobbyCreateTestTags.STARTING_TILES_ROW)
+                    .padding(bottom = 4.dp),
                 cardColor = c.screen.card,
-                selectedColor = c.screen.selectedBox,
-                borderColor = c.screen.cardBorder,
-                selectedBorder = c.screen.selectedBorder,
                 textColor = c.screen.primaryText,
-                selectedTextColor = Color.White
+                buttonColor = c.screen.actionButton,
+                valueTag = LobbyCreateTestTags.STARTING_TILES_VALUE,
+                minusTag = LobbyCreateTestTags.STARTING_TILES_MINUS,
+                plusTag = LobbyCreateTestTags.STARTING_TILES_PLUS,
             )
-        }
 
-        Spacer(modifier = Modifier.height(20.dp))
-
-        SectionTitle(
-            icon = { Icon(Icons.Filled.Timer, null, tint = AccentPurple) },
-            title = "Game Settings"
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        NumericSettingRow(
-            icon = { Icon(Icons.Filled.Timer, null, tint = c.screen.primaryText) },
-            title = "Turn Timer",
-            value = "${uiState.turnTimer}s",
-            onMinus = {
-                onEvent(LobbyCreateEvent.ChangeTurnTimer(-10))
-            },
-            onPlus = {
-                onEvent(LobbyCreateEvent.ChangeTurnTimer(10))
-            },
-            modifier = Modifier
-                .testTag(LobbyCreateTestTags.TURN_TIMER_ROW)
-                .padding(bottom = 4.dp),
-            cardColor = c.screen.card,
-            textColor = c.screen.primaryText,
-            buttonColor = c.screen.actionButton,
-            valueTag = LobbyCreateTestTags.TURN_TIMER_VALUE,
-            minusTag = LobbyCreateTestTags.TURN_TIMER_MINUS,
-            plusTag = LobbyCreateTestTags.TURN_TIMER_PLUS,
-        )
-
-        NumericSettingRow(
-            icon = { Icon(Icons.Filled.Groups, null, tint = c.screen.primaryText) },
-            title = "Starting Tiles",
-            value = uiState.startingTiles.toString(),
-            onMinus = {
-                onEvent(LobbyCreateEvent.ChangeStartingTiles(-10))
-            },
-            onPlus = {
-                onEvent(LobbyCreateEvent.ChangeStartingTiles(10))
-            },
-            modifier = Modifier
-                .testTag(LobbyCreateTestTags.STARTING_TILES_ROW)
-                .padding(bottom = 4.dp),
-            cardColor = c.screen.card,
-            textColor = c.screen.primaryText,
-            buttonColor = c.screen.actionButton,
-            valueTag = LobbyCreateTestTags.STARTING_TILES_VALUE,
-            minusTag = LobbyCreateTestTags.STARTING_TILES_MINUS,
-            plusTag = LobbyCreateTestTags.STARTING_TILES_PLUS,
-        )
-
-        NumericSettingRow(
-            icon = { Icon(Icons.Filled.Star, null, tint = c.screen.primaryText) },
-            title = "Win Score",
-            value = uiState.winScore.toString(),
-            onMinus = {
-                onEvent(LobbyCreateEvent.ChangeWinScore(-100))
-            },
-            onPlus = {
-                onEvent(LobbyCreateEvent.ChangeWinScore(100))
-            },
-            modifier = Modifier
-                .testTag(LobbyCreateTestTags.WIN_SCORE_ROW)
-                .padding(bottom = 4.dp),
-            cardColor = c.screen.card,
-            textColor = c.screen.primaryText,
-            buttonColor = c.screen.actionButton,
-            valueTag = LobbyCreateTestTags.WIN_SCORE_VALUE,
-            minusTag = LobbyCreateTestTags.WIN_SCORE_MINUS,
-            plusTag = LobbyCreateTestTags.WIN_SCORE_PLUS,
-        )
-
-        ToggleSettingRow(
-            icon = { Icon(Icons.Filled.Speed, null, tint = c.screen.primaryText) },
-            title = "Quick Mode",
-            checked = uiState.quickMode,
-            onCheckedChange = { onEvent(LobbyCreateEvent.SetQuickMode(it)) },
-            modifier = Modifier.padding(bottom = 4.dp),
-            cardColor = c.screen.card,
-            textColor = c.screen.primaryText,
-            switchColor = c.screen.actionButton,
-            switchTestTag = LobbyCreateTestTags.QUICK_MODE_TOGGLE
-        )
-
-        ToggleSettingRow(
-            icon = { Icon(Icons.Filled.Visibility, null, tint = c.screen.primaryText) },
-            title = "Require Initial Meld",
-            checked = uiState.requireInitialMeld,
-            onCheckedChange = { onEvent(LobbyCreateEvent.SetRequireInitialMeld(it)) },
-            modifier = Modifier.padding(bottom = 4.dp),
-            cardColor = c.screen.card,
-            textColor = c.screen.primaryText,
-            switchColor = c.screen.actionButton,
-            switchTestTag = LobbyCreateTestTags.REQUIRE_INITIAL_MELD_TOGGLE
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        if (uiState.loadState is LoadState.Error) {
-            Text(
-                text = ErrorUiMapper.toMessage((uiState.loadState as LoadState.Error).error),
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
+            NumericSettingRow(
+                icon = { Icon(Icons.Filled.Star, null, tint = c.screen.primaryText) },
+                title = "Win Score",
+                value = uiState.winScore.toString(),
+                onMinus = {
+                    onEvent(LobbyCreateEvent.ChangeWinScore(-100))
+                          },
+                onPlus = {
+                    onEvent(LobbyCreateEvent.ChangeWinScore(100))
+                         },
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .testTag(LobbyCreateTestTags.WIN_SCORE_ROW)
+                    .padding(bottom = 4.dp),
+                cardColor = c.screen.card,
+                textColor = c.screen.primaryText,
+                buttonColor = c.screen.actionButton,
+                valueTag = LobbyCreateTestTags.WIN_SCORE_VALUE,
+                minusTag = LobbyCreateTestTags.WIN_SCORE_MINUS,
+                plusTag = LobbyCreateTestTags.WIN_SCORE_PLUS,
             )
+
+            ToggleSettingRow(
+                icon = { Icon(Icons.Filled.Speed, null, tint = c.screen.primaryText) },
+                title = "Quick Mode",
+                checked = uiState.quickMode,
+                onCheckedChange = { onEvent(LobbyCreateEvent.SetQuickMode(it)) },
+                modifier = Modifier.padding(bottom = 4.dp),
+                cardColor = c.screen.card,
+                textColor = c.screen.primaryText,
+                switchColor = c.screen.actionButton,
+                switchTestTag = LobbyCreateTestTags.QUICK_MODE_TOGGLE
+            )
+
+            ToggleSettingRow(
+                icon = { Icon(Icons.Filled.Visibility, null, tint = c.screen.primaryText) },
+                title = "Require Initial Meld",
+                checked = uiState.requireInitialMeld,
+                onCheckedChange = { onEvent(LobbyCreateEvent.SetRequireInitialMeld(it)) },
+                modifier = Modifier.padding(bottom = 4.dp),
+                cardColor = c.screen.card,
+                textColor = c.screen.primaryText,
+                switchColor = c.screen.actionButton,
+                switchTestTag = LobbyCreateTestTags.REQUIRE_INITIAL_MELD_TOGGLE
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
         }
 
-        Button(
-            onClick = {
-                onEvent(LobbyCreateEvent.CreateLobby)
-            },
-            modifier = Modifier
-                .testTag(LobbyCreateTestTags.CREATE_BUTTON)
-                .fillMaxWidth()
-                .height(56.dp),
-            enabled = uiState.loadState != LoadState.Loading,
-            shape = RoundedCornerShape(18.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = AccentPurple,
-                contentColor = Color.White
-            )
-        ) {
-            Text(
-                text = if (uiState.loadState == LoadState.Loading) "Loading" else "Create Lobby",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.testTag(LobbyCreateTestTags.CREATE_BUTTON_TEXT)
-            )
-            if (uiState.loadState != LoadState.Loading) {
-                Spacer(modifier = Modifier.width(8.dp))
-                Icon(
-                    imageVector = Icons.Filled.Check,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
+        // error
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
+            if (uiState.loadState is LoadState.Error) {
+                Text(
+                    text = ErrorUiMapper.toMessage((uiState.loadState as LoadState.Error).error),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 8.dp)
                 )
             }
-        }
 
-        Spacer(modifier = Modifier.height(20.dp))
+            Button(
+                onClick = {
+                    onEvent(LobbyCreateEvent.CreateLobby)
+                          },
+                modifier = Modifier
+                    .testTag(LobbyCreateTestTags.CREATE_BUTTON)
+                    .fillMaxWidth()
+                    .height(56.dp),
+                enabled = uiState.loadState != LoadState.Loading,
+                shape = RoundedCornerShape(18.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AccentPurple,
+                    contentColor = Color.White
+                )
+            ) {
+                Text(
+                    text = if (uiState.loadState == LoadState.Loading) "Loading" else "Create Lobby",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.testTag(LobbyCreateTestTags.CREATE_BUTTON_TEXT)
+                )
+                if (uiState.loadState != LoadState.Loading) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
     }
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingScreen.kt
@@ -54,61 +54,64 @@ fun LobbyWaitingScreenContent(
         modifier = Modifier
             .fillMaxSize()
             .background(Brush.verticalGradient(listOf(c.screen.bgTop, c.screen.bgBottom)))
-            .verticalScroll(scrollState)
-            .padding(16.dp)
             .testTag(LobbyWaitingTestTags.SCREEN)
     ) {
 
-        TopBar(
-            subtitle = lobbyName.value,
-            onBack = { onEvent(LobbyWaitingEvent.OnBack) },
-            onSettings = { onEvent(LobbyWaitingEvent.OnSettings) }
-        )
+        // scrollable content
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(scrollState)
+                .padding(16.dp)
+        ) {
+            TopBar(
+                subtitle = lobbyName.value,
+                onBack = { onEvent(LobbyWaitingEvent.OnBack) },
+                onSettings = { onEvent(LobbyWaitingEvent.OnSettings) }
+            )
 
-        Spacer(Modifier.height(12.dp))
+            Spacer(Modifier.height(12.dp))
 
-        WaitingScreenRoomCard(
-            roomCode = roomCode,
-            joinedCount = joinedCount,
-            maxPlayers = maxPlayers,
-            context = context,
-            primaryTextColor = c.screen.primaryText,
-            secondaryTextColor = c.screen.secondaryText,
-            cardColor = c.screen.card
-        )
+            WaitingScreenRoomCard(
+                roomCode = roomCode,
+                joinedCount = joinedCount,
+                maxPlayers = maxPlayers,
+                context = context,
+                primaryTextColor = c.screen.primaryText,
+                secondaryTextColor = c.screen.secondaryText,
+                cardColor = c.screen.card
+            )
 
-        Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(16.dp))
 
-        WaitingScreenPlayerSection(
-            onEvent = onEvent,
-            localId = uiState.user?.uid ?: "",
-            isLoading = uiState.loadState == LoadState.Loading,
-            players = players,
-            fetchedLobby = uiState.lobby,
-            maxPlayers = maxPlayers,
-            joinedCount = joinedCount,
-            primaryTextColor = c.screen.primaryText,
-            secondaryTextColor = c.screen.secondaryText,
-            darkMode = ThemeState.isDarkMode.value,
-        )
+            WaitingScreenPlayerSection(
+                onEvent = onEvent,
+                localId = uiState.user?.uid ?: "",
+                isLoading = uiState.loadState == LoadState.Loading,
+                players = players,
+                fetchedLobby = uiState.lobby,
+                maxPlayers = maxPlayers,
+                joinedCount = joinedCount,
+                primaryTextColor = c.screen.primaryText,
+                secondaryTextColor = c.screen.secondaryText,
+            )
 
-        Spacer(Modifier.height(18.dp))
+            Spacer(Modifier.height(18.dp))
 
-        WaitingScreenSettingsSection(
-            turnTimer = uiState.turnTimer,
-            startingCards = uiState.startingCards,
-            stackEnabled = uiState.stackEnabled,
-            onTurnTimerMinus = { onEvent(LobbyWaitingEvent.OnTurnTimerDecrease) },
-            onTurnTimerPlus = { onEvent(LobbyWaitingEvent.OnTurnTimerIncrease) },
-            onStartingCardsMinus = { onEvent(LobbyWaitingEvent.OnStartingCardsDecrease) },
-            onStartingCardsPlus = { onEvent(LobbyWaitingEvent.OnStartingCardsIncrease) },
-            onStackToggle = { onEvent(LobbyWaitingEvent.OnStackToggle(it)) },
-            cardColor = c.screen.card,
-            primaryTextColor = c.screen.primaryText,
-            buttonColor = c.screen.actionButton
-        )
-
-        Spacer(Modifier.height(24.dp))
+            WaitingScreenSettingsSection(
+                turnTimer = uiState.turnTimer,
+                startingCards = uiState.startingCards,
+                stackEnabled = uiState.stackEnabled,
+                onTurnTimerMinus = { onEvent(LobbyWaitingEvent.OnTurnTimerDecrease) },
+                onTurnTimerPlus = { onEvent(LobbyWaitingEvent.OnTurnTimerIncrease) },
+                onStartingCardsMinus = { onEvent(LobbyWaitingEvent.OnStartingCardsDecrease) },
+                onStartingCardsPlus = { onEvent(LobbyWaitingEvent.OnStartingCardsIncrease) },
+                onStackToggle = { onEvent(LobbyWaitingEvent.OnStackToggle(it)) },
+                cardColor = c.screen.card,
+                primaryTextColor = c.screen.primaryText,
+                buttonColor = c.screen.actionButton
+            )
+        }
 
         // --- start button (just for host) ---
         if (uiState.lobby?.hostUserId == uiState.user?.uid) {
@@ -116,6 +119,7 @@ fun LobbyWaitingScreenContent(
                 onClick = { onEvent(LobbyWaitingEvent.onMatchStart) },
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp)
                     .height(58.dp)
                     .testTag(LobbyWaitingTestTags.START_BUTTON),
                 shape = RoundedCornerShape(18.dp),

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingScreen.kt
@@ -22,7 +22,6 @@ import at.aau.serg.android.ui.screens.lobby.waiting.components.WaitingScreenRoom
 import at.aau.serg.android.ui.screens.lobby.waiting.components.WaitingScreenSettingsSection
 import at.aau.serg.android.ui.state.LoadState
 import at.aau.serg.android.ui.theme.AccentPurple
-import at.aau.serg.android.ui.theme.ThemeState
 import at.aau.serg.android.ui.theme.appColors
 
 @Composable

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/components/GameSettingsPanel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/components/GameSettingsPanel.kt
@@ -8,9 +8,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import at.aau.serg.android.ui.theme.ActionButtonDark
-import at.aau.serg.android.ui.theme.ActionButtonLight
-import at.aau.serg.android.ui.theme.ThemeState
+import at.aau.serg.android.ui.theme.appColors
 
 @Composable
 fun GameSettingsPanel(
@@ -56,7 +54,7 @@ fun SettingRow(
     onMinus: () -> Unit,
     onPlus: () -> Unit
 ) {
-    val buttonColor = if (ThemeState.isDarkMode.value) ActionButtonDark else ActionButtonLight
+    val buttonColor = appColors().screen.actionButton
 
     Row(
         modifier = Modifier

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/components/WaitingScreenPlayerSection.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/waiting/components/WaitingScreenPlayerSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import at.aau.serg.android.ui.screens.lobby.waiting.LobbyWaitingEvent
 import at.aau.serg.android.ui.screens.lobby.waiting.LobbyWaitingTestTags
+import at.aau.serg.android.ui.theme.appColors
 import shared.models.lobby.domain.Lobby
 import shared.models.lobby.domain.LobbyPlayer
 
@@ -23,39 +24,9 @@ fun WaitingScreenPlayerSection(
     maxPlayers: Int,
     joinedCount: Int,
     primaryTextColor: Color,
-    secondaryTextColor: Color,
-    darkMode: Boolean
+    secondaryTextColor: Color
 ) {
-
-    val activePlayerBackground = if (darkMode) {
-        Color(0xFF1F356A)
-    } else {
-        Color(0xFFEAF1FF)
-    }
-
-    val activePlayerBorder = if (darkMode) {
-        Color(0xFF3E73E8)
-    } else {
-        Color(0xFF4C84FF)
-    }
-
-    val secondPlayerBackground = if (darkMode) {
-        Color(0xFF1E3A2D)
-    } else {
-        Color(0xFFEAFBF1)
-    }
-
-    val secondPlayerBorder = if (darkMode) {
-        Color(0xFF2BC46D)
-    } else {
-        Color(0xFF20C76F)
-    }
-
-    val waitingBackground = if (darkMode) {
-        Color(0xFF1E1E1E)
-    } else {
-        Color.White
-    }
+    val w = appColors().waiting
 
     if (fetchedLobby != null) {
         players.forEachIndexed { index, player ->
@@ -66,8 +37,8 @@ fun WaitingScreenPlayerSection(
                 isHost = player.userId == fetchedLobby.hostUserId,
                 isReady = player.isReady,
                 isPlaceholder = false,
-                borderColor = if (isSelf) secondPlayerBorder else activePlayerBorder,
-                backgroundColor = if (isSelf) secondPlayerBackground else activePlayerBackground,
+                borderColor = if (isSelf) w.selfPlayerBorder else w.activePlayerBorder,
+                backgroundColor = if (isSelf) w.selfPlayerBg else w.activePlayerBg,
                 primaryTextColor = primaryTextColor,
                 secondaryTextColor = secondaryTextColor,
                 onClick = if (isSelf) { { onEvent(LobbyWaitingEvent.ToggleReadyState(player.userId)) } } else null,
@@ -94,10 +65,10 @@ fun WaitingScreenPlayerSection(
             name = "Waiting for player...",
             subtitle = "",
             isPlaceholder = true,
-            borderColor = if (darkMode) Color(0xFF3A3F4B) else Color(0xFFD1D5DB),
-            backgroundColor = waitingBackground,
-            primaryTextColor = if (darkMode) Color(0xFF727887) else Color(0xFF9AA3B2),
-            secondaryTextColor = if (darkMode) Color(0xFF5E6573) else Color(0xFFB2BAC8)
+            borderColor = w.placeholderBorder,
+            backgroundColor = w.placeholderBg,
+            primaryTextColor = w.placeholderPrimaryText,
+            secondaryTextColor = w.placeholderSecondaryText
         )
     }
 

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/theme/AppColors.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/theme/AppColors.kt
@@ -49,10 +49,33 @@ data class SettingsColors(
     val chevron: Color
 )
 
+data class GameColors(
+    val background: Color,
+    val surface: Color,
+    val boardBorder: Color,
+    val iconBtnBg: Color,
+    val iconBtnTint: Color,
+    val endTurnButton: Color
+)
+
+data class WaitingColors(
+    val activePlayerBg: Color,
+    val activePlayerBorder: Color,
+    val selfPlayerBg: Color,
+    val selfPlayerBorder: Color,
+    val placeholderBg: Color,
+    val placeholderBorder: Color,
+    val placeholderPrimaryText: Color,
+    val placeholderSecondaryText: Color
+)
+
 data class AppColors(
     val screen: ScreenColors,
     val home: HomeColors,
-    val settings: SettingsColors
+    val settings: SettingsColors,
+    val game: GameColors,
+    val auth: AuthColors,
+    val waiting: WaitingColors
 )
 
 @Composable
@@ -89,6 +112,14 @@ fun appColors(): AppColors {
             loadingIndicator = if (darkMode) Color.White else AccentPurple,
             buttonText = if (darkMode) Color.White else Color.Black
         ),
+        game = GameColors(
+            background = if (darkMode) GameDarkBackground else GameLightBackground,
+            surface = if (darkMode) GameDarkSurface else Color.White,
+            boardBorder = if (darkMode) Color.White.copy(alpha = 0.2f) else GameLightBoardBorder,
+            iconBtnBg = if (darkMode) GameDarkIconBtnBg else GameLightIconBtnBg,
+            iconBtnTint = if (darkMode) Color.White else GameLightIconBtnTint,
+            endTurnButton = AccentPurple
+        ),
         settings = SettingsColors(
             background = if (darkMode) AuthDarkBackground else AuthLightBackground,
             card = if (darkMode) AuthDarkCard else AuthLightCard,
@@ -100,6 +131,29 @@ fun appColors(): AppColors {
             iconPurpleBg = if (darkMode) AuthDarkCardPurple else AuthLightCardPurple,
             iconRedBg = if (darkMode) SettingsIconRedBgDark else SettingsIconRedBgLight,
             chevron = if (darkMode) SettingsChevronDark else SettingsChevronLight
+        ),
+        auth = AuthColors(
+            background = if (darkMode) AuthDarkBackground else AuthLightBackground,
+            card = if (darkMode) AuthDarkCard else AuthLightCard,
+            input = if (darkMode) AuthDarkInput else AuthLightInput,
+            primaryText = if (darkMode) AuthDarkPrimaryText else AuthLightPrimaryText,
+            secondaryText = if (darkMode) AuthDarkSecondaryText else AuthLightSecondaryText,
+            cardBlue = if (darkMode) AuthDarkCardBlue else AuthLightCardBlue,
+            borderBlue = if (darkMode) AuthDarkBorderBlue else AuthLightBorderBlue,
+            cardPurple = if (darkMode) AuthDarkCardPurple else AuthLightCardPurple,
+            borderPurple = if (darkMode) AuthDarkBorderPurple else AuthLightBorderPurple,
+            cardGreen = if (darkMode) AuthDarkCardGreen else AuthLightCardGreen,
+            borderGreen = if (darkMode) AuthDarkBorderGreen else AuthLightBorderGreen
+        ),
+        waiting = WaitingColors(
+            activePlayerBg = if (darkMode) WaitingActivePlayerBgDark else WaitingActivePlayerBgLight,
+            activePlayerBorder = if (darkMode) AuthDarkBorderBlue else WaitingActivePlayerBorderLight,
+            selfPlayerBg = if (darkMode) WaitingSecondPlayerBgDark else WaitingSecondPlayerBgLight,
+            selfPlayerBorder = if (darkMode) WaitingSecondPlayerBorderDark else WaitingSecondPlayerBorderLight,
+            placeholderBg = if (darkMode) WaitingBgDark else Color.White,
+            placeholderBorder = if (darkMode) WaitingPlaceholderBorderDark else WaitingPlaceholderBorderLight,
+            placeholderPrimaryText = if (darkMode) WaitingPlaceholderPrimaryDark else WaitingPlaceholderPrimaryLight,
+            placeholderSecondaryText = if (darkMode) WaitingPlaceholderSecondaryDark else WaitingPlaceholderSecondaryLight
         )
     )
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/theme/Color.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/theme/Color.kt
@@ -109,6 +109,24 @@ val HomeCreateBrushStart = Color(0xE24B68FF)
 val HomeCreateBrushEnd = Color(0xD74B3FD4)
 val HomeIconGradientEnd = Color(0xFF9B42FF)
 
+// Game screen
+val GameDarkBackground = Color(0xFF0F172A)
+val GameLightBackground = Color(0xFFF1F5F9)
+val GameDarkSurface = Color(0xFF1E293B)
+val GameLightBoardBorder = Color(0xFF86EFAC)
+val GameDarkIconBtnBg = Color(0xFF334155)
+val GameLightIconBtnBg = Color(0xFFE2E8F0)
+val GameLightIconBtnTint = Color(0xFF475569)
+
+// Waiting screen — player section
+val WaitingBgDark = Color(0xFF1E1E1E)
+val WaitingPlaceholderBorderDark = Color(0xFF3A3F4B)
+val WaitingPlaceholderBorderLight = Color(0xFFD1D5DB)
+val WaitingPlaceholderPrimaryDark = Color(0xFF727887)
+val WaitingPlaceholderPrimaryLight = Color(0xFF9AA3B2)
+val WaitingPlaceholderSecondaryDark = Color(0xFF5E6573)
+val WaitingPlaceholderSecondaryLight = Color(0xFFB2BAC8)
+
 // Settings screen
 val SettingsDividerDark = Color(0xFF1E2A40)
 val SettingsDividerLight = Color(0xFFE5E7EB)

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -137,7 +137,8 @@ class GameViewModelTest {
                     gameId = initialUser.gameId,
                     lobbyId = "Lobby123",
                     currentPlayerUserId = initialUser.uid
-                )
+                ),
+                isActivePlayer = true
             )
         )
     }
@@ -422,7 +423,8 @@ class GameViewModelTest {
         viewmodel.setUiStateForTest(GameUiState(
             user = user,
             rackTiles = viewmodel.uiState.value.rackTiles,
-            gameState = fakeGameResponse.toDomain()
+            gameState = fakeGameResponse.toDomain(),
+            isActivePlayer = true
         ))
 
         val before = viewmodel.uiState.value.gameState
@@ -536,6 +538,7 @@ class GameViewModelTest {
         setTestGameState()
         val state = viewmodel.uiState.value
 
+        coEvery { service.loadGame(any()) } returns fakeGameResponse
         viewmodel.onUIEvent(GameUIEvent.OnLoadGame("g1"))
         advanceUntilIdle()
 
@@ -944,13 +947,13 @@ class GameViewModelTest {
         viewmodel.setUiStateForTest(GameUiState(
             user = null
         ))
-        viewmodel.applyGameState(fakeGameResponse.toDomain())
+        viewmodel.applyGameState(fakeGameResponse.toDomain(), false)
     }
 
     @Test(expected = IllegalStateException::class)
     fun applyGameState_withNullUser_throws_IllegalStateException() {
         viewmodel.setUiStateForTest(GameUiState(user = null))
-        viewmodel.applyGameState(fakeGameResponse.toDomain())
+        viewmodel.applyGameState(fakeGameResponse.toDomain(), true)
     }
 
     @Test

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -44,6 +44,7 @@ import shared.models.game.event.TurnTimedOutEvent
 import shared.models.game.response.BoardSetResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
+import shared.models.game.response.TileResponse
 import shared.models.game.response.TurnDraftResponse
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -412,14 +413,64 @@ class GameViewModelTest {
 
     @Test
     fun drawTile_addsNew_updatesGameState() = runTest {
-        setTestGameState()
-        val before = viewmodel.uiState.value.gameState
+        val user = User.newBuilder()
+            .setUid("FakeUser1")
+            .setDisplayName("Bob")
+            .setGameId("FakeGame1")
+            .build()
 
+        viewmodel.setUiStateForTest(GameUiState(
+            user = user,
+            rackTiles = viewmodel.uiState.value.rackTiles,
+            gameState = fakeGameResponse.toDomain()
+        ))
+
+        val before = viewmodel.uiState.value.gameState
+        val modifiedGameResponse = fakeGameResponse.copy(
+            players = fakeGameResponse.players.map { p ->
+                if (p.userId == viewmodel.uiState.value.user?.uid) {
+                    p.copy(
+                        rackTiles = listOf(
+                            TileResponse(
+                                tileId = "t1",
+                                color = TileColor.BLACK.toString(),
+                                number = 1,
+                                isJoker = false
+                            )
+                        )
+                    )
+                } else p
+            }
+        )
+        coEvery { service.drawTile(any(), any()) } returns modifiedGameResponse
         viewmodel.onUIEvent(GameUIEvent.DrawTile)
         advanceUntilIdle()
 
         val after = viewmodel.uiState.value.gameState
         assertNotEquals(before, after)
+    }
+
+    @Test
+    fun drawTile_does_not_add_with_empty_rack_updatesGameState() = runTest {
+        val user = User.newBuilder()
+            .setUid("FakeUser1")
+            .setDisplayName("Bob")
+            .setGameId("FakeGame1")
+            .build()
+
+        viewmodel.setUiStateForTest(GameUiState(
+            user = user,
+            rackTiles = emptyList(),
+            gameState = fakeGameResponse.toDomain()
+        ))
+        val before = viewmodel.uiState.value.gameState
+
+        coEvery { service.drawTile(any(), any()) } returns fakeGameResponse
+        viewmodel.onUIEvent(GameUIEvent.DrawTile)
+        advanceUntilIdle()
+
+        val after = viewmodel.uiState.value.gameState
+        assertEquals(before, after)
     }
 
     @Test
@@ -797,8 +848,26 @@ class GameViewModelTest {
     }
 
     @Test
-    fun handleGameSocketEvent_updated_updatesGameState() {
+    fun handleGameSocketEvent_does_not_updateGameState_if_not_active() {
         setTestGameState()
+
+        viewmodel.handleGameSocketEvent(
+            GameEvent.Updated(GameUpdatedEvent(gameId = "Game123", game = fakeGameResponse))
+        )
+
+        assertNotEquals(fakeGameResponse.toDomain(), viewmodel.uiState.value.gameState)
+    }
+
+    @Test
+    fun handleGameSocketEvent_does_updateGameState_if_active() = runTest {
+        val user = User.newBuilder()
+            .setUid("1")
+            .setDisplayName("Bob")
+            .setGameId("g1")
+            .build()
+
+        store.save(user)
+        advanceUntilIdle()
 
         viewmodel.handleGameSocketEvent(
             GameEvent.Updated(GameUpdatedEvent(gameId = "Game123", game = fakeGameResponse))

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -197,6 +197,7 @@ class GameViewModelTest {
         assertTrue(viewmodel.uiState.value.selectedTiles.contains(tile))
 
         viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, false, null))
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, false, null))
         assertFalse(viewmodel.uiState.value.selectedTiles.contains(tile))
     }
 
@@ -351,21 +352,17 @@ class GameViewModelTest {
     }
 
     @Test
-    fun endTurn_updatesGameState_andClearsSelection() = runTest {
+    fun endTurn_sets_success_andClearsSelection() = runTest {
         setTestGameState()
-        val before = viewmodel.uiState.value.gameState
-        val tile = viewmodel.uiState.value.rackTiles.first()
-        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        coEvery { service.endTurn(any(), any()) } returns fakeGameResponse
 
         viewmodel.onUIEvent(GameUIEvent.EndTurn)
         advanceUntilIdle()
 
-        val after = viewmodel.uiState.value.gameState
-        assertNotEquals(before, after)
-
         val state = viewmodel.uiState.value
         assertTrue(state.selectedTiles.isEmpty())
         assertNull(state.activeSelectionRow)
+        assertTrue(state.loadState is LoadState.Success)
     }
 
     @Test

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -10,6 +10,7 @@ import at.aau.serg.android.ui.state.LoadState
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -126,6 +127,17 @@ class GameViewModelTest {
         )
     }
 
+    private fun setPlayerTurnInactive() {
+        val user = User.newBuilder()
+            .setUid("1")
+            .setDisplayName("Max")
+            .build()
+        viewmodel.setUiStateForTest(GameUiState(
+            user = user,
+            gameState = fakeGameResponse.toDomain(),
+        ))
+    }
+
     @Before
     fun setup() = runTest {
         store = InMemoryProtoStore(User.getDefaultInstance())
@@ -147,13 +159,17 @@ class GameViewModelTest {
     }
 
     @Test
-    fun init_setsRackAndBoard() = runTest {
-        val state = viewmodel.uiState.value
+    fun init_loadsUser() = runTest {
+        assertEquals(viewmodel.uiState.value.user, User.getDefaultInstance())
+        val user = User.newBuilder()
+            .setUid("1")
+            .setDisplayName("Bob")
+            .setGameId("g1")
+            .build()
 
-        assertEquals(viewmodel.uiState.value.gameState, fakeGameResponse.toDomain())
-
-        assertTrue(state.selectedTiles.isEmpty())
-        assertNull(state.activeSelectionRow)
+        store.save(user)
+        advanceUntilIdle()
+        assertEquals(viewmodel.uiState.value.user, user)
     }
 
     @Test
@@ -173,14 +189,27 @@ class GameViewModelTest {
     }
 
     @Test
-    fun onTileSelected_togglesSelection() = runTest {
+    fun onTileSelected_togglesSelection_for_hand() = runTest {
         setTestGameState()
         val tile = viewmodel.uiState.value.rackTiles.first()
 
-        viewmodel.onTileSelected(tile, true)
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
         assertTrue(viewmodel.uiState.value.selectedTiles.contains(tile))
 
-        viewmodel.onTileSelected(tile, false)
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, false, null))
+        assertFalse(viewmodel.uiState.value.selectedTiles.contains(tile))
+    }
+
+    @Test
+    fun onTileSelected_togglesSelection_for_board() = runTest {
+        setTestGameState()
+        val boardSet = viewmodel.uiState.value.boardSets.first()
+        val tile = boardSet.tiles.first()
+
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, boardSet.boardSetId))
+        assertTrue(viewmodel.uiState.value.selectedTiles.contains(tile))
+
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, false, boardSet.boardSetId))
         assertFalse(viewmodel.uiState.value.selectedTiles.contains(tile))
     }
 
@@ -189,8 +218,8 @@ class GameViewModelTest {
         setTestGameState()
         val tile = viewmodel.uiState.value.rackTiles.first()
 
-        viewmodel.onTileSelected(tile, true, "row1")
-        viewmodel.onTileSelected(tile, true, "row2")
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, "row1"))
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, "row2"))
 
         val state = viewmodel.uiState.value
 
@@ -203,8 +232,8 @@ class GameViewModelTest {
         setTestGameState()
         val tile = viewmodel.uiState.value.rackTiles.first()
 
-        viewmodel.onTileSelected(tile, true)
-        viewmodel.addRow()
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        viewmodel.onUIEvent(GameUIEvent.AddRow)
 
         val state = viewmodel.uiState.value
 
@@ -217,8 +246,8 @@ class GameViewModelTest {
         setTestGameState()
         val tile = viewmodel.uiState.value.rackTiles.first()
 
-        viewmodel.onTileSelected(tile, true)
-        viewmodel.moveTiles()
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        viewmodel.onUIEvent(GameUIEvent.MoveTiles(null))
 
         val state = viewmodel.uiState.value
 
@@ -237,8 +266,8 @@ class GameViewModelTest {
 
         val initialRackCount = state.rackTiles.size
 
-        viewmodel.onTileSelected(tile, true)
-        viewmodel.moveTiles(initialRow.boardSetId)
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        viewmodel.onUIEvent(GameUIEvent.MoveTiles(initialRow.boardSetId))
 
         val updatedState = viewmodel.uiState.value
         val updatedRow = updatedState.boardSets.first { it.boardSetId == initialRow.boardSetId }
@@ -251,9 +280,9 @@ class GameViewModelTest {
 
     @Test
     fun moveTiles_emptySelection_doesNothing() = runTest {
+        setTestGameState()
         val before = viewmodel.uiState.value
-
-        viewmodel.moveTiles()
+        viewmodel.onUIEvent(GameUIEvent.MoveTiles(null))
 
         assertEquals(before, viewmodel.uiState.value)
     }
@@ -262,8 +291,7 @@ class GameViewModelTest {
     fun moveInSameRow_rack_movesCorrectly() = runTest {
         setTestGameState()
         val before = viewmodel.uiState.value.rackTiles.toList()
-
-        viewmodel.moveInSameRow(null, 0, 1)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(null, 0, 1))
 
         val after = viewmodel.uiState.value.rackTiles
 
@@ -277,8 +305,7 @@ class GameViewModelTest {
         val initialRow = viewmodel.uiState.value.boardSets.first()
         val before = initialRow.tiles
         val rowName = initialRow.boardSetId
-
-        viewmodel.moveInSameRow(rowName, 0, 2)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(rowName, 0, 2))
 
         val after = viewmodel.uiState.value.boardSets
             .first { it.boardSetId == rowName }
@@ -289,36 +316,36 @@ class GameViewModelTest {
 
     @Test
     fun moveInSameRow_invalidRow_doesNothing() = runTest {
+        setTestGameState()
         val before = viewmodel.uiState.value
-
-        viewmodel.moveInSameRow("invalid", 0, 1)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow("invalid", 0, 1))
 
         assertEquals(before, viewmodel.uiState.value)
     }
 
     @Test
     fun moveInSameRow_invalidIndex_negative() = runTest {
+        setTestGameState()
         val before = viewmodel.uiState.value
-
-        viewmodel.moveInSameRow(null, -1, 1)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(null, -1, 1))
 
         assertEquals(before, viewmodel.uiState.value)
     }
 
     @Test
     fun moveInSameRow_invalidIndex_outOfBounds() = runTest {
+        setTestGameState()
         val before = viewmodel.uiState.value
-
-        viewmodel.moveInSameRow(null, 0, 999)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(null, 0, 999))
 
         assertEquals(before, viewmodel.uiState.value)
     }
 
     @Test
     fun moveInSameRow_sameIndex_doesNothing() = runTest {
+        setTestGameState()
         val before = viewmodel.uiState.value
-
-        viewmodel.moveInSameRow(null, 0, 0)
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(null, 0, 0))
 
         assertEquals(before, viewmodel.uiState.value)
     }
@@ -328,9 +355,9 @@ class GameViewModelTest {
         setTestGameState()
         val before = viewmodel.uiState.value.gameState
         val tile = viewmodel.uiState.value.rackTiles.first()
-        viewmodel.onTileSelected(tile, true)
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
 
-        viewmodel.endTurn()
+        viewmodel.onUIEvent(GameUIEvent.EndTurn)
         advanceUntilIdle()
 
         val after = viewmodel.uiState.value.gameState
@@ -343,9 +370,10 @@ class GameViewModelTest {
 
     @Test
     fun endTurn_emitsErrorState_onFailure() = runTest {
+        setTestGameState()
         coEvery { service.endTurn(any(), any()) } throws RuntimeException()
 
-        viewmodel.endTurn()
+        viewmodel.onUIEvent(GameUIEvent.EndTurn)
 
         advanceUntilIdle()
         val state = viewmodel.uiState.value
@@ -353,12 +381,21 @@ class GameViewModelTest {
         assertTrue(state.loadState is LoadState.Error)
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun end_turn_throws_on_user_null() = runTest {
+        viewmodel.setUiStateForTest(GameUiState(
+            user = null
+        ))
+        viewmodel.endTurn()
+        advanceUntilIdle()
+    }
+
     @Test
     fun drawTile_addsNew_updatesGameState() = runTest {
         setTestGameState()
         val before = viewmodel.uiState.value.gameState
 
-        viewmodel.drawTile()
+        viewmodel.onUIEvent(GameUIEvent.DrawTile)
         advanceUntilIdle()
 
         val after = viewmodel.uiState.value.gameState
@@ -367,14 +404,24 @@ class GameViewModelTest {
 
     @Test
     fun drawTile_emitsErrorState_onFailure() = runTest {
+        setTestGameState()
         coEvery { service.drawTile(any(), any()) } throws RuntimeException("Failure")
 
-        viewmodel.drawTile()
+        viewmodel.onUIEvent(GameUIEvent.DrawTile)
 
         advanceUntilIdle()
         val state = viewmodel.uiState.value
 
         assertTrue(state.loadState is LoadState.Error)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun drawTile_throws_on_user_null() = runTest {
+        viewmodel.setUiStateForTest(GameUiState(
+            user = null
+        ))
+        viewmodel.drawTile()
+        advanceUntilIdle()
     }
 
     @Test
@@ -388,14 +435,14 @@ class GameViewModelTest {
         val initialRowTileCount = state.boardSets.first().tiles.size
         assertNotNull(initialRow)
 
-        viewmodel.onTileSelected(tile, true)
-        viewmodel.moveTiles(initialRow.boardSetId)
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        viewmodel.onUIEvent(GameUIEvent.MoveTiles(initialRow.boardSetId))
 
         var updatedState = viewmodel.uiState.value
 
         assertNotEquals(initialRackCount, updatedState.rackTiles.size)
         assertNotEquals(initialRowTileCount, updatedState.boardSets.first().tiles.size)
-        viewmodel.resetSelection()
+        viewmodel.onUIEvent(GameUIEvent.ResetSelection)
 
         updatedState = viewmodel.uiState.value
         assertEquals(initialRackCount, updatedState.rackTiles.size)
@@ -405,12 +452,20 @@ class GameViewModelTest {
         assertNull(updatedState.activeSelectionRow)
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun resetSelection_throws_if_gameState_is_null() {
+        viewmodel.setUiStateForTest(GameUiState(
+            gameState = null
+        ))
+        viewmodel.resetSelection()
+    }
+
     @Test
     fun loadGame_updatesGameState() = runTest {
         setTestGameState()
         val state = viewmodel.uiState.value
 
-        viewmodel.loadGame()
+        viewmodel.onUIEvent(GameUIEvent.OnLoadGame("g1"))
         advanceUntilIdle()
 
         assertNotEquals(state.gameState, viewmodel.uiState.value.gameState)
@@ -420,13 +475,14 @@ class GameViewModelTest {
     fun loadGame_emitsErrorState_onFailure() = runTest {
         coEvery { service.loadGame(any()) } throws RuntimeException()
 
-        viewmodel.loadGame()
+        viewmodel.onUIEvent(GameUIEvent.OnLoadGame("g1"))
 
         advanceUntilIdle()
         val state = viewmodel.uiState.value
 
         assertTrue(state.loadState is LoadState.Error)
     }
+
 
     @Test
     fun sendTurnDraft_updateDraftWorkflowTest() = runTest {
@@ -456,5 +512,131 @@ class GameViewModelTest {
         val state = viewmodel.uiState.value
 
         assertTrue(state.loadState is LoadState.Error)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun sendTurnDraft_emitsErrorState_if_user_is_null() = runTest {
+        viewmodel.setUiStateForTest(GameUiState(
+            user = null
+        ))
+        coEvery { service.updateDraft(any(), any()) }
+
+        viewmodel.sendTurnDraft()
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun addRow_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.AddRow)
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun drawTile_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.DrawTile)
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun endTurn_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.DrawTile)
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun moveInSameRow_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.MoveInSameRow(null, 0, 1))
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun moveTiles_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.MoveTiles(null))
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun loadGame_sets_loadState_success_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.OnLoadGame("g1"))
+        advanceUntilIdle()
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Success)
+    }
+
+    @Test
+    fun tileSelected_sets_loadState_error_if_not_players_turn() = runTest {
+        setTestGameState()
+        val user = User.newBuilder()
+            .setUid("1")
+            .setDisplayName("Max")
+            .build()
+        viewmodel.setUiStateForTest(GameUiState(
+            user = user,
+            rackTiles = viewmodel.uiState.value.rackTiles,
+            gameState = viewmodel.uiState.value.gameState
+        ))
+        val tile = viewmodel.uiState.value.rackTiles.first()
+
+        viewmodel.onUIEvent(GameUIEvent.OnTileSelected(tile, true, null))
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun resetSelection_sets_loadState_error_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.ResetSelection)
+        advanceUntilIdle()
+        assertTrue(viewmodel.uiState.value.loadState is LoadState.Error)
+    }
+
+    @Test
+    fun onSettings_emitsNavigateToSettings_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.OnSettings)
+
+        val effect = viewmodel.effects.first()
+
+        assertEquals(GameEffect.NavigateToSettings, effect)
+    }
+
+    @Test
+    fun onBack_emitsNavigateBack_if_not_players_turn() = runTest {
+        setPlayerTurnInactive()
+        viewmodel.onUIEvent(GameUIEvent.OnBack)
+
+        val effect = viewmodel.effects.first()
+
+        assertEquals(GameEffect.NavigateBack, effect)
+    }
+
+    @Test
+    fun onBack_emitsNavigateBack() = runTest {
+        viewmodel.onUIEvent(GameUIEvent.OnBack)
+
+        val effect = viewmodel.effects.first()
+
+        assertEquals(GameEffect.NavigateBack, effect)
+    }
+
+    @Test
+    fun onSettings_emitsNavigateToSettings() = runTest {
+        viewmodel.onUIEvent(GameUIEvent.OnSettings)
+
+        val effect = viewmodel.effects.first()
+
+        assertEquals(GameEffect.NavigateToSettings, effect)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun applyGameState_throws_if_player_null() = runTest {
+        viewmodel.setUiStateForTest(GameUiState(
+            user = null
+        ))
+        viewmodel.applyGameState(fakeGameResponse.toDomain())
     }
 }

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingViewModelTest.kt
@@ -451,22 +451,13 @@ class LobbyWaitingViewModelTest {
 
     @Test
     fun startSocket_catches_NetworkException_and_updates_loadState() = runTest {
-        // Force the flow to instantly throw a network exception upon collection
-        val networkException = RuntimeException("Connection lost")
         coEvery { service.subscribe("lobby_123") } returns flow {
-            throw networkException
+            throw RuntimeException("Connection lost")
         }
 
-        viewModel.uiState.test {
-            val initialState = awaitItem()
-
-            viewModel.startSocket("lobby_123")
-
-            val errorState = awaitItem()
-            assertTrue(errorState.loadState is LoadState.Error)
-
-            cancelAndIgnoreRemainingEvents()
-        }
+        viewModel.startSocket("lobby_123")
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.loadState is LoadState.Error)
     }
 
     @Test

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/lobby/waiting/LobbyWaitingViewModelTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -87,6 +88,11 @@ class LobbyWaitingViewModelTest {
         viewModel = LobbyWaitingViewModel(store, api, service)
     }
 
+    @After
+    fun tearDown() {
+        // fixes toggleReadyState_does_not_affect_other_users
+    }
+
     @Test
     fun default_constructor_path_isCovered() = runTest {
         val vm = LobbyWaitingViewModel(store)
@@ -98,7 +104,6 @@ class LobbyWaitingViewModelTest {
         advanceUntilIdle()
         Assert.assertEquals("user-1", viewModel.uiState.value.user?.uid)
     }
-
 
     @Test
     fun turnTimer_increase_works() = runTest {


### PR DESCRIPTION
## Summary
This PR refactors the Android game screen architecture to make UI interaction and turn-based control more consistent and easier to maintain.

It introduces a clearer `GameUIEvent` / `GameEffect` flow, centralizes active-player state handling, updates navigation from `matchId` to `gameId`, and rewires the screen/components to use event-driven interaction instead of passing raw ViewModel actions through the UI. It also updates the related tests accordingly.

## Issues

- Closes #519
- Closes #507
- Closes #502 
- Closes #496
- Closes #494
- Closes #493
- Closes #483

## What changed
- introduced `GameUIEvent` / `GameEffect` to make screen interaction more explicit and structured
- updated game screen components to dispatch events instead of directly depending on raw ViewModel passthrough callbacks
- added / derived active-turn state (`isActivePlayer`) to better control which actions are available to the current user
- integrated the new event/effect handling into the `GameScreen` and `GameViewModel`
- updated navigation to use `gameId` instead of `matchId`
- updated affected Android tests and added coverage-related follow-up fixes.

---

The goal of this refactor is to reduce ad-hoc screen wiring and move the game UI toward a more unified architecture:
- clearer separation between UI events, side effects, and state
- cleaner control of turn-based actions
- less direct coupling between composables and ViewModel internals
- easier future extension for loading, error, and multiplayer turn-state handling.

## Result
After this PR, the Android game screen follows a more consistent event-driven structure, active-player restrictions are handled more centrally, and the game route / screen integration is better aligned with the underlying game model.
