### PR TITLE
feat(backend): centralize api error handling and close remaining failure gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,9 @@
 [![Frontend CI](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/actions/workflows/android.yml/badge.svg?branch=main)](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/actions/workflows/android.yml)
 [![Shared CI](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/actions/workflows/shared.yml/badge.svg?branch=main)](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/actions/workflows/shared.yml)
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SE2-Gruppenprojekt_se2-group-codebase&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SE2-Gruppenprojekt_se2-group-codebase)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=se2-gruppenprojekt_se2-group-codebase_frontend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=se2-gruppenprojekt_se2-group-codebase_frontend)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=se2-gruppenprojekt_se2-group-codebase_backend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=se2-gruppenprojekt_se2-group-codebase_backend)
-
 ![Pull Requests](https://img.shields.io/github/issues-pr/SE2-Gruppenprojekt/se2-group-codebase)
 ![Issues](https://img.shields.io/github/issues/SE2-Gruppenprojekt/se2-group-codebase)
 ![Milestones](https://img.shields.io/github/milestones/all/SE2-Gruppenprojekt/se2-group-codebase)
-
-[![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=se2-gruppenprojekt_se2-group-codebase_backend)
 
 ## Overview
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -13,15 +13,25 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import shared.models.api.ApiErrorResponse
 
 /**
- * Centralized HTTP exception mapping for backend REST endpoints.
+ * Centralized REST exception mapping for the backend API.
  *
- * This advice translates common backend exceptions into stable API responses so
- * that controllers can remain thin and service code can signal failures through
- * exceptions instead of hand-building response entities. The handler is also a
- * logging boundary: expected client-caused failures are logged at `WARN`, while
- * unexpected backend failures are logged at `ERROR`.
+ * This advice is the single place where backend failures are translated into
+ * stable HTTP status codes and the shared [ApiErrorResponse] payload. Its main
+ * job is to keep controllers thin and to keep service code free to express
+ * failures through normal exception types instead of duplicating transport-layer
+ * response building in each endpoint.
  *
- * Current mapping policy:
+ * The handler covers two broad failure categories:
+ *
+ * 1. **Request-entry failures raised by Spring MVC**
+ *    These happen before business logic is reached, for example when JSON is
+ *    malformed, a required header is absent, a path value cannot be converted,
+ *    or bean validation rejects a DTO.
+ * 2. **Application failures raised intentionally by backend code**
+ *    These come from mapper, service, and rule-validation layers after request
+ *    binding has succeeded.
+ *
+ * The mapping policy is intentionally simple:
  *
  * - [MethodArgumentNotValidException] -> `400 BAD_REQUEST`
  * - [HttpMessageNotReadableException] -> `400 BAD_REQUEST`
@@ -34,9 +44,15 @@ import shared.models.api.ApiErrorResponse
  * - [InvalidTurnSubmissionException] -> `409 INVALID_TURN_SUBMISSION`
  * - all other [Exception] types -> `500 INTERNAL_SERVER_ERROR`
  *
+ * Logging is also centralized here:
+ *
+ * - expected client-caused failures are logged at `WARN`
+ * - unexpected backend failures are logged at `ERROR`
+ *
  * The rule-validation path is handled explicitly through
- * [InvalidTurnSubmissionException], which preserves structured
- * `RuleViolation` data for clients that need detailed move rejection reasons.
+ * [InvalidTurnSubmissionException], which preserves structured rule violations
+ * for clients that need precise end-turn feedback instead of a generic
+ * conflict message.
  */
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -46,6 +62,8 @@ class GlobalExceptionHandler {
     fun handleMethodArgumentNotValid(
         ex: MethodArgumentNotValidException
     ): ResponseEntity<ApiErrorResponse> {
+        // Bean-validation failures are reduced to one stable transport message
+        // so clients do not depend on Spring's internal error rendering.
         logger.warn("Request validation failed: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -61,6 +79,8 @@ class GlobalExceptionHandler {
     fun handleUnreadableBody(
         ex: HttpMessageNotReadableException
     ): ResponseEntity<ApiErrorResponse> {
+        // JSON syntax errors, wrong scalar types, and invalid enum text all
+        // arrive here before controller business logic is entered.
         logger.warn("Malformed request body: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -76,6 +96,8 @@ class GlobalExceptionHandler {
     fun handleMissingHeader(
         ex: MissingRequestHeaderException
     ): ResponseEntity<ApiErrorResponse> {
+        // Required transport metadata such as X-User-Id should fail as a normal
+        // client error instead of bubbling up as framework-default HTML/JSON.
         logger.warn("Missing required header: {}", ex.headerName)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -91,6 +113,8 @@ class GlobalExceptionHandler {
     fun handleTypeMismatch(
         ex: MethodArgumentTypeMismatchException
     ): ResponseEntity<ApiErrorResponse> {
+        // Keep conversion failures generic at the REST layer; the concrete bad
+        // value is useful for logs but does not need to shape client logic.
         logger.warn("Request type mismatch for '{}': {}", ex.name, ex.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
@@ -132,6 +156,8 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException::class)
     fun handleNoSuchElement(ex: NoSuchElementException): ResponseEntity<ApiErrorResponse> {
+        // Missing game, lobby, or draft lookups should converge on one 404
+        // contract regardless of the originating service.
         logger.warn("Resource not found: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
@@ -145,6 +171,8 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException::class)
     fun handleIllegalState(ex: IllegalStateException): ResponseEntity<ApiErrorResponse> {
+        // IllegalStateException is used for lifecycle and turn conflicts such as
+        // wrong current player, inactive game, or repeated draw attempts.
         logger.warn("Conflict while processing request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
@@ -158,6 +186,8 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(SecurityException::class)
     fun handleSecurity(ex: SecurityException): ResponseEntity<ApiErrorResponse> {
+        // SecurityException is reserved for authorization boundaries such as
+        // host-only lobby operations.
         logger.warn("Forbidden request: {}", ex.message)
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)
@@ -173,7 +203,8 @@ class GlobalExceptionHandler {
     fun handleInvalidTurnSubmission(
         ex: InvalidTurnSubmissionException
     ): ResponseEntity<ApiErrorResponse> {
-        // Keep rule-validation failures structured so clients can show precise move feedback.
+        // Keep rule-validation failures structured so clients can highlight
+        // specific invalid sets and still show a top-level submission error.
         logger.warn(
             "Invalid turn submission with {} rule violation(s): {}",
             ex.validationResult.violations.size,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GlobalExceptionHandler.kt
@@ -4,8 +4,12 @@ import at.se2group.backend.service.InvalidTurnSubmissionException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import shared.models.api.ApiErrorResponse
 
 /**
@@ -19,6 +23,10 @@ import shared.models.api.ApiErrorResponse
  *
  * Current mapping policy:
  *
+ * - [MethodArgumentNotValidException] -> `400 BAD_REQUEST`
+ * - [HttpMessageNotReadableException] -> `400 BAD_REQUEST`
+ * - [MissingRequestHeaderException] -> `400 BAD_REQUEST`
+ * - [MethodArgumentTypeMismatchException] -> `400 BAD_REQUEST`
  * - [IllegalArgumentException] -> `400 BAD_REQUEST`
  * - [NoSuchElementException] -> `404 NOT_FOUND`
  * - [IllegalStateException] -> `409 CONFLICT`
@@ -33,6 +41,66 @@ import shared.models.api.ApiErrorResponse
 @RestControllerAdvice
 class GlobalExceptionHandler {
     private val logger = LoggerFactory.getLogger(javaClass)
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValid(
+        ex: MethodArgumentNotValidException
+    ): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Request validation failed: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "BAD_REQUEST",
+                    errorMessage = "Request validation failed"
+                )
+            )
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleUnreadableBody(
+        ex: HttpMessageNotReadableException
+    ): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Malformed request body: {}", ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "BAD_REQUEST",
+                    errorMessage = "Malformed JSON request body"
+                )
+            )
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingHeader(
+        ex: MissingRequestHeaderException
+    ): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Missing required header: {}", ex.headerName)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "BAD_REQUEST",
+                    errorMessage = "Missing required header: ${ex.headerName}"
+                )
+            )
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatch(
+        ex: MethodArgumentTypeMismatchException
+    ): ResponseEntity<ApiErrorResponse> {
+        logger.warn("Request type mismatch for '{}': {}", ex.name, ex.message)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(
+                ApiErrorResponse(
+                    errorCode = "BAD_REQUEST",
+                    errorMessage = "Request parameter type mismatch"
+                )
+            )
+    }
 
     @ExceptionHandler(Exception::class)
     fun handleGeneric(ex: Exception): ResponseEntity<ApiErrorResponse> {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -121,6 +121,7 @@ class GameControllerTest {
                 status { isNotFound() }
                 jsonPath("$.errorCode") { value("NOT_FOUND") }
                 jsonPath("$.errorMessage") { value("Game not found") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -217,6 +218,7 @@ class GameControllerTest {
                 status { isNotFound() }
                 jsonPath("$.errorCode") { value("NOT_FOUND") }
                 jsonPath("$.errorMessage") { value("Game not found") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -233,6 +235,7 @@ class GameControllerTest {
                 status { isConflict() }
                 jsonPath("$.errorCode") { value("CONFLICT") }
                 jsonPath("$.errorMessage") { value("Game is not active") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -243,6 +246,7 @@ class GameControllerTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Missing required header: X-User-Id") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -309,6 +313,7 @@ class GameControllerTest {
                 status { isNotFound() }
                 jsonPath("$.errorCode") { value("NOT_FOUND") }
                 jsonPath("$.errorMessage") { value("Game not found") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -331,6 +336,7 @@ class GameControllerTest {
                 status { isConflict() }
                 jsonPath("$.errorCode") { value("CONFLICT") }
                 jsonPath("$.errorMessage") { value("Game is not active") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -378,6 +384,7 @@ class GameControllerTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Malformed JSON request body") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -391,6 +398,7 @@ class GameControllerTest {
                 status { isInternalServerError() }
                 jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
                 jsonPath("$.errorMessage") { value("An unexpected error occurred") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -30,9 +30,17 @@ import shared.models.game.validation.ValidationResult
 /**
  * Web-layer tests for [GameController].
  *
- * The error-handling additions in this class focus on verifying that game
- * endpoints surface the shared REST error contract when request-entry failures
- * or propagated service exceptions occur.
+ * This class exercises the controller through Spring MVC with mocked game
+ * services so that transport behavior can be verified independently from game
+ * rules or persistence. For the error-handling PR, the important responsibility
+ * here is proving that game endpoints surface the shared REST contract when:
+ *
+ * - request-entry failures happen before service code is reached
+ * - service-layer exceptions are propagated into the global advice
+ * - structured invalid-turn conflicts stay distinct from generic conflicts
+ *
+ * The tests in this class therefore serve as the game-specific confirmation
+ * that the global error-handling policy is actually visible at the public API.
  */
 @WebMvcTest(GameController::class)
 @Import(GlobalExceptionHandler::class)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -27,7 +27,13 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import shared.models.game.validation.ValidationResult
 
-
+/**
+ * Web-layer tests for [GameController].
+ *
+ * The error-handling additions in this class focus on verifying that game
+ * endpoints surface the shared REST error contract when request-entry failures
+ * or propagated service exceptions occur.
+ */
 @WebMvcTest(GameController::class)
 @Import(GlobalExceptionHandler::class)
 class GameControllerTest {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -223,6 +223,16 @@ class GameControllerTest {
     }
 
     @Test
+    fun `drawTile returns 400 when required user header is missing`() {
+        mockMvc.post("/api/games/game-1/draw")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Missing required header: X-User-Id") }
+            }
+    }
+
+    @Test
     fun `endTurn returns 200 with game response`() {
         val requestJson = """
             {
@@ -329,6 +339,44 @@ class GameControllerTest {
                 status { isConflict() }
                 jsonPath("$.errorCode") { value("INVALID_TURN_SUBMISSION") }
                 jsonPath("$.errorMessage") { value("Submitted draft is invalid") }
+            }
+    }
+
+    @Test
+    fun `updateDraft returns 400 for malformed json body`() {
+        mockMvc.put("/api/games/game-1/draft") {
+            header("X-User-Id", "mock-user")
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                    "boardSets": [
+                        {
+                            "boardSetId": "set-1",
+                            "type": "NOT_A_REAL_TYPE",
+                            "tiles": []
+                        }
+                    ],
+                    "rackTiles": []
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Malformed JSON request body") }
+            }
+    }
+
+    @Test
+    fun `getGame returns 500 for unexpected backend exception`() {
+        `when`(gameService.getGame("game-1"))
+            .thenThrow(RuntimeException("boom"))
+
+        mockMvc.get("/api/games/game-1")
+            .andExpect {
+                status { isInternalServerError() }
+                jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
+                jsonPath("$.errorMessage") { value("An unexpected error occurred") }
             }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -49,6 +49,7 @@ class GlobalExceptionHandlerMvcTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Request parameter type mismatch") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -59,6 +60,7 @@ class GlobalExceptionHandlerMvcTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Missing required header: X-Probe-User") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -72,6 +74,7 @@ class GlobalExceptionHandlerMvcTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Malformed JSON request body") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -92,6 +95,7 @@ class GlobalExceptionHandlerMvcTest {
                 status { isBadRequest() }
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Request validation failed") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 
@@ -102,6 +106,7 @@ class GlobalExceptionHandlerMvcTest {
                 status { isInternalServerError() }
                 jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
                 jsonPath("$.errorMessage") { value("An unexpected error occurred") }
+                jsonPath("$.violations.length()") { value(0) }
             }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -18,6 +18,13 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * MVC-level tests for [GlobalExceptionHandler].
+ *
+ * The dedicated probe controller below exists purely to trigger framework-level
+ * failures such as type mismatch, missing headers, unreadable bodies, and bean
+ * validation errors before normal service code would run.
+ */
 @WebMvcTest(ExceptionProbeController::class)
 @Import(GlobalExceptionHandler::class)
 class GlobalExceptionHandlerMvcTest {
@@ -89,17 +96,26 @@ class GlobalExceptionHandlerMvcTest {
     }
 }
 
+/**
+ * Minimal probe endpoints that trigger Spring MVC request-entry failures on
+ * demand so the global exception advice can be verified through the full web
+ * stack.
+ */
 @RestController
 @RequestMapping("/api/exception-probe")
 private class ExceptionProbeController {
 
     @GetMapping("/type-mismatch/{turnNumber}")
+    // Int path conversion is intentional so a non-numeric segment triggers
+    // MethodArgumentTypeMismatchException before any application logic runs.
     fun typeMismatch(@PathVariable turnNumber: Int): Int = turnNumber
 
     @GetMapping("/missing-header")
     fun missingHeader(@RequestHeader("X-Probe-User") userId: String): String = userId
 
     @PostMapping("/unreadable")
+    // Binding against a real DTO lets Spring raise HttpMessageNotReadableException
+    // for malformed JSON or incompatible field types.
     fun unreadable(@RequestBody request: CreateLobbyRequest): String = request.displayName
 
     @PostMapping("/validation")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -19,11 +19,21 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * MVC-level tests for [GlobalExceptionHandler].
+ * MVC-level routing tests for [GlobalExceptionHandler].
  *
- * The dedicated probe controller below exists purely to trigger framework-level
- * failures such as type mismatch, missing headers, unreadable bodies, and bean
- * validation errors before normal service code would run.
+ * Unlike the direct handler tests, this class verifies that Spring MVC really
+ * routes request-entry failures through the global advice during real request
+ * processing. The dedicated probe controller below exists only to trigger
+ * framework-level failures that happen before service code is entered, such as:
+ *
+ * - path variable type mismatch
+ * - missing required headers
+ * - unreadable JSON bodies
+ * - bean-validation failures
+ * - uncaught generic exceptions
+ *
+ * This gives the backend one tested, end-to-end proof that the request-entry
+ * layer uses the same REST error contract as the application exception layer.
  */
 @WebMvcTest(ExceptionProbeController::class)
 @Import(GlobalExceptionHandler::class)
@@ -97,9 +107,11 @@ class GlobalExceptionHandlerMvcTest {
 }
 
 /**
- * Minimal probe endpoints that trigger Spring MVC request-entry failures on
- * demand so the global exception advice can be verified through the full web
- * stack.
+ * Minimal probe endpoints used only for exception-routing verification.
+ *
+ * Each endpoint is intentionally tiny and shaped around one failure category so
+ * the tests can prove exactly which framework exception is being mapped by the
+ * global advice without depending on unrelated controller behavior.
  */
 @RestController
 @RequestMapping("/api/exception-probe")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -1,0 +1,110 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.dto.CreateLobbyRequest
+import jakarta.validation.Valid
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@WebMvcTest(ExceptionProbeController::class)
+@Import(GlobalExceptionHandler::class)
+class GlobalExceptionHandlerMvcTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `returns 400 for path variable type mismatch`() {
+        mockMvc.get("/api/exception-probe/type-mismatch/not-a-number")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Request parameter type mismatch") }
+            }
+    }
+
+    @Test
+    fun `returns 400 for missing required header`() {
+        mockMvc.get("/api/exception-probe/missing-header")
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Missing required header: X-Probe-User") }
+            }
+    }
+
+    @Test
+    fun `returns 400 for malformed request body`() {
+        mockMvc.post("/api/exception-probe/unreadable") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{ "displayName": "Alice", "maxPlayers": "abc" }"""
+        }
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Malformed JSON request body") }
+            }
+    }
+
+    @Test
+    fun `returns 400 for bean validation failure`() {
+        mockMvc.post("/api/exception-probe/validation") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                    "displayName": "",
+                    "maxPlayers": 4,
+                    "isPrivate": false,
+                    "allowGuests": true
+                }
+            """.trimIndent()
+        }
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.errorCode") { value("BAD_REQUEST") }
+                jsonPath("$.errorMessage") { value("Request validation failed") }
+            }
+    }
+
+    @Test
+    fun `returns 500 for unexpected exception`() {
+        mockMvc.get("/api/exception-probe/generic")
+            .andExpect {
+                status { isInternalServerError() }
+                jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
+                jsonPath("$.errorMessage") { value("An unexpected error occurred") }
+            }
+    }
+}
+
+@RestController
+@RequestMapping("/api/exception-probe")
+private class ExceptionProbeController {
+
+    @GetMapping("/type-mismatch/{turnNumber}")
+    fun typeMismatch(@PathVariable turnNumber: Int): Int = turnNumber
+
+    @GetMapping("/missing-header")
+    fun missingHeader(@RequestHeader("X-Probe-User") userId: String): String = userId
+
+    @PostMapping("/unreadable")
+    fun unreadable(@RequestBody request: CreateLobbyRequest): String = request.displayName
+
+    @PostMapping("/validation")
+    fun validation(@Valid @RequestBody request: CreateLobbyRequest): String = request.displayName
+
+    @GetMapping("/generic")
+    fun generic(): Nothing = throw RuntimeException("boom")
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -23,6 +23,14 @@ import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
 import java.beans.PropertyDescriptor
 
+/**
+ * Direct unit tests for [GlobalExceptionHandler].
+ *
+ * These tests exercise the advice methods without going through Spring MVC so
+ * that the response contract and logging policy can be verified in isolation.
+ * MVC routing coverage for the same handlers lives in
+ * [GlobalExceptionHandlerMvcTest].
+ */
 class GlobalExceptionHandlerTest {
 
     private val handler = GlobalExceptionHandler()
@@ -219,6 +227,8 @@ class GlobalExceptionHandlerTest {
     }
 
     private fun nullableMethodParameter(): MethodParameter {
+        // Build a writable method parameter that Spring's exception types accept
+        // without requiring a real controller method from production code.
         val property = PropertyDescriptor("displayName", CreateLobbyRequestStub::class.java)
         val writeMethod = property.writeMethod
         assertNotNull(writeMethod)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.springframework.core.MethodParameter
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.mock.http.MockHttpInputMessage
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -27,6 +28,28 @@ class GlobalExceptionHandlerTest {
     private val handler = GlobalExceptionHandler()
 
     @Test
+    fun `handleIllegalArgument should return 400`() {
+        val ex = IllegalArgumentException("bad request")
+
+        val response = handler.handleIllegalArgument(ex)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("BAD_REQUEST", response.body?.errorCode)
+        assertEquals("bad request", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleNoSuchElement should return 404`() {
+        val ex = NoSuchElementException("missing resource")
+
+        val response = handler.handleNoSuchElement(ex)
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        assertEquals("NOT_FOUND", response.body?.errorCode)
+        assertEquals("missing resource", response.body?.errorMessage)
+    }
+
+    @Test
     fun `handleIllegalState should return 409`() {
         val ex = IllegalStateException("test error")
 
@@ -35,6 +58,17 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.statusCode)
         assertEquals("CONFLICT", response.body?.errorCode)
         assertEquals("test error", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleSecurity should return 403`() {
+        val ex = SecurityException("forbidden")
+
+        val response = handler.handleSecurity(ex)
+
+        assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+        assertEquals("FORBIDDEN", response.body?.errorCode)
+        assertEquals("forbidden", response.body?.errorMessage)
     }
 
     @Test
@@ -77,7 +111,10 @@ class GlobalExceptionHandlerTest {
 
     @Test
     fun `handleUnreadableBody should return 400`() {
-        val ex = HttpMessageNotReadableException("Unreadable JSON body")
+        val ex = HttpMessageNotReadableException(
+            "Unreadable JSON body",
+            MockHttpInputMessage(ByteArray(0))
+        )
 
         val response = handler.handleUnreadableBody(ex)
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -5,13 +5,22 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.springframework.core.MethodParameter
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.slf4j.LoggerFactory
 import shared.models.game.validation.RuleViolation
 import shared.models.game.validation.ValidationResult
+import java.beans.PropertyDescriptor
 
 class GlobalExceptionHandlerTest {
 
@@ -52,6 +61,63 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    fun `handleMethodArgumentNotValid should return 400`() {
+        val bindingResult = BeanPropertyBindingResult(CreateLobbyRequestStub(), "request")
+        bindingResult.addError(
+            FieldError("request", "displayName", "displayName must not be blank")
+        )
+        val ex = MethodArgumentNotValidException(nullableMethodParameter(), bindingResult)
+
+        val response = handler.handleMethodArgumentNotValid(ex)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("BAD_REQUEST", response.body?.errorCode)
+        assertEquals("Request validation failed", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleUnreadableBody should return 400`() {
+        val ex = HttpMessageNotReadableException("Unreadable JSON body")
+
+        val response = handler.handleUnreadableBody(ex)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("BAD_REQUEST", response.body?.errorCode)
+        assertEquals("Malformed JSON request body", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleMissingHeader should return 400`() {
+        val ex = MissingRequestHeaderException(
+            "X-User-Id",
+            nullableMethodParameter()
+        )
+
+        val response = handler.handleMissingHeader(ex)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("BAD_REQUEST", response.body?.errorCode)
+        assertEquals("Missing required header: X-User-Id", response.body?.errorMessage)
+    }
+
+    @Test
+    fun `handleTypeMismatch should return 400`() {
+        val ex = MethodArgumentTypeMismatchException(
+            "abc",
+            Int::class.java,
+            "gameId",
+            nullableMethodParameter(),
+            NumberFormatException("For input string: \"abc\"")
+        )
+
+        val response = handler.handleTypeMismatch(ex)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("BAD_REQUEST", response.body?.errorCode)
+        assertEquals("Request parameter type mismatch", response.body?.errorMessage)
+    }
+
+    @Test
     fun `handleIllegalState logs warning`() {
         val appender = attachAppender()
 
@@ -75,11 +141,55 @@ class GlobalExceptionHandlerTest {
         assertTrue(event.formattedMessage.contains("Unhandled backend exception"))
     }
 
+    @Test
+    fun `handleMissingHeader logs warning`() {
+        val appender = attachAppender()
+
+        handler.handleMissingHeader(
+            MissingRequestHeaderException("X-User-Id", nullableMethodParameter())
+        )
+
+        val event = appender.list.single()
+        assertEquals(Level.WARN, event.level)
+        assertTrue(event.formattedMessage.contains("Missing required header: X-User-Id"))
+    }
+
+    @Test
+    fun `handleTypeMismatch logs warning`() {
+        val appender = attachAppender()
+
+        handler.handleTypeMismatch(
+            MethodArgumentTypeMismatchException(
+                "abc",
+                Int::class.java,
+                "gameId",
+                nullableMethodParameter(),
+                NumberFormatException("For input string: \"abc\"")
+            )
+        )
+
+        val event = appender.list.single()
+        assertEquals(Level.WARN, event.level)
+        assertTrue(event.formattedMessage.contains("Request type mismatch for 'gameId'"))
+    }
+
     private fun attachAppender(): ListAppender<ILoggingEvent> {
         val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java) as Logger
         return ListAppender<ILoggingEvent>().also {
             it.start()
             logger.addAppender(it)
         }
+    }
+
+    private fun nullableMethodParameter(): MethodParameter {
+        val property = PropertyDescriptor("displayName", CreateLobbyRequestStub::class.java)
+        val writeMethod = property.writeMethod
+        assertNotNull(writeMethod)
+        return MethodParameter(writeMethod!!, 0)
+    }
+
+    private class CreateLobbyRequestStub {
+        @Suppress("unused")
+        var displayName: String? = null
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -52,6 +52,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("BAD_REQUEST", response.body?.errorCode)
         assertEquals("bad request", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -63,6 +64,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
         assertEquals("NOT_FOUND", response.body?.errorCode)
         assertEquals("missing resource", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -74,6 +76,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.CONFLICT, response.statusCode)
         assertEquals("CONFLICT", response.body?.errorCode)
         assertEquals("test error", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -85,6 +88,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
         assertEquals("FORBIDDEN", response.body?.errorCode)
         assertEquals("forbidden", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -123,6 +127,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("BAD_REQUEST", response.body?.errorCode)
         assertEquals("Request validation failed", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -137,6 +142,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("BAD_REQUEST", response.body?.errorCode)
         assertEquals("Malformed JSON request body", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -151,6 +157,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("BAD_REQUEST", response.body?.errorCode)
         assertEquals("Missing required header: X-User-Id", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test
@@ -168,6 +175,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("BAD_REQUEST", response.body?.errorCode)
         assertEquals("Request parameter type mismatch", response.body?.errorMessage)
+        assertEquals(emptyList<RuleViolation>(), response.body?.violations)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerTest.kt
@@ -26,10 +26,18 @@ import java.beans.PropertyDescriptor
 /**
  * Direct unit tests for [GlobalExceptionHandler].
  *
- * These tests exercise the advice methods without going through Spring MVC so
- * that the response contract and logging policy can be verified in isolation.
+ * These tests call the advice methods directly without bootstrapping a full MVC
+ * stack. That makes them the most focused place to verify three things:
+ *
+ * - the HTTP status chosen for each exception family
+ * - the exact [shared.models.api.ApiErrorResponse] payload shape returned to
+ *   clients
+ * - the logging level split between expected client-caused failures and
+ *   unexpected backend faults
+ *
  * MVC routing coverage for the same handlers lives in
- * [GlobalExceptionHandlerMvcTest].
+ * [GlobalExceptionHandlerMvcTest]. This class exists to lock down the handler's
+ * contract in isolation from controller wiring.
  */
 class GlobalExceptionHandlerTest {
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
@@ -88,7 +88,9 @@ class LobbyControllerTest {
             header("X-User-Id", "user1")
             content = invalidJson
         }.andExpect {
-            status { isInternalServerError() }
+            status { isBadRequest() }
+            jsonPath("$.errorCode") { value("BAD_REQUEST") }
+            jsonPath("$.errorMessage") { value("Request validation failed") }
         }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
@@ -23,10 +23,14 @@ import shared.models.lobby.domain.LobbyPlayer
 import org.springframework.test.web.servlet.patch
 
 /**
- * Integration-style MVC tests for [LobbyController].
+ * MVC tests for [LobbyController].
  *
- * For the error-handling PR, this class is the place where lobby DTO bean
- * validation is verified against the shared `ApiErrorResponse` contract.
+ * This class uses the real Spring Boot test slice for lobby endpoints and a
+ * mocked [LobbyService] so that request validation, controller wiring, and
+ * exception mapping can be verified together. For the error-handling PR, its
+ * main value is proving that lobby DTO bean validation is normalized into the
+ * shared `ApiErrorResponse` contract instead of leaking Spring's default error
+ * payload shape.
  */
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
@@ -101,6 +101,7 @@ class LobbyControllerTest {
             status { isBadRequest() }
             jsonPath("$.errorCode") { value("BAD_REQUEST") }
             jsonPath("$.errorMessage") { value("Request validation failed") }
+            jsonPath("$.violations.length()") { value(0) }
         }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
@@ -22,6 +22,12 @@ import shared.models.lobby.domain.LobbyStatus
 import shared.models.lobby.domain.LobbyPlayer
 import org.springframework.test.web.servlet.patch
 
+/**
+ * Integration-style MVC tests for [LobbyController].
+ *
+ * For the error-handling PR, this class is the place where lobby DTO bean
+ * validation is verified against the shared `ApiErrorResponse` contract.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 class LobbyControllerTest {


### PR DESCRIPTION
## Summary

This PR completes the backend error-handling flow by normalizing remaining Spring MVC request-entry failures into the shared ApiErrorResponse contract.

The backend already has a central GlobalExceptionHandler, a shared REST error payload, structured invalid-turn errors, and request/response logging. The missing part is that some framework-level request failures, such as malformed JSON, missing headers, request type mismatches, and DTO validation errors, can still fall back to Spring’s default error response.

## Changes

- Extend GlobalExceptionHandler with explicit handlers for Spring MVC request-entry exceptions:
  - MethodArgumentNotValidException
  - HttpMessageNotReadableException
  - MissingRequestHeaderException
  - MethodArgumentTypeMismatchException
- Return the shared ApiErrorResponse shape for these failures.
- Keep existing application-level exception mappings unchanged:
  - IllegalArgumentException → 400 BAD_REQUEST
  - NoSuchElementException → 404 NOT_FOUND
  - IllegalStateException → 409 CONFLICT
  - SecurityException → 403 FORBIDDEN
  - InvalidTurnSubmissionException → 409 INVALID_TURN_SUBMISSION
  - generic Exception → 500 INTERNAL_SERVER_ERROR
- Preserve structured violations only for invalid turn submissions.
- Add tests for the new Spring MVC error mappings and important MVC failure paths.

## Goal

After this PR, backend REST errors should consistently use one response format:

```json
{
  "errorCode": "...",
  "errorMessage": "...",
  "violations": []
}
```
This ensures the frontend does not need to handle different error shapes depending on whether the failure came from service logic or from Spring MVC request binding.

## Linked Issues

The issue set now falls into two layers:

1. the original foundation issues that established the backend-wide error contract
2. the remaining completion issues that close the Spring MVC / request-entry gaps still left in the current implementation

### Foundation issues

These issues define the original backbone of backend error handling and should remain linked even where the implementation is now already largely or fully present.

- Closes #349
- Closes #350
- Closes #351
- Closes #352
- Closes #353
- Closes #354
- Closes #355

### Remaining completion issues

These are the issues that should finish the current backend error-handling surface so that request-entry failures are handled with the same contract as service-layer failures.

- Closes #713
- Closes #714
- Closes #715
- Closes #716
- Closes #717
- Closes #718
- Closes #719 