### PR TITLE
feat(backend)(game): add end-turn validation and commit flow

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
@@ -5,6 +5,7 @@ import at.se2group.backend.mapper.toResponse
 import at.se2group.backend.service.GameService
 import at.se2group.backend.service.TurnDraftService
 import at.se2group.backend.service.DrawTileService
+import at.se2group.backend.service.EndTurnService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import shared.models.game.response.TurnDraftResponse
-import shared.models.game.request.DrawTileRequest
+import shared.models.game.request.EndTurnRequest
 import jakarta.validation.Valid
 
 @RestController
@@ -23,7 +24,8 @@ import jakarta.validation.Valid
 class GameController(
     private val gameService: GameService,
     private val turnDraftService: TurnDraftService,
-    private val drawTileService: DrawTileService
+    private val drawTileService: DrawTileService,
+    private val endTurnService: EndTurnService
 ) {
     @GetMapping("/{gameId}")
     fun getGame(@PathVariable gameId: String): GameResponse {
@@ -46,5 +48,14 @@ class GameController(
         @RequestHeader("X-User-Id") userId: String
     ): GameResponse {
         return drawTileService.drawTile(gameId, userId).toResponse()
+    }
+
+    @PostMapping("/{gameId}/end-turn")
+    fun endTurn(
+        @PathVariable gameId: String,
+        @RequestHeader("X-User-Id") userId: String,
+        @Valid @RequestBody request: EndTurnRequest
+    ): GameResponse {
+        return endTurnService.endTurn(gameId, userId, request).toResponse()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.service.InvalidTurnSubmissionException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -64,6 +65,20 @@ class GlobalExceptionHandler {
                 ApiErrorResponse(
                     errorCode = "FORBIDDEN",
                     errorMessage = ex.message ?: "Access denied"
+                )
+            )
+    }
+
+    @ExceptionHandler(InvalidTurnSubmissionException::class)
+    fun handleInvalidTurnSubmission(
+        ex: InvalidTurnSubmissionException
+    ): ResponseEntity<ApiErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "INVALID_TURN_SUBMISSION",
+                    errorMessage = ex.message ?: "Submitted draft is invalid"
                 )
             )
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -79,7 +79,7 @@ class GlobalExceptionHandler {
                 ApiErrorResponse(
                     errorCode = "INVALID_TURN_SUBMISSION",
                     errorMessage = ex.message ?: "Submitted draft is invalid",
-                    violations = ex.violations
+                    violations = ex.validationResult.violations
                 )
             )
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -78,7 +78,8 @@ class GlobalExceptionHandler {
             .body(
                 ApiErrorResponse(
                     errorCode = "INVALID_TURN_SUBMISSION",
-                    errorMessage = ex.message ?: "Submitted draft is invalid"
+                    errorMessage = ex.message ?: "Submitted draft is invalid",
+                    violations = ex.violations
                 )
             )
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/TurnDraftMapper.kt
@@ -7,6 +7,7 @@ import shared.models.game.request.UpdateDraftRequest
 import shared.models.game.response.TurnDraftResponse
 import at.se2group.backend.persistence.TurnDraftEntity
 import at.se2group.backend.persistence.TurnDraftBoardSetEntity
+import shared.models.game.request.EndTurnRequest
 
 fun UpdateDraftRequest.toDomain(gameId: String, userId: String): TurnDraft {
     return TurnDraft(
@@ -83,5 +84,14 @@ fun TurnDraft.toResponse(): TurnDraftResponse {
         draftBoard = boardSets.map { it.toResponse() },
         draftHand = rackTiles.map { it.toResponse() },
         version = version
+    )
+}
+
+fun EndTurnRequest.toDomain(gameId: String, userId: String): TurnDraft {
+    return TurnDraft(
+        gameId = gameId,
+        playerUserId = userId,
+        boardSets = boardSets.map { it.toBoardSetDomain() },
+        rackTiles = rackTiles.map { it.toTileDomain() },
     )
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -57,7 +57,7 @@ class EndTurnService(
         )
 
         if (!validation.isValid) {
-            throw InvalidTurnSubmissionException(validation.violations)
+            throw InvalidTurnSubmissionException(validation)
         }
 
         val resolvedGame = commitDraftToConfirmedGame(game, submittedDraft)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -1,0 +1,142 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.mapper.toDomain
+import at.se2group.backend.mapper.toEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.rules.service.RummikubRuleService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.TurnDraft
+import shared.models.game.request.EndTurnRequest
+import java.time.Instant
+
+@Service
+@Transactional(readOnly = true)
+class EndTurnService(
+    private val gameRepository: GameRepository,
+    private val turnDraftRepository: TurnDraftRepository,
+    private val gameService: GameService,
+    private val rummikubRuleService: RummikubRuleService,
+    private val gameBroadcastService: GameBroadcastService,
+    private val afterCommitExecutor: AfterCommitExecutor
+) {
+    private companion object {
+        const val GAME_NOT_FOUND = "Game not found"
+        const val DRAFT_NOT_FOUND = "Draft not found"
+        const val GAME_NOT_ACTIVE = "Game is not active"
+        const val NOT_CURRENT_PLAYER = "User is not the current active player"
+        const val NOT_DRAFT_OWNER = "Draft belongs to a different user"
+    }
+
+    @Transactional
+    fun endTurn(
+        gameId: String,
+        userId: String,
+        request: EndTurnRequest
+    ): ConfirmedGame {
+        val game = gameRepository.findById(gameId)
+            .orElseThrow { NoSuchElementException(GAME_NOT_FOUND) }
+            .toDomain()
+
+        val draftEntity = turnDraftRepository.findByGameId(gameId)
+            ?: throw NoSuchElementException(DRAFT_NOT_FOUND)
+
+        check(game.status == GameStatus.ACTIVE) { GAME_NOT_ACTIVE }
+        check(game.currentPlayerUserId == userId) { NOT_CURRENT_PLAYER }
+        check(draftEntity.playerUserId == userId) { NOT_DRAFT_OWNER }
+
+        val submittedDraft = request.toDomain(gameId, userId)
+
+        val validation = rummikubRuleService.validateSubmittedDraft(
+            confirmedGame = game,
+            actingPlayerUserId = userId,
+            submittedDraft = submittedDraft
+        )
+
+        if (!validation.isValid) {
+            throw InvalidTurnSubmissionException(validation.violations)
+        }
+
+        val committedGame = commitDraftToConfirmedGame(game, submittedDraft)
+        val finishedGame = finishIfWinnerExists(committedGame, userId)
+
+        if (finishedGame.status == GameStatus.FINISHED) {
+            val savedGame = gameRepository.save(finishedGame.toEntity()).toDomain()
+
+            turnDraftRepository.deleteById(gameId)
+
+            afterCommitExecutor.execute {
+                gameBroadcastService.broadcastGameUpdated(savedGame)
+                gameBroadcastService.broadcastGameEnded(savedGame.gameId, userId)
+            }
+
+            return savedGame
+        }
+
+        val nextPlayerId = gameService.nextPlayerId(finishedGame)
+        val advancedGame = finishedGame.copy(currentPlayerUserId = nextPlayerId)
+        val savedGame = gameRepository.save(advancedGame.toEntity()).toDomain()
+
+        val nextDraft = createNextDraft(savedGame)
+
+        draftEntity.playerUserId = nextDraft.playerUserId
+        turnDraftRepository.save(nextDraft.toEntity(draftEntity))
+
+        afterCommitExecutor.execute {
+            gameBroadcastService.broadcastGameUpdated(savedGame)
+            gameBroadcastService.broadcastTurnChanged(savedGame.gameId, nextPlayerId)
+            gameBroadcastService.broadcastDraftUpdated(nextDraft)
+        }
+
+        return savedGame
+    }
+
+    private fun commitDraftToConfirmedGame(
+        confirmedGame: ConfirmedGame,
+        draft: TurnDraft
+    ): ConfirmedGame {
+        val updatedPlayers = confirmedGame.players.map { player ->
+            if (player.userId == draft.playerUserId) {
+                player.copy(rackTiles = draft.rackTiles)
+            } else {
+                player
+            }
+        }
+
+        return confirmedGame.copy(
+            players = updatedPlayers,
+            boardSets = draft.boardSets
+        )
+    }
+
+    private fun finishIfWinnerExists(
+        game: ConfirmedGame,
+        actingPlayerUserId: String
+    ): ConfirmedGame {
+        val actingPlayer = game.players.first { it.userId == actingPlayerUserId }
+
+        return if (actingPlayer.rackTiles.isEmpty()) {
+            game.copy(
+                status = GameStatus.FINISHED,
+                finishedAt = Instant.now()
+            )
+        } else {
+            game
+        }
+    }
+
+    private fun createNextDraft(game: ConfirmedGame): TurnDraft {
+        val nextPlayer = game.players.first { it.userId == game.currentPlayerUserId }
+
+        return TurnDraft(
+            gameId = game.gameId,
+            playerUserId = nextPlayer.userId,
+            boardSets = game.boardSets,
+            rackTiles = nextPlayer.rackTiles,
+            version = 0
+        )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -60,11 +60,11 @@ class EndTurnService(
             throw InvalidTurnSubmissionException(validation.violations)
         }
 
-        val committedGame = commitDraftToConfirmedGame(game, submittedDraft)
-        val finishedGame = finishIfWinnerExists(committedGame, userId)
+        val resolvedGame = commitDraftToConfirmedGame(game, submittedDraft)
+            .finishIfWinnerExists(userId)
 
-        if (finishedGame.status == GameStatus.FINISHED) {
-            val savedGame = gameRepository.save(finishedGame.toEntity()).toDomain()
+        if (resolvedGame.status == GameStatus.FINISHED) {
+            val savedGame = gameRepository.save(resolvedGame.toEntity()).toDomain()
 
             turnDraftRepository.deleteById(gameId)
 
@@ -76,8 +76,8 @@ class EndTurnService(
             return savedGame
         }
 
-        val nextPlayerId = gameService.nextPlayerId(finishedGame)
-        val advancedGame = finishedGame.copy(currentPlayerUserId = nextPlayerId)
+        val nextPlayerId = gameService.nextPlayerId(resolvedGame)
+        val advancedGame = resolvedGame.copy(currentPlayerUserId = nextPlayerId)
         val savedGame = gameRepository.save(advancedGame.toEntity()).toDomain()
 
         val nextDraft = createNextDraft(savedGame)
@@ -112,20 +112,25 @@ class EndTurnService(
         )
     }
 
-    private fun finishIfWinnerExists(
-        game: ConfirmedGame,
-        actingPlayerUserId: String
+    private fun ConfirmedGame.finishIfWinnerExists(
+        actingPlayerUserId: String,
+        finishedAt: Instant = Instant.now()
     ): ConfirmedGame {
-        val actingPlayer = game.players.first { it.userId == actingPlayerUserId }
-
-        return if (actingPlayer.rackTiles.isEmpty()) {
-            game.copy(
+        return if (hasEmptyRack(actingPlayerUserId)) {
+            copy(
                 status = GameStatus.FINISHED,
-                finishedAt = Instant.now()
+                finishedAt = finishedAt
             )
         } else {
-            game
+            this
         }
+    }
+
+    private fun ConfirmedGame.hasEmptyRack(actingPlayerUserId: String): Boolean {
+        return players
+            .first { it.userId == actingPlayerUserId }
+            .rackTiles
+            .isEmpty()
     }
 
     private fun createNextDraft(game: ConfirmedGame): TurnDraft {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/InvalidTurnSubmissionException.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/InvalidTurnSubmissionException.kt
@@ -1,0 +1,7 @@
+package at.se2group.backend.service
+
+import shared.models.game.validation.RuleViolation
+
+class InvalidTurnSubmissionException(
+    val violations: List<RuleViolation>
+): RuntimeException("Submitted draft is invalid")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/InvalidTurnSubmissionException.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/InvalidTurnSubmissionException.kt
@@ -1,7 +1,7 @@
 package at.se2group.backend.service
 
-import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.ValidationResult
 
 class InvalidTurnSubmissionException(
-    val violations: List<RuleViolation>
-): RuntimeException("Submitted draft is invalid")
+    val validationResult: ValidationResult
+) : RuntimeException("Submitted draft is invalid")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -8,6 +8,8 @@ import shared.models.game.domain.TileColor
 import at.se2group.backend.service.GameService
 import at.se2group.backend.service.TurnDraftService
 import at.se2group.backend.service.DrawTileService
+import at.se2group.backend.service.EndTurnService
+import at.se2group.backend.service.InvalidTurnSubmissionException
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,6 +42,9 @@ class GameControllerTest {
 
     @MockitoBean
     lateinit var drawTileService: DrawTileService
+
+    @MockitoBean
+    lateinit var endTurnService: EndTurnService
 
     @Test
     fun `getGame returns game response`() {
@@ -216,5 +221,114 @@ class GameControllerTest {
             }
     }
 
+    @Test
+    fun `endTurn returns 200 with game response`() {
+        val requestJson = """
+            {
+                "boardSets": [
+                    {
+                        "boardSetId": "set-1",
+                        "type": "RUN",
+                        "tiles": [
+                            { "tileId": "tile-1", "color": "RED", "number": 3, "isJoker": false },
+                            { "tileId": "tile-2", "color": "RED", "number": 4, "isJoker": false },
+                            { "tileId": "tile-3", "color": "RED", "number": 5, "isJoker": false }
+                        ]
+                    }
+                ],
+                "rackTiles": [
+                    { "tileId": "tile-4", "color": "BLACK", "number": 9, "isJoker": false }
+                ]
+            }
+        """.trimIndent()
+
+        val game = confirmedGame()
+
+        `when`(
+            endTurnService.endTurn(
+                eq("game-1"),
+                eq("user-1"),
+                any()
+            )
+        ).thenReturn(game)
+
+        mockMvc.post("/api/games/game-1/end-turn") {
+            header("X-User-Id", "user-1")
+            contentType = MediaType.APPLICATION_JSON
+            content = requestJson
+        }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.gameId") { value("game-1") }
+                jsonPath("$.currentPlayerUserId") { value("user-1") }
+                jsonPath("$.status") { value("ACTIVE") }
+            }
+    }
+
+    @Test
+    fun `endTurn returns 404 when game or draft does not exist`() {
+        `when`(endTurnService.endTurn(any(), any(), any()))
+            .thenThrow(NoSuchElementException("Game not found"))
+
+        mockMvc.post("/api/games/missing-game/end-turn") {
+            header("X-User-Id", "user-1")
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                    "boardSets": [],
+                    "rackTiles": []
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isNotFound() }
+                jsonPath("$.errorCode") { value("NOT_FOUND") }
+                jsonPath("$.errorMessage") { value("Game not found") }
+            }
+    }
+
+    @Test
+    fun `endTurn returns 409 when game rule is violated`() {
+        `when`(endTurnService.endTurn(any(), any(), any()))
+            .thenThrow(IllegalStateException("Game is not active"))
+
+        mockMvc.post("/api/games/game-1/end-turn") {
+            header("X-User-Id", "user-1")
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                    "boardSets": [],
+                    "rackTiles": []
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isConflict() }
+                jsonPath("$.errorCode") { value("CONFLICT") }
+                jsonPath("$.errorMessage") { value("Game is not active") }
+            }
+    }
+
+    @Test
+    fun `endTurn returns 409 when submitted draft is invalid`() {
+        `when`(endTurnService.endTurn(any(), any(), any()))
+            .thenThrow(InvalidTurnSubmissionException(emptyList()))
+
+        mockMvc.post("/api/games/game-1/end-turn") {
+            header("X-User-Id", "user-1")
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                    "boardSets": [],
+                    "rackTiles": []
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isConflict() }
+                jsonPath("$.errorCode") { value("INVALID_TURN_SUBMISSION") }
+                jsonPath("$.errorMessage") { value("Submitted draft is invalid") }
+            }
+    }
 
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.post
 import org.springframework.http.MediaType
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import shared.models.game.validation.ValidationResult
 
 
 @WebMvcTest(GameController::class)
@@ -312,7 +313,7 @@ class GameControllerTest {
     @Test
     fun `endTurn returns 409 when submitted draft is invalid`() {
         `when`(endTurnService.endTurn(any(), any(), any()))
-            .thenThrow(InvalidTurnSubmissionException(emptyList()))
+            .thenThrow(InvalidTurnSubmissionException(ValidationResult()))
 
         mockMvc.post("/api/games/game-1/end-turn") {
             header("X-User-Id", "user-1")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -39,5 +39,6 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.statusCode)
         assertEquals("INVALID_TURN_SUBMISSION", response.body?.errorCode)
         assertEquals("Submitted draft is invalid", response.body?.errorMessage)
+        assertEquals(ex.violations, response.body?.violations)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.ValidationResult
 
 class GlobalExceptionHandlerTest {
 
@@ -23,7 +24,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     fun `handleInvalidTurnSubmission should return 409`() {
-        val ex = InvalidTurnSubmissionException(
+        val validationResult = ValidationResult(
             violations = listOf(
                 RuleViolation(
                     code = "INVALID_SET",
@@ -34,11 +35,13 @@ class GlobalExceptionHandlerTest {
             )
         )
 
+        val ex = InvalidTurnSubmissionException(validationResult)
+
         val response = handler.handleInvalidTurnSubmission(ex)
 
         assertEquals(HttpStatus.CONFLICT, response.statusCode)
         assertEquals("INVALID_TURN_SUBMISSION", response.body?.errorCode)
         assertEquals("Submitted draft is invalid", response.body?.errorMessage)
-        assertEquals(ex.violations, response.body?.violations)
+        assertEquals(validationResult.violations, response.body?.violations)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -1,8 +1,10 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.service.InvalidTurnSubmissionException
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Assertions.assertEquals
+import shared.models.game.validation.RuleViolation
 
 class GlobalExceptionHandlerTest {
 
@@ -17,5 +19,25 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.statusCode)
         assertEquals("CONFLICT", response.body?.errorCode)
         assertEquals("test error", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleInvalidTurnSubmission should return 409`() {
+        val ex = InvalidTurnSubmissionException(
+            violations = listOf(
+                RuleViolation(
+                    code = "INVALID_SET",
+                    message = "Set is invalid",
+                    boardSetId = "set-1",
+                    tileIds = listOf("tile-1", "tile-2")
+                )
+            )
+        )
+
+        val response = handler.handleInvalidTurnSubmission(ex)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals("INVALID_TURN_SUBMISSION", response.body?.errorCode)
+        assertEquals("Submitted draft is invalid", response.body?.errorMessage)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameRequestDtoTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameRequestDtoTest.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.dto
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import shared.models.game.domain.BoardSetType
 import shared.models.game.request.BoardSetRequest
@@ -34,9 +35,13 @@ class GameRequestDtoTest {
 
     @Test
     fun `creates end turn request`() {
-        val request = EndTurnRequest(playerId = "player-1")
+        val request = EndTurnRequest(
+            boardSets = emptyList(),
+            rackTiles = emptyList()
+        )
 
-        assertEquals("player-1", request.playerId)
+        assertTrue(request.boardSets.isEmpty())
+        assertTrue(request.rackTiles.isEmpty())
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -243,6 +243,49 @@ class EndTurnServiceTest {
         verify(gameBroadcastService, never()).broadcastDraftUpdated(any())
     }
 
+    @Test
+    fun `finishes game and skips next draft when acting player rack becomes empty`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(
+                Optional.of(
+                    gameEntity(
+                        user1Rack = mutableListOf(tile("old-user-1-rack")),
+                        user2Rack = mutableListOf(tile("user-2-rack"))
+                    )
+                )
+            )
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(valid())
+
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn(
+            gameId = "game-1",
+            userId = "user-1",
+            request = request(rackTiles = emptyList())
+        )
+
+        assertEquals(GameStatus.FINISHED, result.status)
+        assertTrue(result.finishedAt != null)
+        assertEquals("user-1", result.currentPlayerUserId)
+        assertEquals(emptyList<String>(), result.players.first { it.userId == "user-1" }.rackTiles.map { it.tileId })
+        assertEquals(listOf("user-2-rack"), result.players.first { it.userId == "user-2" }.rackTiles.map { it.tileId })
+
+        verify(gameRepository).save(any())
+        verify(turnDraftRepository).deleteById("game-1")
+        verify(turnDraftRepository, never()).save(any())
+
+        verify(gameBroadcastService).broadcastGameUpdated(result)
+        verify(gameBroadcastService).broadcastGameEnded("game-1", "user-1")
+        verify(gameBroadcastService, never()).broadcastTurnChanged(any(), any())
+        verify(gameBroadcastService, never()).broadcastDraftUpdated(any())
+    }
+
     private fun request(
         rackTiles: List<TileRequest> = listOf(TileRequest("new-rack-tile", "BLACK", 9, false))
     ) = EndTurnRequest(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -1,0 +1,314 @@
+package at.se2group.backend.game.service
+
+import at.se2group.backend.persistence.GameEntity
+import at.se2group.backend.persistence.GamePlayerEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.TileEmbeddable
+import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.rules.service.RummikubRuleService
+import at.se2group.backend.service.AfterCommitExecutor
+import at.se2group.backend.service.EndTurnService
+import at.se2group.backend.service.GameBroadcastService
+import at.se2group.backend.service.GameService
+import at.se2group.backend.service.InvalidTurnSubmissionException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.TileColor
+import shared.models.game.request.BoardSetRequest
+import shared.models.game.request.EndTurnRequest
+import shared.models.game.request.TileRequest
+import shared.models.game.validation.invalid
+import shared.models.game.validation.valid
+import java.time.Instant
+import java.util.Optional
+
+class EndTurnServiceTest {
+
+    private val gameRepository: GameRepository = mock()
+    private val turnDraftRepository: TurnDraftRepository = mock()
+    private val rummikubRuleService: RummikubRuleService = mock()
+    private val gameBroadcastService: GameBroadcastService = mock()
+
+    private val gameService = GameService(gameRepository)
+    private val afterCommitExecutor = AfterCommitExecutor()
+
+    private val endTurnService = EndTurnService(
+        gameRepository = gameRepository,
+        turnDraftRepository = turnDraftRepository,
+        gameService = gameService,
+        rummikubRuleService = rummikubRuleService,
+        gameBroadcastService = gameBroadcastService,
+        afterCommitExecutor = afterCommitExecutor
+    )
+
+    @Test
+    fun `rejects when game does not exist`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.empty())
+
+        assertThrows<NoSuchElementException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(gameRepository, never()).save(any())
+        verify(turnDraftRepository, never()).save(any())
+        verify(gameBroadcastService, never()).broadcastGameUpdated(any())
+    }
+
+    @Test
+    fun `rejects when draft does not exist`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity()))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(null)
+
+        assertThrows<NoSuchElementException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(gameRepository, never()).save(any())
+        verify(turnDraftRepository, never()).save(any())
+    }
+
+    @Test
+    fun `rejects when user is not current player`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity(currentPlayerUserId = "user-1")))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity(playerUserId = "user-2"))
+
+        assertThrows<IllegalStateException> {
+            endTurnService.endTurn("game-1", "user-2", request())
+        }
+
+        verify(rummikubRuleService, never()).validateSubmittedDraft(any(), any(), any())
+        verify(gameRepository, never()).save(any())
+    }
+
+    @Test
+    fun `rejects when draft belongs to another user`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity(currentPlayerUserId = "user-1")))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity(playerUserId = "user-2"))
+
+        assertThrows<IllegalStateException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(rummikubRuleService, never()).validateSubmittedDraft(any(), any(), any())
+        verify(gameRepository, never()).save(any())
+    }
+
+    @Test
+    fun `rejects when game is not active`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity(status = GameStatus.WAITING)))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        assertThrows<IllegalStateException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(rummikubRuleService, never()).validateSubmittedDraft(any(), any(), any())
+        verify(gameRepository, never()).save(any())
+    }
+
+    @Test
+    fun `rejects when submitted draft validation is invalid`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity()))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(invalid("INVALID_SET", "Set is invalid"))
+
+        assertThrows<InvalidTurnSubmissionException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(gameRepository, never()).save(any())
+        verify(turnDraftRepository, never()).save(any())
+        verify(gameBroadcastService, never()).broadcastGameUpdated(any())
+    }
+
+    @Test
+    fun `commits board and acting player rack then advances to next player`() {
+        val game = gameEntity(
+            user1Rack = mutableListOf(tile("old-rack-tile")),
+            user2Rack = mutableListOf(tile("user-2-rack"))
+        )
+
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(game))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(valid())
+
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        whenever(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn("game-1", "user-1", request())
+
+        assertEquals("user-2", result.currentPlayerUserId)
+        assertEquals(1, result.boardSets.size)
+        assertEquals("set-1", result.boardSets.single().boardSetId)
+
+        val user1 = result.players.first { it.userId == "user-1" }
+        assertEquals(listOf("new-rack-tile"), user1.rackTiles.map { it.tileId })
+
+        verify(gameRepository).save(any())
+        verify(turnDraftRepository).save(any())
+        verify(gameBroadcastService).broadcastGameUpdated(result)
+        verify(gameBroadcastService).broadcastTurnChanged("game-1", "user-2")
+        verify(gameBroadcastService).broadcastDraftUpdated(any())
+    }
+
+    @Test
+    fun `replaces old draft with next player draft`() {
+        val draft = draftEntity(playerUserId = "user-1", version = 4)
+
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity(user2Rack = mutableListOf(tile("user-2-rack")))))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draft)
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(valid())
+
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        whenever(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        endTurnService.endTurn("game-1", "user-1", request())
+
+        assertEquals("user-2", draft.playerUserId)
+        assertEquals(0, draft.version)
+        assertEquals(listOf("user-2-rack"), draft.rackTiles.map { it.tileId })
+    }
+
+    @Test
+    fun `finishes game when acting player rack becomes empty`() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(gameEntity()))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(valid())
+
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn(
+            gameId = "game-1",
+            userId = "user-1",
+            request = request(rackTiles = emptyList())
+        )
+
+        assertEquals(GameStatus.FINISHED, result.status)
+        assertTrue(result.finishedAt != null)
+
+        verify(turnDraftRepository).deleteById("game-1")
+        verify(turnDraftRepository, never()).save(any())
+        verify(gameBroadcastService).broadcastGameUpdated(result)
+        verify(gameBroadcastService).broadcastGameEnded("game-1", "user-1")
+        verify(gameBroadcastService, never()).broadcastTurnChanged(any(), any())
+        verify(gameBroadcastService, never()).broadcastDraftUpdated(any())
+    }
+
+    private fun request(
+        rackTiles: List<TileRequest> = listOf(TileRequest("new-rack-tile", "BLACK", 9, false))
+    ) = EndTurnRequest(
+        boardSets = listOf(
+            BoardSetRequest(
+                boardSetId = "set-1",
+                type = shared.models.game.domain.BoardSetType.RUN,
+                tiles = listOf(
+                    TileRequest("tile-1", "RED", 3, false),
+                    TileRequest("tile-2", "RED", 4, false),
+                    TileRequest("tile-3", "RED", 5, false)
+                )
+            )
+        ),
+        rackTiles = rackTiles
+    )
+
+    private fun gameEntity(
+        currentPlayerUserId: String = "user-1",
+        status: GameStatus = GameStatus.ACTIVE,
+        user1Rack: MutableList<TileEmbeddable> = mutableListOf(),
+        user2Rack: MutableList<TileEmbeddable> = mutableListOf()
+    ): GameEntity {
+        val game = GameEntity(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            currentPlayerUserId = currentPlayerUserId,
+            status = status,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        )
+
+        game.players = mutableListOf(
+            GamePlayerEntity(
+                game = game,
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                rackTiles = user1Rack,
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            ),
+            GamePlayerEntity(
+                game = game,
+                userId = "user-2",
+                displayName = "Bob",
+                turnOrder = 1,
+                rackTiles = user2Rack,
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            )
+        )
+
+        return game
+    }
+
+    private fun draftEntity(
+        playerUserId: String = "user-1",
+        version: Long = 0
+    ) = TurnDraftEntity(
+        gameId = "game-1",
+        playerUserId = playerUserId,
+        version = version
+    )
+
+    private fun tile(tileId: String) = TileEmbeddable(
+        tileId = tileId,
+        color = TileColor.RED,
+        number = 5,
+        joker = false
+    )
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/InvalidTurnSubmissionExceptionTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/InvalidTurnSubmissionExceptionTest.kt
@@ -1,0 +1,26 @@
+package at.se2group.backend.game.service
+
+import at.se2group.backend.service.InvalidTurnSubmissionException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import shared.models.game.validation.RuleViolation
+
+class InvalidTurnSubmissionExceptionTest {
+
+    @Test
+    fun `stores rule violations and exposes default message`() {
+        val violations = listOf(
+            RuleViolation(
+                code = "INVALID_SET",
+                message = "Set is invalid",
+                boardSetId = "set-1",
+                tileIds = listOf("tile-1", "tile-2")
+            )
+        )
+
+        val exception = InvalidTurnSubmissionException(violations)
+
+        assertEquals("Submitted draft is invalid", exception.message)
+        assertEquals(violations, exception.violations)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/InvalidTurnSubmissionExceptionTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/InvalidTurnSubmissionExceptionTest.kt
@@ -4,23 +4,26 @@ import at.se2group.backend.service.InvalidTurnSubmissionException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import shared.models.game.validation.RuleViolation
+import shared.models.game.validation.ValidationResult
 
 class InvalidTurnSubmissionExceptionTest {
 
     @Test
-    fun `stores rule violations and exposes default message`() {
-        val violations = listOf(
-            RuleViolation(
-                code = "INVALID_SET",
-                message = "Set is invalid",
-                boardSetId = "set-1",
-                tileIds = listOf("tile-1", "tile-2")
+    fun `stores validation result and exposes default message`() {
+        val validationResult = ValidationResult(
+            violations = listOf(
+                RuleViolation(
+                    code = "INVALID_SET",
+                    message = "Set is invalid",
+                    boardSetId = "set-1",
+                    tileIds = listOf("tile-1", "tile-2")
+                )
             )
         )
 
-        val exception = InvalidTurnSubmissionException(violations)
+        val exception = InvalidTurnSubmissionException(validationResult)
 
         assertEquals("Submitted draft is invalid", exception.message)
-        assertEquals(violations, exception.violations)
+        assertEquals(validationResult, exception.validationResult)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/TurnDraftMapperTest.kt
@@ -9,6 +9,7 @@ import shared.models.game.request.TileRequest
 import shared.models.game.request.UpdateDraftRequest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import shared.models.game.request.EndTurnRequest
 
 class TurnDraftMapperTest {
 
@@ -228,6 +229,44 @@ class TurnDraftMapperTest {
         assertEquals("tile-1", response.draftBoard.single().tiles.single().tileId)
         assertEquals("tile-2", response.draftHand.single().tileId)
         assertTrue(response.draftHand.single().isJoker)
+    }
+
+    @Test
+    fun `should map EndTurnRequest to TurnDraft`() {
+        val request = EndTurnRequest(
+            boardSets = listOf(
+                BoardSetRequest(
+                    boardSetId = "set-1",
+                    type = BoardSetType.RUN,
+                    tiles = listOf(
+                        TileRequest("tile-1", "RED", 3, false),
+                        TileRequest("tile-2", "RED", 4, false),
+                        TileRequest("tile-3", "RED", 5, false)
+                    )
+                )
+            ),
+            rackTiles = listOf(
+                TileRequest("tile-4", "BLACK", null, true)
+            )
+        )
+
+        val result = request.toDomain(
+            gameId = "game-1",
+            userId = "user-1"
+        )
+
+        assertEquals("game-1", result.gameId)
+        assertEquals("user-1", result.playerUserId)
+        assertEquals(0, result.version)
+
+        assertEquals(1, result.boardSets.size)
+        assertEquals("set-1", result.boardSets.single().boardSetId)
+        assertEquals(BoardSetType.RUN, result.boardSets.single().type)
+        assertEquals(3, result.boardSets.single().tiles.size)
+        assertEquals(numbered("tile-1", TileColor.RED, 3), result.boardSets.single().tiles[0])
+
+        assertEquals(1, result.rackTiles.size)
+        assertEquals(joker("tile-4", TileColor.BLACK), result.rackTiles.single())
     }
 
     private fun numbered(tileId: String, color: TileColor, number: Int) =

--- a/apps/shared/src/main/kotlin/shared/models/api/ApiErrorResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/api/ApiErrorResponse.kt
@@ -1,6 +1,9 @@
 package shared.models.api
 
+import shared.models.game.validation.RuleViolation
+
 data class ApiErrorResponse(
     val errorCode: String,
-    val errorMessage: String
+    val errorMessage: String,
+    val violations: List<RuleViolation> = emptyList()
 )

--- a/apps/shared/src/main/kotlin/shared/models/game/request/EndTurnRequest.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/request/EndTurnRequest.kt
@@ -1,5 +1,6 @@
 package shared.models.game.request
 
 data class EndTurnRequest(
-    val playerId: String
+    val boardSets: List<BoardSetRequest>,
+    val rackTiles: List<TileRequest>
 )


### PR DESCRIPTION
## Summary
This PR should implement the strict move-submission flow behind POST /api/games/{gameId}/end-turn by consuming the finished RummikubRuleService.

This PR assumes the rule layer already exists and does not re-explain it. The core question for this PR is:

“Can the active player submit their current draft in the end-turn request, have it validated against confirmed server state, and have it committed into the next confirmed game state?”

## Issues

- Closes #338 
- Closes #337 
- Closes #336 
- Closes #310 
- Closes #306 
- Closes #328 
- Closes #252 
- Closes #253 
- Closes #254 
- Closes #255 
- Related to #256 
- Related to #312 
- Closes #314
- Closes #315  
- Closes #316 
- Closes #317 
- Closes #318 
- Closes #319 
- Closes #320 
- Related to #322 
- Closes #324 
- Closes #343 
- Related to #349 
- Closes #358 
- Closes #356 
- Related to #372 
- Closes #378 
- Closes #379 
- Closes #380 
- Related to #383 


## Scope
Included:
- end-turn application service
- POST /api/games/{gameId}/end-turn
- validation before commit
- commit from TurnDraft into ConfirmedGame
- next-player advancement
- next-turn draft replacement
- websocket emission after successful commit

Not included:
- first-move validation
- initial-meld progression
- draw-and-end-turn combined rule variants
- timeout handling
- reset-draft reintroduction

## Related Issue

Closes #
Related to #

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / setup
- [x] Test