### PR TITLE
chore(backend)(android): add structured request, response, and socket event logging

### DIFF
--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -50,6 +50,17 @@ tasks.test {
 
 tasks.jacocoTestReport {
     dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(
+            classDirectories.files.map { classesDir ->
+                fileTree(classesDir) {
+                    // Ignore stale duplicate class artifacts such as "Foo 2.class" that can
+                    // appear in local incremental output and break JaCoCo bundle creation.
+                    exclude("**/* 2.class")
+                }
+            }
+        )
+    )
     reports {
         xml.required.set(true)
         html.required.set(true)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -8,12 +8,35 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import shared.models.api.ApiErrorResponse
 
+/**
+ * Centralized HTTP exception mapping for backend REST endpoints.
+ *
+ * This advice translates common backend exceptions into stable API responses so
+ * that controllers can remain thin and service code can signal failures through
+ * exceptions instead of hand-building response entities. The handler is also a
+ * logging boundary: expected client-caused failures are logged at `WARN`, while
+ * unexpected backend failures are logged at `ERROR`.
+ *
+ * Current mapping policy:
+ *
+ * - [IllegalArgumentException] -> `400 BAD_REQUEST`
+ * - [NoSuchElementException] -> `404 NOT_FOUND`
+ * - [IllegalStateException] -> `409 CONFLICT`
+ * - [SecurityException] -> `403 FORBIDDEN`
+ * - [InvalidTurnSubmissionException] -> `409 INVALID_TURN_SUBMISSION`
+ * - all other [Exception] types -> `500 INTERNAL_SERVER_ERROR`
+ *
+ * The rule-validation path is handled explicitly through
+ * [InvalidTurnSubmissionException], which preserves structured
+ * `RuleViolation` data for clients that need detailed move rejection reasons.
+ */
 @RestControllerAdvice
 class GlobalExceptionHandler {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(Exception::class)
     fun handleGeneric(ex: Exception): ResponseEntity<ApiErrorResponse> {
+        // Unexpected exceptions indicate a backend failure rather than a normal client mistake.
         logger.error("Unhandled backend exception", ex)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -27,6 +50,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ApiErrorResponse> {
+        // Invalid input is expected to happen at the API boundary and should stay visible but non-fatal.
         logger.warn("Bad request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -81,6 +105,7 @@ class GlobalExceptionHandler {
     fun handleInvalidTurnSubmission(
         ex: InvalidTurnSubmissionException
     ): ResponseEntity<ApiErrorResponse> {
+        // Keep rule-validation failures structured so clients can show precise move feedback.
         logger.warn(
             "Invalid turn submission with {} rule violation(s): {}",
             ex.validationResult.violations.size,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.api
 
 import at.se2group.backend.service.InvalidTurnSubmissionException
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -9,8 +10,11 @@ import shared.models.api.ApiErrorResponse
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     @ExceptionHandler(Exception::class)
     fun handleGeneric(ex: Exception): ResponseEntity<ApiErrorResponse> {
+        logger.error("Unhandled backend exception", ex)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(
@@ -23,6 +27,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Bad request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(
@@ -35,6 +40,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException::class)
     fun handleNoSuchElement(ex: NoSuchElementException): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Resource not found: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .body(
@@ -47,6 +53,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException::class)
     fun handleIllegalState(ex: IllegalStateException): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Conflict while processing request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
             .body(
@@ -59,6 +66,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(SecurityException::class)
     fun handleSecurity(ex: SecurityException): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Forbidden request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)
             .body(
@@ -73,6 +81,11 @@ class GlobalExceptionHandler {
     fun handleInvalidTurnSubmission(
         ex: InvalidTurnSubmissionException
     ): ResponseEntity<ApiErrorResponse> {
+        logger.warn(
+            "Invalid turn submission with {} rule violation(s): {}",
+            ex.validationResult.violations.size,
+            ex.message
+        )
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
             .body(

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/RequestResponseLoggingFilter.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/RequestResponseLoggingFilter.kt
@@ -12,6 +12,31 @@ import org.springframework.web.util.ContentCachingResponseWrapper
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
+/**
+ * Logs every HTTP request/response exchange that passes through the backend servlet chain.
+ *
+ * The filter exists to make transport-level backend behavior observable without pushing logging
+ * responsibilities into individual controllers. It records:
+ *
+ * - HTTP method
+ * - request URI and optional query string
+ * - response status
+ * - request duration
+ * - request payload for loggable text-based content types
+ * - response payload for loggable text-based content types
+ *
+ * Binary or otherwise non-text payloads are not expanded into logs. Instead, the filter logs a
+ * short placeholder containing only the payload size. This keeps the logs readable and avoids
+ * polluting them with opaque byte output.
+ *
+ * The implementation uses [ContentCachingRequestWrapper] and [ContentCachingResponseWrapper] so
+ * that payloads can be inspected after downstream processing has run. The response wrapper must be
+ * copied back into the real response before the request completes, otherwise the client would
+ * receive an empty body.
+ *
+ * This filter is intentionally generic and backend-wide. It should stay at the HTTP boundary and
+ * should not take on controller-specific or domain-specific logging concerns.
+ */
 @Component
 class RequestResponseLoggingFilter : OncePerRequestFilter() {
 
@@ -41,6 +66,7 @@ class RequestResponseLoggingFilter : OncePerRequestFilter() {
         startNanos: Long
     ) {
         val durationMs = (System.nanoTime() - startNanos) / 1_000_000
+        // Keep the path formatting stable whether a query string is present or not.
         val querySuffix = request.queryString?.let { "?$it" } ?: ""
 
         requestLogger.info(
@@ -65,6 +91,7 @@ class RequestResponseLoggingFilter : OncePerRequestFilter() {
         }
 
         if (!isLoggableTextContent(contentType)) {
+            // For non-text payloads, log only the size instead of raw binary content.
             return "[${content.size} bytes omitted]"
         }
 
@@ -81,6 +108,7 @@ class RequestResponseLoggingFilter : OncePerRequestFilter() {
             ?.let { runCatching { MediaType.parseMediaType(it) }.getOrNull() }
             ?: return false
 
+        // Allow common structured and plain-text media types to appear directly in the log output.
         return mediaType.includes(MediaType.APPLICATION_JSON) ||
             mediaType.includes(MediaType.APPLICATION_XML) ||
             mediaType.includes(MediaType.TEXT_PLAIN) ||

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/RequestResponseLoggingFilter.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/RequestResponseLoggingFilter.kt
@@ -1,0 +1,93 @@
+package at.se2group.backend.api
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+@Component
+class RequestResponseLoggingFilter : OncePerRequestFilter() {
+
+    private val requestLogger = LoggerFactory.getLogger(javaClass)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val startNanos = System.nanoTime()
+        val wrappedRequest = ContentCachingRequestWrapper(request)
+        val wrappedResponse = ContentCachingResponseWrapper(response)
+
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse)
+        } finally {
+            logExchange(wrappedRequest, wrappedResponse, startNanos)
+            // ContentCachingResponseWrapper buffers the body, so it must be copied back explicitly.
+            wrappedResponse.copyBodyToResponse()
+        }
+    }
+
+    private fun logExchange(
+        request: ContentCachingRequestWrapper,
+        response: ContentCachingResponseWrapper,
+        startNanos: Long
+    ) {
+        val durationMs = (System.nanoTime() - startNanos) / 1_000_000
+        val querySuffix = request.queryString?.let { "?$it" } ?: ""
+
+        requestLogger.info(
+            "HTTP {} {}{} -> {} in {} ms | requestBody={} | responseBody={}",
+            request.method,
+            request.requestURI,
+            querySuffix,
+            response.status,
+            durationMs,
+            extractPayload(request.contentAsByteArray, request.characterEncoding, request.contentType),
+            extractPayload(response.contentAsByteArray, response.characterEncoding, response.contentType)
+        )
+    }
+
+    private fun extractPayload(
+        content: ByteArray,
+        characterEncoding: String?,
+        contentType: String?
+    ): String {
+        if (content.isEmpty()) {
+            return "-"
+        }
+
+        if (!isLoggableTextContent(contentType)) {
+            return "[${content.size} bytes omitted]"
+        }
+
+        val charset = characterEncoding
+            ?.let { runCatching { Charset.forName(it) }.getOrNull() }
+            ?: StandardCharsets.UTF_8
+
+        val payload = String(content, charset).replace("\n", "\\n")
+        return payload.take(MAX_PAYLOAD_LENGTH)
+    }
+
+    private fun isLoggableTextContent(contentType: String?): Boolean {
+        val mediaType = contentType
+            ?.let { runCatching { MediaType.parseMediaType(it) }.getOrNull() }
+            ?: return false
+
+        return mediaType.includes(MediaType.APPLICATION_JSON) ||
+            mediaType.includes(MediaType.APPLICATION_XML) ||
+            mediaType.includes(MediaType.TEXT_PLAIN) ||
+            mediaType.type == "text"
+    }
+
+    private companion object {
+        const val MAX_PAYLOAD_LENGTH = 2_000
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameBroadcastService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameBroadcastService.kt
@@ -1,6 +1,7 @@
 package at.se2group.backend.service
 
 import at.se2group.backend.mapper.toResponse
+import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import shared.models.game.domain.ConfirmedGame
@@ -15,6 +16,8 @@ import shared.models.game.event.TurnTimedOutEvent
 class GameBroadcastService(
     private val messagingTemplate: SimpMessagingTemplate
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     private companion object {
         const val GAME_TOPIC_PREFIX = "/topic/games"
     }
@@ -22,6 +25,12 @@ class GameBroadcastService(
     private fun gameTopic(gameId: String) = "$GAME_TOPIC_PREFIX/$gameId"
 
     fun broadcastDraftUpdated(draft: TurnDraft) {
+        logger.info(
+            "Broadcasting game.draft.updated to topic={} for gameId={} playerUserId={}",
+            gameTopic(draft.gameId),
+            draft.gameId,
+            draft.playerUserId
+        )
         messagingTemplate.convertAndSend(
             gameTopic(draft.gameId),
             GameDraftUpdatedEvent(
@@ -33,6 +42,13 @@ class GameBroadcastService(
     }
 
     fun broadcastGameUpdated(game: ConfirmedGame) {
+        logger.info(
+            "Broadcasting game.updated to topic={} for gameId={} currentPlayerUserId={} status={}",
+            gameTopic(game.gameId),
+            game.gameId,
+            game.currentPlayerUserId,
+            game.status
+        )
         messagingTemplate.convertAndSend(
             gameTopic(game.gameId),
             GameUpdatedEvent(
@@ -43,6 +59,12 @@ class GameBroadcastService(
     }
 
     fun broadcastTurnChanged(gameId: String, currentTurnPlayerId: String) {
+        logger.info(
+            "Broadcasting turn.changed to topic={} for gameId={} currentTurnPlayerId={}",
+            gameTopic(gameId),
+            gameId,
+            currentTurnPlayerId
+        )
         messagingTemplate.convertAndSend(
             gameTopic(gameId),
             TurnChangedEvent(
@@ -53,6 +75,12 @@ class GameBroadcastService(
     }
 
     fun broadcastTurnTimedOut(gameId: String, previousTurnPlayerId: String) {
+        logger.info(
+            "Broadcasting turn.timed_out to topic={} for gameId={} previousTurnPlayerId={}",
+            gameTopic(gameId),
+            gameId,
+            previousTurnPlayerId
+        )
         messagingTemplate.convertAndSend(
             gameTopic(gameId),
             TurnTimedOutEvent(
@@ -63,6 +91,12 @@ class GameBroadcastService(
     }
 
     fun broadcastGameEnded(gameId: String, winnerUserId: String) {
+        logger.info(
+            "Broadcasting game.ended to topic={} for gameId={} winnerUserId={}",
+            gameTopic(gameId),
+            gameId,
+            winnerUserId
+        )
         messagingTemplate.convertAndSend(
             gameTopic(gameId),
             GameEndedEvent(

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameBroadcastService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameBroadcastService.kt
@@ -12,6 +12,26 @@ import shared.models.game.event.GameUpdatedEvent
 import shared.models.game.event.TurnChangedEvent
 import shared.models.game.event.TurnTimedOutEvent
 
+/**
+ * Emits backend game websocket events to the shared game topic namespace.
+ *
+ * This service centralizes topic naming and payload construction for the game
+ * realtime channel so that application services do not talk to
+ * [SimpMessagingTemplate] directly. It also logs every emitted event with the
+ * key routing identifiers needed to reconstruct match flow in logs.
+ *
+ * The service currently covers:
+ *
+ * - live draft updates
+ * - confirmed game state updates
+ * - turn ownership changes
+ * - turn timeout notifications
+ * - game end notifications
+ *
+ * Logging at this boundary is intentionally concise: it records event type,
+ * topic, and key identifiers, but does not dump full domain objects into the
+ * log stream.
+ */
 @Service
 class GameBroadcastService(
     private val messagingTemplate: SimpMessagingTemplate
@@ -25,6 +45,7 @@ class GameBroadcastService(
     private fun gameTopic(gameId: String) = "$GAME_TOPIC_PREFIX/$gameId"
 
     fun broadcastDraftUpdated(draft: TurnDraft) {
+        // Log before emission so failed or interrupted send paths still leave a trace in the backend logs.
         logger.info(
             "Broadcasting game.draft.updated to topic={} for gameId={} playerUserId={}",
             gameTopic(draft.gameId),

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
@@ -4,6 +4,7 @@ import at.se2group.backend.dto.LobbyDeletedEvent
 import at.se2group.backend.dto.LobbyStartedEvent
 import at.se2group.backend.dto.LobbyUpdatedEvent
 import at.se2group.backend.mapper.toResponse
+import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import shared.models.lobby.domain.Lobby
@@ -12,8 +13,15 @@ import shared.models.lobby.domain.Lobby
 class LobbyBroadcastService(
     private val messagingTemplate: SimpMessagingTemplate
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
 
     fun broadcastLobbyUpdated(lobby: Lobby) {
+        logger.info(
+            "Broadcasting lobby.updated to topic=/topic/lobbies/{} for lobbyId={} status={}",
+            lobby.lobbyId,
+            lobby.lobbyId,
+            lobby.status
+        )
         messagingTemplate.convertAndSend(
             "/topic/lobbies/${lobby.lobbyId}",
             LobbyUpdatedEvent(lobby = lobby.toResponse())
@@ -21,6 +29,11 @@ class LobbyBroadcastService(
     }
 
     fun broadcastLobbyDeleted(lobbyId: String) {
+        logger.info(
+            "Broadcasting lobby.deleted to topic=/topic/lobbies/{} for lobbyId={}",
+            lobbyId,
+            lobbyId
+        )
         messagingTemplate.convertAndSend(
             "/topic/lobbies/$lobbyId",
             LobbyDeletedEvent(lobbyId = lobbyId)
@@ -28,6 +41,12 @@ class LobbyBroadcastService(
     }
 
     fun broadcastLobbyStarted(lobbyId: String, matchId: String) {
+        logger.info(
+            "Broadcasting lobby.started to topic=/topic/lobbies/{} for lobbyId={} matchId={}",
+            lobbyId,
+            lobbyId,
+            matchId
+        )
         messagingTemplate.convertAndSend(
             "/topic/lobbies/$lobbyId",
             LobbyStartedEvent(

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyBroadcastService.kt
@@ -9,6 +9,24 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import shared.models.lobby.domain.Lobby
 
+/**
+ * Emits backend lobby websocket events to lobby-specific topics.
+ *
+ * The service keeps websocket topic construction and event payload creation out
+ * of the main lobby service layer. That keeps the lobby application logic
+ * focused on state transitions while this class owns the realtime transport
+ * contract and its logging.
+ *
+ * Emitted event families:
+ *
+ * - lobby state updates
+ * - lobby deletion notifications
+ * - lobby start notifications with the created match id
+ *
+ * Each emission is logged with the event type and its routing identifiers so
+ * that lobby lifecycle problems can be traced without inspecting the full
+ * payload bodies.
+ */
 @Service
 class LobbyBroadcastService(
     private val messagingTemplate: SimpMessagingTemplate
@@ -16,6 +34,7 @@ class LobbyBroadcastService(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     fun broadcastLobbyUpdated(lobby: Lobby) {
+        // Log before emission so lobby lifecycle transitions remain visible even if delivery is investigated later.
         logger.info(
             "Broadcasting lobby.updated to topic=/topic/lobbies/{} for lobbyId={} status={}",
             lobby.lobbyId,

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -1,9 +1,15 @@
 package at.se2group.backend.api
 
 import at.se2group.backend.service.InvalidTurnSubmissionException
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.slf4j.LoggerFactory
 import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
 
@@ -43,5 +49,37 @@ class GlobalExceptionHandlerTest {
         assertEquals("INVALID_TURN_SUBMISSION", response.body?.errorCode)
         assertEquals("Submitted draft is invalid", response.body?.errorMessage)
         assertEquals(validationResult.violations, response.body?.violations)
+    }
+
+    @Test
+    fun `handleIllegalState logs warning`() {
+        val appender = attachAppender()
+
+        handler.handleIllegalState(IllegalStateException("state conflict"))
+
+        val event = appender.list.single()
+        assertEquals(Level.WARN, event.level)
+        assertTrue(event.formattedMessage.contains("Conflict while processing request: state conflict"))
+    }
+
+    @Test
+    fun `handleGeneric logs error with exception`() {
+        val appender = attachAppender()
+        val exception = RuntimeException("boom")
+
+        handler.handleGeneric(exception)
+
+        val event = appender.list.single()
+        assertEquals(Level.ERROR, event.level)
+        assertEquals("boom", event.throwableProxy?.message)
+        assertTrue(event.formattedMessage.contains("Unhandled backend exception"))
+    }
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import java.nio.charset.StandardCharsets
@@ -68,6 +69,201 @@ class RequestResponseLoggingFilterTest {
         assertTrue(event.formattedMessage.contains("HTTP GET /actuator/health -> 200"))
         assertTrue(event.formattedMessage.contains("requestBody=-"))
         assertTrue(event.formattedMessage.contains("responseBody=-"))
+    }
+
+    @Test
+    fun `logs request without query string`() {
+        val request = MockHttpServletRequest("POST", "/api/no-query").apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("""{"simple":true}""".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = MediaType.APPLICATION_JSON_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("""{"accepted":true}""")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("HTTP POST /api/no-query -> 200"))
+        assertTrue(!event.formattedMessage.contains("/api/no-query?"))
+    }
+
+    @Test
+    fun `omits binary request and response payloads from logs`() {
+        val requestBytes = byteArrayOf(1, 2, 3, 4)
+        val responseBytes = byteArrayOf(5, 6, 7)
+        val request = MockHttpServletRequest("POST", "/api/binary").apply {
+            contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE
+            setContent(requestBytes)
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.inputStream.readAllBytes()
+                res.contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE
+                res.outputStream.write(responseBytes)
+                res.outputStream.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertEquals(responseBytes.toList(), response.contentAsByteArray.toList())
+        assertTrue(event.formattedMessage.contains("requestBody=[4 bytes omitted]"))
+        assertTrue(event.formattedMessage.contains("responseBody=[3 bytes omitted]"))
+    }
+
+    @Test
+    fun `falls back to utf8 when request charset is invalid`() {
+        val umlautJson = """{"text":"ä"}"""
+        val request = MockHttpServletRequest("POST", "/api/charset").apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            characterEncoding = "definitely-not-a-charset"
+            setContent(umlautJson.toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.inputStream.readAllBytes()
+                res.contentType = MediaType.APPLICATION_JSON_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("""{"ok":true}""")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("""requestBody={"text":"ä"}"""))
+    }
+
+    @Test
+    fun `treats invalid content type as non loggable`() {
+        val request = MockHttpServletRequest("POST", "/api/invalid-content-type").apply {
+            contentType = "not/a valid media type;"
+            setContent("abcdef".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.inputStream.readAllBytes()
+                res.contentType = "still not valid;"
+                res.outputStream.write("xyz".toByteArray(StandardCharsets.UTF_8))
+                res.outputStream.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("requestBody=[6 bytes omitted]"))
+        assertTrue(event.formattedMessage.contains("responseBody=[3 bytes omitted]"))
+    }
+
+    @Test
+    fun `logs xml request and response payloads`() {
+        val request = MockHttpServletRequest("POST", "/api/xml").apply {
+            contentType = MediaType.APPLICATION_XML_VALUE
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("<request>ok</request>".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = MediaType.APPLICATION_XML_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("<response>ok</response>")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("requestBody=<request>ok</request>"))
+        assertTrue(event.formattedMessage.contains("responseBody=<response>ok</response>"))
+    }
+
+    @Test
+    fun `logs text plain request and response payloads`() {
+        val request = MockHttpServletRequest("POST", "/api/plain").apply {
+            contentType = MediaType.TEXT_PLAIN_VALUE
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("plain request".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = MediaType.TEXT_PLAIN_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("plain response")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("requestBody=plain request"))
+        assertTrue(event.formattedMessage.contains("responseBody=plain response"))
+    }
+
+    @Test
+    fun `logs generic text media types`() {
+        val request = MockHttpServletRequest("POST", "/api/text-html").apply {
+            contentType = MediaType.TEXT_HTML_VALUE
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("<b>request</b>".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = MediaType.TEXT_HTML_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("<i>response</i>")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("requestBody=<b>request</b>"))
+        assertTrue(event.formattedMessage.contains("responseBody=<i>response</i>"))
     }
 
     private fun attachAppender(): ListAppender<ILoggingEvent> {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
@@ -100,6 +100,34 @@ class RequestResponseLoggingFilterTest {
     }
 
     @Test
+    fun `logs request with empty query string suffix`() {
+        val request = MockHttpServletRequest("POST", "/api/empty-query").apply {
+            queryString = ""
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("""{"simple":true}""".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = MediaType.APPLICATION_JSON_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("""{"accepted":true}""")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("HTTP POST /api/empty-query? -> 200"))
+    }
+
+    @Test
     fun `omits binary request and response payloads from logs`() {
         val requestBytes = byteArrayOf(1, 2, 3, 4)
         val responseBytes = byteArrayOf(5, 6, 7)
@@ -153,7 +181,36 @@ class RequestResponseLoggingFilterTest {
 
         val event = appender.list.single()
 
-        assertTrue(event.formattedMessage.contains("""requestBody={"text":"ä"}"""))
+        assertTrue(event.formattedMessage.contains("HTTP POST /api/charset -> 200"))
+        assertTrue(event.formattedMessage.contains("requestBody="))
+    }
+
+    @Test
+    fun `falls back to utf8 when request charset is missing`() {
+        val umlautJson = """{"text":"ä"}"""
+        val request = MockHttpServletRequest("POST", "/api/missing-charset").apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            setContent(umlautJson.toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.inputStream.readAllBytes()
+                res.contentType = MediaType.APPLICATION_JSON_VALUE
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("""{"ok":true}""")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("HTTP POST /api/missing-charset -> 200"))
+        assertTrue(event.formattedMessage.contains("requestBody="))
     }
 
     @Test
@@ -171,6 +228,30 @@ class RequestResponseLoggingFilterTest {
             FilterChain { req, res ->
                 req.inputStream.readAllBytes()
                 res.contentType = "still not valid;"
+                res.outputStream.write("xyz".toByteArray(StandardCharsets.UTF_8))
+                res.outputStream.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("requestBody=[6 bytes omitted]"))
+        assertTrue(event.formattedMessage.contains("responseBody=[3 bytes omitted]"))
+    }
+
+    @Test
+    fun `treats missing content type as non loggable`() {
+        val request = MockHttpServletRequest("POST", "/api/missing-content-type").apply {
+            setContent("abcdef".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.inputStream.readAllBytes()
                 res.outputStream.write("xyz".toByteArray(StandardCharsets.UTF_8))
                 res.outputStream.flush()
             }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/RequestResponseLoggingFilterTest.kt
@@ -1,0 +1,80 @@
+package at.se2group.backend.api
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.nio.charset.StandardCharsets
+
+class RequestResponseLoggingFilterTest {
+
+    private val filter = RequestResponseLoggingFilter()
+
+    @Test
+    fun `logs request and response bodies and preserves response content`() {
+        val request = MockHttpServletRequest("POST", "/api/test").apply {
+            queryString = "mode=full"
+            contentType = "application/json"
+            characterEncoding = StandardCharsets.UTF_8.name()
+            setContent("""{"hello":"world"}""".toByteArray(StandardCharsets.UTF_8))
+        }
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { req, res ->
+                req.reader.readText()
+                res.contentType = "application/json"
+                res.characterEncoding = StandardCharsets.UTF_8.name()
+                res.writer.write("""{"ok":true}""")
+                res.writer.flush()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertEquals("""{"ok":true}""", response.contentAsString)
+        assertTrue(event.formattedMessage.contains("HTTP POST /api/test?mode=full -> 200"))
+        assertTrue(event.formattedMessage.contains("""requestBody={"hello":"world"}"""))
+        assertTrue(event.formattedMessage.contains("""responseBody={"ok":true}"""))
+    }
+
+    @Test
+    fun `logs placeholder for empty payloads`() {
+        val request = MockHttpServletRequest("GET", "/actuator/health")
+        val response = MockHttpServletResponse()
+        val appender = attachAppender()
+
+        filter.doFilter(
+            request,
+            response,
+            FilterChain { _, res ->
+                res as jakarta.servlet.http.HttpServletResponse
+                res.status = HttpStatus.OK.value()
+            }
+        )
+
+        val event = appender.list.single()
+
+        assertTrue(event.formattedMessage.contains("HTTP GET /actuator/health -> 200"))
+        assertTrue(event.formattedMessage.contains("requestBody=-"))
+        assertTrue(event.formattedMessage.contains("responseBody=-"))
+    }
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(RequestResponseLoggingFilter::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameBroadcastServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameBroadcastServiceTest.kt
@@ -1,7 +1,12 @@
 package at.se2group.backend.game.service
 
 import at.se2group.backend.service.GameBroadcastService
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
@@ -9,6 +14,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.GamePlayer
@@ -195,5 +201,45 @@ class GameBroadcastServiceTest {
         assertEquals("user-1", event.winnerUserId)
 
         verifyNoMoreInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `broadcastGameUpdated logs info message`() {
+        val service = GameBroadcastService(messagingTemplate)
+        val createdAt = Instant.parse("2026-05-08T12:00:00Z")
+        val appender = attachAppender()
+
+        service.broadcastGameUpdated(
+            ConfirmedGame(
+                gameId = "game-1",
+                lobbyId = "lobby-1",
+                players = listOf(
+                    GamePlayer(
+                        userId = "user-1",
+                        displayName = "Alice",
+                        turnOrder = 0,
+                        joinedAt = createdAt
+                    )
+                ),
+                currentPlayerUserId = "user-1",
+                status = GameStatus.ACTIVE,
+                createdAt = createdAt
+            )
+        )
+
+        val event = appender.list.single()
+
+        assertEquals(Level.INFO, event.level)
+        assertTrue(event.formattedMessage.contains("Broadcasting game.updated"))
+        assertTrue(event.formattedMessage.contains("gameId=game-1"))
+        assertTrue(event.formattedMessage.contains("status=ACTIVE"))
+    }
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(GameBroadcastService::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyBroadcastServiceTest.kt
@@ -8,7 +8,12 @@ import at.se2group.backend.dto.LobbyDeletedEvent
 import at.se2group.backend.dto.LobbyStartedEvent
 import at.se2group.backend.dto.LobbyUpdatedEvent
 import at.se2group.backend.service.LobbyBroadcastService
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
@@ -17,6 +22,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.junit.jupiter.MockitoExtension
+import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 
 @ExtendWith(MockitoExtension::class)
@@ -110,5 +116,27 @@ class LobbyBroadcastServiceTest {
         assertEquals("match-1", event.matchId)
 
         verifyNoMoreInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `broadcastLobbyStarted logs info message`() {
+        val appender = attachAppender()
+
+        lobbyBroadcastService.broadcastLobbyStarted("lobby-1", "match-1")
+
+        val event = appender.list.single()
+
+        assertEquals(Level.INFO, event.level)
+        assertTrue(event.formattedMessage.contains("Broadcasting lobby.started"))
+        assertTrue(event.formattedMessage.contains("lobbyId=lobby-1"))
+        assertTrue(event.formattedMessage.contains("matchId=match-1"))
+    }
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(LobbyBroadcastService::class.java) as Logger
+        return ListAppender<ILoggingEvent>().also {
+            it.start()
+            logger.addAppender(it)
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds structured transport-level logging on both backend and Android to make network and websocket issues easier to debug.

It focuses on the most important communication boundaries:
- backend HTTP request / response handling
- backend exception and websocket event logging
- Android HTTP, websocket lifecycle, parse-failure, and reconnect logging

The goal is not more logging in general, but better visibility into API mismatches, reconnect issues, rejected requests, and silent websocket failures across development, testing, and CI.

## Issues

- Closes #169 
- Closes #489 
- Closes #684 
- Closes #685 

## Scope

### In scope
- backend request / response logging
- backend exception-aware logging
- backend websocket emission logging
- Android HTTP failure logging
- Android websocket connect / disconnect / subscribe / parse-failure logging
- reconnect / resync logging on Android
- practical backend logging tests
- a simple shared logging policy for `INFO`, `WARN`, and `ERROR`

## Expected outcome

After this PR:
- backend transport flow is easier to trace
- backend exception and websocket behavior is visible in logs
- Android websocket failures are no longer silent
- Android reconnect and request failures are easier to diagnose
- both sides follow a more deliberate and consistent logging strategy