### PR TITLE
feat(backend)(rules): integrate joker tiles into tile generation and submitted-turn validation

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/GroupValidationService.kt
@@ -30,17 +30,17 @@ class GroupValidationService {
             )
         }
 
-        if (set.tiles.any { it is JokerTile }) {
+        val jokers = set.tiles.filterIsInstance<JokerTile>()
+        val numberedTiles = set.tiles.filterIsInstance<NumberedTile>()
+
+        if (numberedTiles.isEmpty()) {
             return invalid(
-                code = "GROUP_JOKER_NOT_SUPPORTED",
-                message = "Joker support is not implemented yet",
+                code = "GROUP_ALL_JOKERS_NOT_ALLOWED",
+                message = "All-joker groups are not allowed",
                 boardSetId = set.boardSetId,
-                tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
+                tileIds = jokers.map { it.tileId }
             )
         }
-
-        // JokerTile is the only non-numbered tile type right now and is rejected above.
-        val numberedTiles = set.tiles.map { it as NumberedTile }
 
         val distinctNumbers = numberedTiles.map { it.number }.distinct()
         if (distinctNumbers.size != 1) {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -55,9 +55,7 @@ class RunValidationService {
             )
         }
 
-        val requiredGapFillers = sortedNumbers
-            .zipWithNext()
-            .sumOf { (a, b) -> (b - a - 1).coerceAtLeast(0) }
+        val requiredGapFillers = countRequiredGapFillers(sortedNumbers)
 
         if (jokers.isEmpty() && requiredGapFillers > 0) {
             return invalid(
@@ -94,4 +92,9 @@ class RunValidationService {
 
         return valid()
     }
+
+    private fun countRequiredGapFillers(sortedNumbers: List<Int>): Int =
+        sortedNumbers
+            .zipWithNext()
+            .sumOf { (current, next) -> (next - current - 1).coerceAtLeast(0) }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RunValidationService.kt
@@ -1,5 +1,6 @@
 package at.se2group.backend.rules.service
 
+import at.se2group.backend.domain.TileRules
 import org.springframework.stereotype.Service
 import shared.models.game.domain.BoardSet
 import shared.models.game.domain.JokerTile
@@ -12,59 +13,85 @@ import shared.models.game.validation.valid
 class RunValidationService {
 
     fun validate(set: BoardSet): ValidationResult {
-            if (set.tiles.size < 3) {
-                return invalid(
-                    code = "RUN_MIN_SIZE",
-                    message = "Run must contain at least 3 tiles",
-                    boardSetId = set.boardSetId,
-                    tileIds = set.tiles.map { it.tileId }
-                )
-            }
-
-            if (set.tiles.any { it is JokerTile }) {
-                return invalid(
-                    code = "RUN_JOKER_NOT_SUPPORTED",
-                    message = "Joker support is not implemented yet",
-                    boardSetId = set.boardSetId,
-                    tileIds = set.tiles.filterIsInstance<JokerTile>().map { it.tileId }
-                )
-            }
-
-            val numberedTiles = set.tiles.map { it as NumberedTile }
-
-            val distinctColors = numberedTiles.map { it.color }.distinct()
-            if (distinctColors.size != 1 ) {
-                return invalid(
-                    code = "RUN_COLOR_MISMATCH",
-                    message = "All run tiles must have the same color",
-                    boardSetId = set.boardSetId,
-                    tileIds = numberedTiles.map { it.tileId }
-                )
-            }
-
-            val sortedNumbers = numberedTiles.sortedBy { it.number }.map { it.number }
-
-            if (sortedNumbers.size != sortedNumbers.distinct().size) {
-                return invalid(
-                    code = "RUN_DUPLICATE_NUMBER",
-                    message = "Run tiles must not have duplicate numbers",
-                    boardSetId = set.boardSetId,
-                    tileIds = numberedTiles.map { it.tileId }
-                )
-            }
-
-            val isConsecutive = sortedNumbers
-                .zipWithNext()
-                .all { (a, b) -> b == a + 1 }
-
-            if (!isConsecutive) {
-                return invalid(
-                    code = "RUN_NOT_CONSECUTIVE",
-                    message = "Run tiles must create a consecutive ascending sequence",
-                    boardSetId = set.boardSetId,
-                    tileIds = numberedTiles.map { it.tileId }
-                )
-            }
-            return valid()
+        if (set.tiles.size < 3) {
+            return invalid(
+                code = "RUN_MIN_SIZE",
+                message = "Run must contain at least 3 tiles",
+                boardSetId = set.boardSetId,
+                tileIds = set.tiles.map { it.tileId }
+            )
         }
+
+        val jokers = set.tiles.filterIsInstance<JokerTile>()
+        val numberedTiles = set.tiles.filterIsInstance<NumberedTile>()
+
+        if (numberedTiles.isEmpty()) {
+            return invalid(
+                code = "RUN_ALL_JOKERS_NOT_ALLOWED",
+                message = "All-joker runs are not allowed",
+                boardSetId = set.boardSetId,
+                tileIds = jokers.map { it.tileId }
+            )
+        }
+
+        val distinctColors = numberedTiles.map { it.color }.distinct()
+        if (distinctColors.size != 1) {
+            return invalid(
+                code = "RUN_COLOR_MISMATCH",
+                message = "All run tiles must have the same color",
+                boardSetId = set.boardSetId,
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        val sortedNumbers = numberedTiles.map { it.number }.sorted()
+
+        if (sortedNumbers.size != sortedNumbers.distinct().size) {
+            return invalid(
+                code = "RUN_DUPLICATE_NUMBER",
+                message = "Run tiles must not have duplicate numbers",
+                boardSetId = set.boardSetId,
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        val requiredGapFillers = sortedNumbers
+            .zipWithNext()
+            .sumOf { (a, b) -> (b - a - 1).coerceAtLeast(0) }
+
+        if (jokers.isEmpty() && requiredGapFillers > 0) {
+            return invalid(
+                code = "RUN_NOT_CONSECUTIVE",
+                message = "Run tiles must create a consecutive ascending sequence",
+                boardSetId = set.boardSetId,
+                tileIds = numberedTiles.map { it.tileId }
+            )
+        }
+
+        if (requiredGapFillers > jokers.size) {
+            return invalid(
+                code = "RUN_JOKER_GAP_TOO_LARGE",
+                message = "Available jokers are not enough to fill the run gaps",
+                boardSetId = set.boardSetId,
+                tileIds = set.tiles.map { it.tileId }
+            )
+        }
+
+        val spareJokers = jokers.size - requiredGapFillers
+        val minNumber = sortedNumbers.first()
+        val maxNumber = sortedNumbers.last()
+        val extensionCapacity =
+            (minNumber - TileRules.MIN_TILE_NUMBER) + (TileRules.MAX_TILE_NUMBER - maxNumber)
+
+        if (spareJokers > extensionCapacity) {
+            return invalid(
+                code = "RUN_JOKER_OUT_OF_RANGE",
+                message = "Resolving the joker would force numbers outside the legal tile range",
+                boardSetId = set.boardSetId,
+                tileIds = jokers.map { it.tileId }
+            )
+        }
+
+        return valid()
     }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TilePoolGenerationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TilePoolGenerationService.kt
@@ -54,14 +54,13 @@ class TilePoolGenerationService {
                 }
             }
         }
-        /*
         tiles += TileRules.jokerColors.map { color ->
             JokerTile(
                 tileId = UUID.randomUUID().toString(),
                 color = color
             )
         }
-        */
+
         return tiles
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -6,12 +6,17 @@ import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.TileEmbeddable
 import at.se2group.backend.persistence.TurnDraftEntity
 import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.rules.service.BoardValidationService
+import at.se2group.backend.rules.service.GroupValidationService
 import at.se2group.backend.rules.service.RummikubRuleService
+import at.se2group.backend.rules.service.RunValidationService
+import at.se2group.backend.rules.service.SetValidationService
 import at.se2group.backend.service.AfterCommitExecutor
 import at.se2group.backend.service.EndTurnService
 import at.se2group.backend.service.GameBroadcastService
 import at.se2group.backend.service.GameService
 import at.se2group.backend.service.InvalidTurnSubmissionException
+import at.se2group.backend.service.TileConservationService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -22,6 +27,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import shared.models.game.domain.GameStatus
+import shared.models.game.domain.JokerTile
 import shared.models.game.domain.TileColor
 import shared.models.game.request.BoardSetRequest
 import shared.models.game.request.EndTurnRequest
@@ -187,6 +193,61 @@ class EndTurnServiceTest {
     }
 
     @Test
+    fun `commits valid joker containing submitted draft`() {
+        val realRuleService = RummikubRuleService(
+            TileConservationService(),
+            BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService()))
+        )
+        val realEndTurnService = EndTurnService(
+            gameRepository = gameRepository,
+            turnDraftRepository = turnDraftRepository,
+            gameService = gameService,
+            rummikubRuleService = realRuleService,
+            gameBroadcastService = gameBroadcastService,
+            afterCommitExecutor = afterCommitExecutor
+        )
+
+        whenever(
+            gameRepository.findById("game-1")
+        ).thenReturn(
+            Optional.of(
+                gameEntity(
+                    user1Rack = mutableListOf(
+                        tile("tile-1", TileColor.RED, 3, false),
+                        tile("tile-2", TileColor.BLACK, null, true),
+                        tile("tile-3", TileColor.RED, 5, false),
+                        tile("new-rack-tile", TileColor.BLACK, 9, false)
+                    ),
+                    user2Rack = mutableListOf(tile("user-2-rack"))
+                )
+            )
+        )
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+        whenever(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = realEndTurnService.endTurn(
+            gameId = "game-1",
+            userId = "user-1",
+            request = jokerRunRequest()
+        )
+
+        assertEquals("user-2", result.currentPlayerUserId)
+        assertEquals("set-joker-run", result.boardSets.single().boardSetId)
+        assertTrue(result.boardSets.single().tiles[1] is JokerTile)
+        assertEquals(listOf("new-rack-tile"), result.players.first { it.userId == "user-1" }.rackTiles.map { it.tileId })
+
+        verify(gameRepository).save(any())
+        verify(turnDraftRepository).save(any())
+        verify(gameBroadcastService).broadcastGameUpdated(result)
+        verify(gameBroadcastService).broadcastTurnChanged("game-1", "user-2")
+        verify(gameBroadcastService).broadcastDraftUpdated(any())
+    }
+
+    @Test
     fun `replaces old draft with next player draft`() {
         val draft = draftEntity(playerUserId = "user-1", version = 4)
 
@@ -303,6 +364,21 @@ class EndTurnServiceTest {
         rackTiles = rackTiles
     )
 
+    private fun jokerRunRequest() = EndTurnRequest(
+        boardSets = listOf(
+            BoardSetRequest(
+                boardSetId = "set-joker-run",
+                type = shared.models.game.domain.BoardSetType.RUN,
+                tiles = listOf(
+                    TileRequest("tile-1", "RED", 3, false),
+                    TileRequest("tile-2", "BLACK", null, true),
+                    TileRequest("tile-3", "RED", 5, false)
+                )
+            )
+        ),
+        rackTiles = listOf(TileRequest("new-rack-tile", "BLACK", 9, false))
+    )
+
     private fun gameEntity(
         currentPlayerUserId: String = "user-1",
         status: GameStatus = GameStatus.ACTIVE,
@@ -348,10 +424,17 @@ class EndTurnServiceTest {
         version = version
     )
 
-    private fun tile(tileId: String) = TileEmbeddable(
+    private fun tile(tileId: String) = tile(
         tileId = tileId,
         color = TileColor.RED,
         number = 5,
         joker = false
+    )
+
+    private fun tile(tileId: String, color: TileColor, number: Int?, joker: Boolean) = TileEmbeddable(
+        tileId = tileId,
+        color = color,
+        number = number,
+        joker = joker
     )
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TilePoolGenerationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TilePoolGenerationServiceTest.kt
@@ -12,7 +12,6 @@ class TilePoolGenerationServiceTest {
 
     private val service = TilePoolGenerationService()
 
-    /*
     @Test
     fun `createTilePool returns correct total number of tiles`() {
         val tiles = service.createTilePool()
@@ -26,7 +25,6 @@ class TilePoolGenerationServiceTest {
 
         assertEquals(expectedTotal, tiles.size)
     }
-    */
 
     @Test
     fun `createTilePool contains exactly two copies of every numbered tile`() {
@@ -45,7 +43,6 @@ class TilePoolGenerationServiceTest {
         }
     }
 
-    /*
     @Test
     fun `createTilePool contains exactly one joker for each configured joker color`() {
         val tiles = service.createTilePool()
@@ -58,7 +55,6 @@ class TilePoolGenerationServiceTest {
             assertEquals(1, count, "Expected exactly one joker with color $color")
         }
     }
-    */
 
     @Test
     fun `createTilePool contains only configured joker colors for jokers`() {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/BoardValidationServiceTest.kt
@@ -9,7 +9,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import shared.models.game.domain.BoardSet
+import shared.models.game.domain.JokerTile
 import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.Tile
 import shared.models.game.domain.TileColor
 import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.invalid
@@ -19,6 +21,9 @@ class BoardValidationServiceTest {
 
     private val setValidationService = mock<SetValidationService>()
     private val service = BoardValidationService(setValidationService)
+    private val realService = BoardValidationService(
+        SetValidationService(GroupValidationService(), RunValidationService())
+    )
 
     @Test
     fun `returns valid when all board sets are valid`() {
@@ -115,6 +120,56 @@ class BoardValidationServiceTest {
         verify(setValidationService).validate(thirdSet)
     }
 
+    @Test
+    fun `returns valid for board with valid joker sets`() {
+        val result = realService.validate(
+            listOf(
+                BoardSet(
+                    boardSetId = "set-1",
+                    tiles = listOf(
+                        tile("tile-1", TileColor.RED, 7),
+                        tile("tile-2", TileColor.BLUE, 7),
+                        joker("tile-3", TileColor.BLACK)
+                    )
+                ),
+                BoardSet(
+                    boardSetId = "set-2",
+                    tiles = listOf(
+                        tile("tile-4", TileColor.RED, 3),
+                        joker("tile-5", TileColor.RED),
+                        tile("tile-6", TileColor.RED, 5)
+                    )
+                )
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `aggregates invalid joker set violations with board set id`() {
+        val result = realService.validate(
+            listOf(
+                BoardSet(
+                    boardSetId = "set-joker",
+                    tiles = listOf(
+                        joker("tile-1", TileColor.RED),
+                        joker("tile-2", TileColor.BLACK),
+                        joker("tile-3", TileColor.RED)
+                    )
+                )
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals(
+            listOf("GROUP_ALL_JOKERS_NOT_ALLOWED", "RUN_ALL_JOKERS_NOT_ALLOWED"),
+            result.violations.map { it.code }
+        )
+        assertTrue(result.violations.all { it.boardSetId == "set-joker" })
+    }
+
     private fun boardSet(boardSetId: String, firstNumber: Int): BoardSet =
         BoardSet(
             boardSetId = boardSetId,
@@ -132,4 +187,10 @@ class BoardValidationServiceTest {
             boardSetId = boardSetId,
             tileIds = listOf(tileId)
         )
+
+    private fun tile(id: String, color: TileColor, number: Int): Tile =
+        NumberedTile(id, color, number)
+
+    private fun joker(id: String, color: TileColor): Tile =
+        JokerTile(id, color)
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
@@ -143,10 +143,71 @@ class GroupValidationServiceTest {
     }
 
     @Test
-    fun `rejects group containing jokers`() {
+    fun `validates group with joker filling missing color`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 7),
+                tile("tile-2", TileColor.BLUE, 7),
+                joker("tile-3", TileColor.BLACK)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `validates group with two jokers and one numbered anchor tile`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 10),
+                joker("tile-2", TileColor.BLACK),
+                joker("tile-3", TileColor.RED)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `validates size four group with joker`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 5),
+                tile("tile-2", TileColor.BLUE, 5),
+                tile("tile-3", TileColor.BLACK, 5),
+                joker("tile-4", TileColor.RED)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `rejects all joker group`() {
+        val set = set(
+            joker("tile-1", TileColor.RED),
+            joker("tile-2", TileColor.BLACK),
+            joker("tile-3", TileColor.RED)
+        )
+
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
+        assertFalse(result.isValid)
+        assertEquals("GROUP_ALL_JOKERS_NOT_ALLOWED", violation.code)
+        assertEquals("All-joker groups are not allowed", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
+    fun `rejects joker group with duplicate non joker colors`() {
         val set = set(
             tile("tile-1", TileColor.RED, 7),
-            tile("tile-2", TileColor.BLUE, 7),
+            tile("tile-2", TileColor.RED, 7),
             joker("tile-3", TileColor.BLACK)
         )
 
@@ -154,12 +215,27 @@ class GroupValidationServiceTest {
 
         val violation = result.violations.single()
         assertFalse(result.isValid)
-        assertEquals("GROUP_JOKER_NOT_SUPPORTED", violation.code)
-        assertEquals("Joker support is not implemented yet", violation.message)
+        assertEquals("GROUP_DUPLICATE_COLOR", violation.code)
+        assertEquals("Group tiles must have unique colors", violation.message)
         assertEquals("set-1", violation.boardSetId)
-        assertEquals(
-            set.tiles.filterIsInstance<JokerTile>().map { it.tileId },
-            violation.tileIds
+        assertEquals(set.tiles.filterIsInstance<NumberedTile>().map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
+    fun `rejects joker group with mismatching non joker numbers`() {
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 8),
+            joker("tile-3", TileColor.BLACK)
         )
+
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
+        assertFalse(result.isValid)
+        assertEquals("GROUP_NUMBER_MISMATCH", violation.code)
+        assertEquals("All group tiles must have the same number", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(set.tiles.filterIsInstance<NumberedTile>().map { it.tileId }, violation.tileIds)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/GroupValidationServiceTest.kt
@@ -107,6 +107,26 @@ class GroupValidationServiceTest {
     }
 
     @Test
+    fun `rejects group with more than 4 tiles including jokers`() {
+        val set = set(
+            tile("tile-1", TileColor.RED, 7),
+            tile("tile-2", TileColor.BLUE, 7),
+            tile("tile-3", TileColor.BLACK, 7),
+            joker("tile-4", TileColor.RED),
+            joker("tile-5", TileColor.BLACK)
+        )
+
+        val result = service.validate(set)
+
+        val violation = result.violations.single()
+        assertFalse(result.isValid)
+        assertEquals("GROUP_MAX_SIZE", violation.code)
+        assertEquals("Group must contain at most 4 tiles", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(set.tiles.map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
     fun `rejects group with mixed tile numbers`() {
         val set = set(
             tile("tile-1", TileColor.RED, 7),

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -221,6 +221,7 @@ class RummikubRuleServiceTest {
             listOf("GROUP_ALL_JOKERS_NOT_ALLOWED", "RUN_ALL_JOKERS_NOT_ALLOWED"),
             result.violations.map { it.code }
         )
+        assertTrue(result.violations.all { it.boardSetId == "set-1" })
     }
 
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -32,6 +32,10 @@ class RummikubRuleServiceTest {
     private val ruleService by lazy {
         RummikubRuleService(tileConservationService, boardValidationService)
     }
+    private val realRuleService = RummikubRuleService(
+        TileConservationService(),
+        BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService()))
+    )
 
     private val player = GamePlayer(
         userId = "user-1",
@@ -160,6 +164,63 @@ class RummikubRuleServiceTest {
         assertEquals("TILE_CONSERVATION_VIOLATION", result.violations[0].code)
         assertEquals("RUN_MIN_SIZE", result.violations[1].code)
 
+    }
+
+    @Test
+    fun `accepts legal joker containing submitted draft`() {
+        val jokerRun = listOf(
+            NumberedTile("tile-1", TileColor.RED, 3),
+            JokerTile("tile-2", TileColor.BLACK),
+            NumberedTile("tile-3", TileColor.RED, 5)
+        )
+        val game = confirmedGame.copy(
+            players = listOf(player.copy(rackTiles = jokerRun))
+        )
+        val draft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1",
+            boardSets = listOf(BoardSet(boardSetId = "set-1", tiles = jokerRun)),
+            rackTiles = emptyList()
+        )
+
+        val result = realRuleService.validateSubmittedDraft(
+            confirmedGame = game,
+            actingPlayerUserId = "user-1",
+            submittedDraft = draft
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `returns joker validation violations for illegal joker draft`() {
+        val allJokers = listOf(
+            JokerTile("tile-1", TileColor.RED),
+            JokerTile("tile-2", TileColor.BLACK),
+            JokerTile("tile-3", TileColor.RED)
+        )
+        val game = confirmedGame.copy(
+            players = listOf(player.copy(rackTiles = allJokers))
+        )
+        val draft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1",
+            boardSets = listOf(BoardSet(boardSetId = "set-1", tiles = allJokers)),
+            rackTiles = emptyList()
+        )
+
+        val result = realRuleService.validateSubmittedDraft(
+            confirmedGame = game,
+            actingPlayerUserId = "user-1",
+            submittedDraft = draft
+        )
+
+        assertFalse(result.isValid)
+        assertEquals(
+            listOf("GROUP_ALL_JOKERS_NOT_ALLOWED", "RUN_ALL_JOKERS_NOT_ALLOWED"),
+            result.violations.map { it.code }
+        )
     }
 
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -152,24 +152,177 @@ class RunValidationServiceTest {
     }
 
     @Test
-    fun `rejects run containing joker`() {
+    fun `accepts run with joker filling one internal gap`() {
         val result  = service.validate(
             set(
                 tile("tile-1", TileColor.RED, 3),
-                tile("tile-2", TileColor.RED, 4),
+                tile("tile-2", TileColor.RED, 5),
                 joker("tile-3", TileColor.BLACK),
             )
         )
 
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `accepts run with multiple internal gaps filled by jokers`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.BLACK, 10),
+                joker("tile-2", TileColor.RED),
+                joker("tile-3", TileColor.BLACK),
+                tile("tile-4", TileColor.BLACK, 13)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `accepts run with joker at start`() {
+        val result = service.validate(
+            set(
+                joker("tile-1", TileColor.RED),
+                tile("tile-2", TileColor.BLUE, 6),
+                tile("tile-3", TileColor.BLUE, 7)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `accepts run with joker at end`() {
+        val result = service.validate(
+            set(
+                tile("tile-1", TileColor.RED, 11),
+                tile("tile-2", TileColor.RED, 12),
+                joker("tile-3", TileColor.BLACK)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `accepts run with spare jokers extending both sides within bounds`() {
+        val result = service.validate(
+            set(
+                joker("tile-1", TileColor.RED),
+                tile("tile-2", TileColor.BLACK, 6),
+                tile("tile-3", TileColor.BLACK, 7),
+                joker("tile-4", TileColor.BLACK)
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `rejects all joker run`() {
+        val boardSet = set(
+            joker("tile-1", TileColor.RED),
+            joker("tile-2", TileColor.BLACK),
+            joker("tile-3", TileColor.RED)
+        )
+
+        val result = service.validate(boardSet)
 
         val violation = result.violations.single()
 
         assertFalse(result.isValid)
-        assertEquals("RUN_JOKER_NOT_SUPPORTED", violation.code)
-        assertEquals("Joker support is not implemented yet", violation.message)
+        assertEquals("RUN_ALL_JOKERS_NOT_ALLOWED", violation.code)
+        assertEquals("All-joker runs are not allowed", violation.message)
         assertEquals("set-1", violation.boardSetId)
-        assertEquals(listOf("tile-3"), violation.tileIds)
+        assertEquals(boardSet.tiles.map { it.tileId }, violation.tileIds)
+    }
 
+    @Test
+    fun `rejects joker run with mixed non joker colors`() {
+        val boardSet = set(
+            tile("tile-1", TileColor.RED, 3),
+            tile("tile-2", TileColor.BLUE, 4),
+            joker("tile-3", TileColor.BLACK)
+        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_COLOR_MISMATCH", violation.code)
+        assertEquals("All run tiles must have the same color", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(boardSet.tiles.filterIsInstance<NumberedTile>().map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
+    fun `rejects joker run with duplicate non joker numbers`() {
+        val boardSet = set(
+            tile("tile-1", TileColor.RED, 3),
+            tile("tile-2", TileColor.RED, 3),
+            joker("tile-3", TileColor.BLACK)
+        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_DUPLICATE_NUMBER", violation.code)
+        assertEquals("Run tiles must not have duplicate numbers", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(boardSet.tiles.filterIsInstance<NumberedTile>().map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
+    fun `rejects joker run when gap is too large`() {
+        val boardSet = set(
+            tile("tile-1", TileColor.RED, 3),
+            joker("tile-2", TileColor.BLACK),
+            tile("tile-3", TileColor.RED, 7)
+        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_JOKER_GAP_TOO_LARGE", violation.code)
+        assertEquals("Available jokers are not enough to fill the run gaps", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(boardSet.tiles.map { it.tileId }, violation.tileIds)
+    }
+
+    @Test
+    fun `rejects joker run when spare joker would be out of range`() {
+        val boardSet = set(
+            tile("tile-1", TileColor.RED, 1),
+            tile("tile-2", TileColor.RED, 13),
+            joker("tile-3", TileColor.BLACK),
+            joker("tile-4", TileColor.RED),
+            joker("tile-5", TileColor.BLACK),
+            joker("tile-6", TileColor.RED),
+            joker("tile-7", TileColor.BLACK),
+            joker("tile-8", TileColor.RED),
+            joker("tile-9", TileColor.BLACK),
+            joker("tile-10", TileColor.RED),
+            joker("tile-11", TileColor.BLACK),
+            joker("tile-12", TileColor.RED),
+            joker("tile-13", TileColor.BLACK),
+            joker("tile-14", TileColor.RED)
+        )
+
+        val result = service.validate(boardSet)
+        val violation = result.violations.single()
+
+        assertFalse(result.isValid)
+        assertEquals("RUN_JOKER_OUT_OF_RANGE", violation.code)
+        assertEquals("Resolving the joker would force numbers outside the legal tile range", violation.message)
+        assertEquals("set-1", violation.boardSetId)
+        assertEquals(boardSet.tiles.filterIsInstance<JokerTile>().map { it.tileId }, violation.tileIds)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RunValidationServiceTest.kt
@@ -153,7 +153,7 @@ class RunValidationServiceTest {
 
     @Test
     fun `accepts run with joker filling one internal gap`() {
-        val result  = service.validate(
+        val result = service.validate(
             set(
                 tile("tile-1", TileColor.RED, 3),
                 tile("tile-2", TileColor.RED, 5),

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/SetValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/SetValidationServiceTest.kt
@@ -8,7 +8,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import shared.models.game.domain.BoardSet
+import shared.models.game.domain.JokerTile
 import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.Tile
 import shared.models.game.domain.TileColor
 import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.invalid
@@ -19,6 +21,7 @@ class SetValidationServiceTest {
     private val groupValidationService = mock<GroupValidationService>()
     private val runValidationService = mock<RunValidationService>()
     private val service = SetValidationService(groupValidationService, runValidationService)
+    private val realService = SetValidationService(GroupValidationService(), RunValidationService())
 
     private val boardSet = BoardSet(
         boardSetId = "set-1",
@@ -83,6 +86,60 @@ class SetValidationServiceTest {
         verify(runValidationService).validate(boardSet)
     }
 
+    @Test
+    fun `accepts joker set through valid group path`() {
+        val result = realService.validate(
+            BoardSet(
+                boardSetId = "set-1",
+                tiles = listOf(
+                    tile("tile-1", TileColor.RED, 7),
+                    tile("tile-2", TileColor.BLUE, 7),
+                    joker("tile-3", TileColor.BLACK)
+                )
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `accepts joker set through valid run path`() {
+        val result = realService.validate(
+            BoardSet(
+                boardSetId = "set-1",
+                tiles = listOf(
+                    tile("tile-1", TileColor.RED, 3),
+                    joker("tile-2", TileColor.BLACK),
+                    tile("tile-3", TileColor.RED, 5)
+                )
+            )
+        )
+
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
+    }
+
+    @Test
+    fun `returns combined joker violations when group and run paths fail`() {
+        val result = realService.validate(
+            BoardSet(
+                boardSetId = "set-1",
+                tiles = listOf(
+                    joker("tile-1", TileColor.RED),
+                    joker("tile-2", TileColor.BLACK),
+                    joker("tile-3", TileColor.RED)
+                )
+            )
+        )
+
+        assertFalse(result.isValid)
+        assertEquals(
+            listOf("GROUP_ALL_JOKERS_NOT_ALLOWED", "RUN_ALL_JOKERS_NOT_ALLOWED"),
+            result.violations.map { it.code }
+        )
+    }
+
     private fun groupViolation(): RuleViolation =
         RuleViolation(
             code = "GROUP_INVALID",
@@ -98,4 +155,10 @@ class SetValidationServiceTest {
             boardSetId = "set-1",
             tileIds = listOf("tile-2")
         )
+
+    private fun tile(id: String, color: TileColor, number: Int): Tile =
+        NumberedTile(id, color, number)
+
+    private fun joker(id: String, color: TileColor): Tile =
+        JokerTile(id, color)
 }


### PR DESCRIPTION
## Summary

This PR integrates joker support into the backend rule flow.

The domain model, persistence, mappers, and DTOs already support `JokerTile`, but jokers were not fully usable in gameplay yet. Joker generation was still disabled, and group/run validation rejected joker-containing sets with placeholder errors.

## Changes

- Re-enable joker generation in `TilePoolGenerationService`
- Implement joker-aware validation in `GroupValidationService`
- Implement joker-aware validation in `RunValidationService`
- Replace placeholder joker errors with rule-specific validation errors
- Keep `SetValidationService`, `BoardValidationService`, `RummikubRuleService`, and `EndTurnService` free of joker-specific branching
- Add focused tests for joker generation, joker groups, joker runs, set/board validation, submitted draft validation, and end-turn behavior

## Issues

- Closes #224 
- Closes #226 
- Closes #269 
- Closes #275 
- Closes #276 
- Closes #277 
- Closes #284 
- Closes #285 
- Closes #258 

## Rule behavior

### Joker groups

Groups with jokers are valid when:
- the set has 3 or 4 tiles
- at least one numbered tile exists
- all numbered tiles have the same number
- numbered tile colors are distinct
- jokers can represent missing colors

All-joker groups remain invalid.

### Joker runs

Runs with jokers are valid when:
- the set has at least 3 tiles
- at least one numbered tile exists
- all numbered tiles have the same color
- numbered tiles have no duplicate numbers
- jokers can fill internal gaps or extend the run
- the resolved sequence stays within 1..13

All-joker runs remain invalid.

## Architecture

Joker handling is implemented only inside the existing group/run validators.

`SetValidationService` continues to try both interpretations and accepts the set if at least one validator succeeds.

`BoardValidationService`, `RummikubRuleService`, and `EndTurnService` continue to work through the existing validation flow without joker-specific logic.

## Out of scope

- Frontend joker rendering
- Persisting explicit joker substitutions
- Advanced joker scoring rules
- Separate joker-only validation service