### PR TITLE
feat(android)(game): handle structured rule validation errors on end turn

### DIFF
--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
@@ -343,7 +343,7 @@ class GameScreenTest {
     // --- rule validation UI ---
 
     @Test
-    fun gameScreen_showsViolationMessage_whenRowHasViolations() {
+    fun gameScreen_showsViolationMessages_whenRowHasViolations() {
 
         stateFlow.value = stateFlow.value.copy(
             ruleValidation = RuleValidationUiState(
@@ -352,6 +352,11 @@ class GameScreenTest {
                         ApiRuleViolation(
                             code = "RUN_NOT_CONSECUTIVE",
                             message = "Tiles must be consecutive",
+                            boardSetId = "row1"
+                        ),
+                        ApiRuleViolation(
+                            code = "MIN_SET_SIZE",
+                            message = "Set must have at least 3 tiles",
                             boardSetId = "row1"
                         )
                     )
@@ -365,6 +370,10 @@ class GameScreenTest {
 
         composeRule
             .onNodeWithText("Tiles must be consecutive")
+            .assertExists()
+
+        composeRule
+            .onNodeWithText("Set must have at least 3 tiles")
             .assertExists()
     }
 

--- a/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
+++ b/apps/android/app/src/androidTest/java/at/aau/serg/android/ui/screens/game/GameScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onLast
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import at.aau.serg.android.core.errors.ApiRuleViolation
 import at.aau.serg.android.ui.theme.ThemeState
 import io.mockk.every
 import io.mockk.mockk
@@ -337,6 +338,86 @@ class GameScreenTest {
 
         composeRule.onNodeWithText("Charlie").assertExists()
         composeRule.onNodeWithText("Dana").assertExists()
+    }
+
+    // --- rule validation UI ---
+
+    @Test
+    fun gameScreen_showsViolationMessage_whenRowHasViolations() {
+
+        stateFlow.value = stateFlow.value.copy(
+            ruleValidation = RuleValidationUiState(
+                violationsByBoardSetId = mapOf(
+                    "row1" to listOf(
+                        ApiRuleViolation(
+                            code = "RUN_NOT_CONSECUTIVE",
+                            message = "Tiles must be consecutive",
+                            boardSetId = "row1"
+                        )
+                    )
+                )
+            )
+        )
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule
+            .onNodeWithText("Tiles must be consecutive")
+            .assertExists()
+    }
+
+    @Test
+    fun gameScreen_showsGlobalValidationBanner_whenGlobalViolationsExist() {
+
+        stateFlow.value = stateFlow.value.copy(
+            ruleValidation = RuleValidationUiState(
+                globalViolations = listOf(
+                    ApiRuleViolation(
+                        code = "INITIAL_MELD_TOO_SMALL",
+                        message = "Initial meld must score at least 30 points",
+                        boardSetId = null
+                    )
+                ),
+                summaryMessage = "Submitted draft is invalid"
+            )
+        )
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        composeRule
+            .onNodeWithTag(GameTestTags.GLOBAL_VALIDATION_BANNER)
+            .assertExists()
+
+        composeRule
+            .onNodeWithText("Submitted draft is invalid")
+            .assertExists()
+
+        composeRule
+            .onNodeWithText("• Initial meld must score at least 30 points")
+            .assertExists()
+    }
+
+    @Test
+    fun gameScreen_noGlobalValidationBanner_whenNoViolations() {
+
+        stateFlow.value = stateFlow.value.copy(
+            ruleValidation = RuleValidationUiState()
+        )
+
+        composeRule.setContent {
+            GameScreen(viewModel = viewModel)
+        }
+
+        assert(
+            composeRule
+                .onAllNodes(hasTestTag(GameTestTags.GLOBAL_VALIDATION_BANNER))
+                .fetchSemanticsNodes()
+                .isEmpty()
+        )
     }
 
     // --- ViewModel fallback when callbacks are null ---

--- a/apps/android/app/src/main/java/at/aau/serg/android/core/errors/AppError.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/core/errors/AppError.kt
@@ -1,5 +1,11 @@
 package at.aau.serg.android.core.errors
 
+data class ApiRuleViolation(
+    val code: String,
+    val message: String,
+    val boardSetId: String? = null
+)
+
 sealed class AppError {
 
     // REST / HTTP
@@ -11,6 +17,10 @@ sealed class AppError {
         data object NotFound : Rest()
         data object Conflict : Rest()
         data class Api(val message: String) : Rest()
+        data class RuleValidation(
+            val message: String,
+            val violations: List<ApiRuleViolation>
+        ) : Rest()
     }
 
     // WebSocket / STOMP

--- a/apps/android/app/src/main/java/at/aau/serg/android/core/network/mapper/NetworkErrorMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/core/network/mapper/NetworkErrorMapper.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.android.core.network.mapper
 
+import at.aau.serg.android.core.errors.ApiRuleViolation
 import at.aau.serg.android.core.errors.AppError
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -7,7 +8,9 @@ import retrofit2.HttpException
 import java.io.IOException
 
 data class ApiErrorResponse(
-    val errorMessage: String?
+    val errorCode: String? = null,
+    val errorMessage: String? = null,
+    val violations: List<ApiRuleViolation> = emptyList()
 )
 
 object NetworkErrorMapper {
@@ -27,7 +30,14 @@ object NetworkErrorMapper {
 
     private fun mapHttpError(e: HttpException): AppError {
         val body = e.response()?.errorBody()?.string()
-        val parsed = body?.let { adapter.fromJson(it) }
+        val parsed = body?.let { runCatching { adapter.fromJson(it) }.getOrNull() }
+
+        if (e.code() == 409 && parsed?.errorCode == "INVALID_TURN_SUBMISSION") {
+            return AppError.Rest.RuleValidation(
+                message = parsed.errorMessage ?: "Submitted draft is invalid",
+                violations = parsed.violations
+            )
+        }
 
         val message = parsed?.errorMessage?.takeIf { it.isNotBlank() }
         if (message != null) return AppError.Rest.Api(message)

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -26,6 +26,7 @@ import at.aau.serg.android.ui.components.BackButton
 import at.aau.serg.android.ui.screens.game.components.PlayerChip
 import at.aau.serg.android.ui.screens.game.components.TileRow
 import at.aau.serg.android.ui.screens.game.components.TileRowPlaceholder
+import at.aau.serg.android.ui.theme.NotReadyRed
 import at.aau.serg.android.ui.theme.appColors
 
 @Composable
@@ -134,15 +135,31 @@ fun GameScreenContent(
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         items(uiState.boardSets) { boardSet ->
-                            TileRow(
-                                onEvent,
-                                tiles = boardSet.tiles,
-                                tileSize = 60,
-                                borderColor = c.game.boardBorder,
-                                selectedTiles = uiState.selectedTiles,
-                                selectedRow = uiState.activeSelectionRow,
-                                rowId = boardSet.boardSetId,
-                            )
+                            val rowViolations = uiState.ruleValidation
+                                .violationsByBoardSetId[boardSet.boardSetId]
+                                .orEmpty()
+                            val isInvalid = rowViolations.isNotEmpty()
+
+                            Column {
+                                TileRow(
+                                    onEvent,
+                                    tiles = boardSet.tiles,
+                                    tileSize = 60,
+                                    borderColor = if (isInvalid) NotReadyRed else c.game.boardBorder,
+                                    selectedTiles = uiState.selectedTiles,
+                                    selectedRow = uiState.activeSelectionRow,
+                                    rowId = boardSet.boardSetId,
+                                )
+
+                                if (isInvalid) {
+                                    Text(
+                                        text = rowViolations.first().message,
+                                        color = NotReadyRed,
+                                        fontSize = 12.sp,
+                                        modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                                    )
+                                }
+                            }
                         }
 
                         if (uiState.selectedTiles.isNotEmpty()) {

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -23,10 +23,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import at.aau.serg.android.ui.components.BackButton
+import at.aau.serg.android.ui.screens.game.components.BoardSetValidationMessage
+import at.aau.serg.android.ui.screens.game.components.GlobalValidationBanner
 import at.aau.serg.android.ui.screens.game.components.PlayerChip
 import at.aau.serg.android.ui.screens.game.components.TileRow
 import at.aau.serg.android.ui.screens.game.components.TileRowPlaceholder
-import at.aau.serg.android.ui.theme.NotReadyRed
 import at.aau.serg.android.ui.theme.appColors
 
 @Composable
@@ -116,29 +117,10 @@ fun GameScreenContent(
 
             // GLOBAL VALIDATION BANNER
             if (uiState.ruleValidation.globalViolations.isNotEmpty()) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp, vertical = 6.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(NotReadyRed.copy(alpha = 0.12f))
-                        .padding(horizontal = 12.dp, vertical = 8.dp)
-                        .testTag(GameTestTags.GLOBAL_VALIDATION_BANNER)
-                ) {
-                    Text(
-                        text = uiState.ruleValidation.summaryMessage ?: "Invalid move",
-                        fontWeight = FontWeight.Bold,
-                        color = NotReadyRed,
-                        fontSize = 13.sp
-                    )
-                    uiState.ruleValidation.globalViolations.forEach { violation ->
-                        Text(
-                            text = "• ${violation.message}",
-                            color = NotReadyRed,
-                            fontSize = 12.sp
-                        )
-                    }
-                }
+                GlobalValidationBanner(
+                    summaryMessage = uiState.ruleValidation.summaryMessage,
+                    violations = uiState.ruleValidation.globalViolations
+                )
             }
 
             // CONTENT
@@ -179,14 +161,7 @@ fun GameScreenContent(
                                 )
 
                                 if (isInvalid) {
-                                    rowViolations.forEach { violation ->
-                                        Text(
-                                            text = violation.message,
-                                            color = NotReadyRed,
-                                            fontSize = 12.sp,
-                                            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
-                                        )
-                                    }
+                                    BoardSetValidationMessage(violations = rowViolations)
                                 }
                             }
                         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -28,6 +28,7 @@ import at.aau.serg.android.ui.screens.game.components.GlobalValidationBanner
 import at.aau.serg.android.ui.screens.game.components.PlayerChip
 import at.aau.serg.android.ui.screens.game.components.TileRow
 import at.aau.serg.android.ui.screens.game.components.TileRowPlaceholder
+import at.aau.serg.android.ui.theme.NotReadyRed
 import at.aau.serg.android.ui.theme.appColors
 
 @Composable

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -114,6 +114,33 @@ fun GameScreenContent(
                 }
             }
 
+            // GLOBAL VALIDATION BANNER
+            if (uiState.ruleValidation.globalViolations.isNotEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(NotReadyRed.copy(alpha = 0.12f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .testTag(GameTestTags.GLOBAL_VALIDATION_BANNER)
+                ) {
+                    Text(
+                        text = uiState.ruleValidation.summaryMessage ?: "Invalid move",
+                        fontWeight = FontWeight.Bold,
+                        color = NotReadyRed,
+                        fontSize = 13.sp
+                    )
+                    uiState.ruleValidation.globalViolations.forEach { violation ->
+                        Text(
+                            text = "• ${violation.message}",
+                            color = NotReadyRed,
+                            fontSize = 12.sp
+                        )
+                    }
+                }
+            }
+
             // CONTENT
             Box(
                 Modifier

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameScreen.kt
@@ -179,12 +179,14 @@ fun GameScreenContent(
                                 )
 
                                 if (isInvalid) {
-                                    Text(
-                                        text = rowViolations.first().message,
-                                        color = NotReadyRed,
-                                        fontSize = 12.sp,
-                                        modifier = Modifier.padding(start = 4.dp, top = 2.dp)
-                                    )
+                                    rowViolations.forEach { violation ->
+                                        Text(
+                                            text = violation.message,
+                                            color = NotReadyRed,
+                                            fontSize = 12.sp,
+                                            modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameTestTags.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameTestTags.kt
@@ -9,4 +9,5 @@ object GameTestTags {
     const val ACTION_ADD = "game_action_add"
     const val ACTION_RESET = "game_action_reset"
     const val ACTION_END_TURN = "game_action_end_turn"
+    const val GLOBAL_VALIDATION_BANNER = "game_global_validation_banner"
 }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameUiState.kt
@@ -1,11 +1,17 @@
 package at.aau.serg.android.ui.screens.game
 
+import at.aau.serg.android.core.errors.ApiRuleViolation
 import at.aau.serg.android.datastore.proto.User
 import at.aau.serg.android.ui.state.LoadState
 import shared.models.game.domain.BoardSet
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.Tile
 
+data class RuleValidationUiState(
+    val violationsByBoardSetId: Map<String, List<ApiRuleViolation>> = emptyMap(),
+    val globalViolations: List<ApiRuleViolation> = emptyList(),
+    val summaryMessage: String? = null
+)
 
 data class GameUiState(
     val loadState: LoadState = LoadState.Success,
@@ -16,5 +22,6 @@ data class GameUiState(
     val activeSelectionRow: String? = null,
     val gameState: ConfirmedGame? = null,
     val winnerUserId: String? = null,
-    val isActivePlayer: Boolean = false
+    val isActivePlayer: Boolean = false,
+    val ruleValidation: RuleValidationUiState = RuleValidationUiState()
 )

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -229,7 +229,8 @@ class GameViewModel(
                 rackTiles = newRack,
                 boardSets = updatedBoardSets,
                 selectedTiles = emptySet(),
-                activeSelectionRow = null
+                activeSelectionRow = null,
+                ruleValidation = RuleValidationUiState()
             )
         }
         sendTurnDraft()
@@ -267,7 +268,8 @@ class GameViewModel(
                 rackTiles = finalRack,
                 boardSets = updatedBoardSets,
                 selectedTiles = emptySet(),
-                activeSelectionRow = null
+                activeSelectionRow = null,
+                ruleValidation = RuleValidationUiState()
             )
         }
         sendTurnDraft()
@@ -289,11 +291,11 @@ class GameViewModel(
             list.add(to, item)
 
             if (boardIndex == null) {
-                state.copy(rackTiles = list)
+                state.copy(rackTiles = list, ruleValidation = RuleValidationUiState())
             } else {
                 val updatedSets = state.boardSets.toMutableList()
                 updatedSets[boardIndex] = updatedSets[boardIndex].copy(tiles = list)
-                state.copy(boardSets = updatedSets)
+                state.copy(boardSets = updatedSets, ruleValidation = RuleValidationUiState())
             }
         }
         sendTurnDraft()
@@ -306,7 +308,8 @@ class GameViewModel(
         _uiState.update { state ->
             state.copy(
                 selectedTiles = emptySet(),
-                activeSelectionRow = null
+                activeSelectionRow = null,
+                ruleValidation = RuleValidationUiState()
             )
         }
         sendTurnDraft()

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -361,14 +361,31 @@ class GameViewModel(
                     it.copy(
                         selectedTiles = emptySet(),
                         activeSelectionRow = null,
-                        loadState = LoadState.Success
+                        loadState = LoadState.Success,
+                        ruleValidation = RuleValidationUiState()
                     )
                 }
             } catch (e: Throwable) {
-                val appError = NetworkErrorMapper.map(e)
-
-                _uiState.update {
-                    it.copy(loadState = LoadState.Error(appError))
+                when (val appError = NetworkErrorMapper.map(e)) {
+                    is AppError.Rest.RuleValidation -> {
+                        val setViolations = appError.violations.filter { it.boardSetId != null }
+                        val globalViolations = appError.violations.filter { it.boardSetId == null }
+                        _uiState.update {
+                            it.copy(
+                                loadState = LoadState.Success,
+                                ruleValidation = RuleValidationUiState(
+                                    violationsByBoardSetId = setViolations.groupBy { v -> v.boardSetId!! },
+                                    globalViolations = globalViolations,
+                                    summaryMessage = appError.message
+                                )
+                            )
+                        }
+                    }
+                    else -> {
+                        _uiState.update {
+                            it.copy(loadState = LoadState.Error(appError))
+                        }
+                    }
                 }
             }
         }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/GameViewModel.kt
@@ -369,6 +369,11 @@ class GameViewModel(
                     )
                 }
             } catch (e: Throwable) {
+                /*
+                Rule-validation failures are recoverable: the player stays on the board
+                and corrects the move. All other errors (network, server, etc.) are fatal
+                and surface through LoadState.Error as usual.
+                */
                 when (val appError = NetworkErrorMapper.map(e)) {
                     is AppError.Rest.RuleValidation -> {
                         val setViolations = appError.violations.filter { it.boardSetId != null }

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/BoardSetValidationMessage.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/BoardSetValidationMessage.kt
@@ -1,0 +1,28 @@
+package at.aau.serg.android.ui.screens.game.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.android.core.errors.ApiRuleViolation
+import at.aau.serg.android.ui.theme.NotReadyRed
+
+@Composable
+fun BoardSetValidationMessage(
+    violations: List<ApiRuleViolation>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        violations.forEach { violation ->
+            Text(
+                text = violation.message,
+                color = NotReadyRed,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(start = 4.dp, top = 2.dp)
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/GlobalValidationBanner.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/game/components/GlobalValidationBanner.kt
@@ -1,0 +1,49 @@
+package at.aau.serg.android.ui.screens.game.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import at.aau.serg.android.core.errors.ApiRuleViolation
+import at.aau.serg.android.ui.screens.game.GameTestTags
+import at.aau.serg.android.ui.theme.NotReadyRed
+
+@Composable
+fun GlobalValidationBanner(
+    summaryMessage: String?,
+    violations: List<ApiRuleViolation>,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(NotReadyRed.copy(alpha = 0.12f))
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag(GameTestTags.GLOBAL_VALIDATION_BANNER)
+    ) {
+        Text(
+            text = summaryMessage ?: "Invalid move",
+            fontWeight = FontWeight.Bold,
+            color = NotReadyRed,
+            fontSize = 13.sp
+        )
+        violations.forEach { violation ->
+            Text(
+                text = "• ${violation.message}",
+                color = NotReadyRed,
+                fontSize = 12.sp
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/util/ErrorUiMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/util/ErrorUiMapper.kt
@@ -19,6 +19,7 @@ object ErrorUiMapper {
             AppError.Rest.NotFound -> "Resource not found"
             AppError.Rest.Conflict -> "Conflict"
             is AppError.Rest.Api -> error.message
+            is AppError.Rest.RuleValidation -> error.message
 
             is AppError.Game.TurnTimedOut -> "Your turn has ended!"
 

--- a/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/NetworkErrorMapperTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/NetworkErrorMapperTest.kt
@@ -105,4 +105,50 @@ class NetworkErrorMapperTest {
         assertTrue(result is AppError.UnknownNetwork)
         assertEquals("Unexpected Network Error", (result as AppError.UnknownNetwork).message)
     }
+
+    // --- RuleValidation ---
+
+    @Test
+    fun map_returnsRuleValidation_for409_withInvalidTurnSubmission() {
+        val json = """
+            {
+              "errorCode": "INVALID_TURN_SUBMISSION",
+              "errorMessage": "Submitted draft is invalid",
+              "violations": [
+                { "code": "RUN_NOT_CONSECUTIVE", "message": "Tiles must be consecutive", "boardSetId": "set-1" },
+                { "code": "INITIAL_MELD_TOO_SMALL", "message": "Initial meld too small", "boardSetId": null }
+              ]
+            }
+        """.trimIndent()
+
+        val result = NetworkErrorMapper.map(httpException(409, json))
+
+        assertTrue(result is AppError.Rest.RuleValidation)
+        val rv = result as AppError.Rest.RuleValidation
+        assertEquals("Submitted draft is invalid", rv.message)
+        assertEquals(2, rv.violations.size)
+        assertEquals("set-1", rv.violations[0].boardSetId)
+        assertEquals(null, rv.violations[1].boardSetId)
+    }
+
+    @Test
+    fun map_returnsConflict_for409_withoutInvalidTurnSubmissionCode() {
+        val json = """{"errorCode": "SOME_OTHER_CODE", "errorMessage": ""}"""
+        val result = NetworkErrorMapper.map(httpException(409, json))
+        assertEquals(AppError.Rest.Conflict, result)
+    }
+
+    @Test
+    fun map_returnsConflict_for409_withMalformedJson() {
+        val result = NetworkErrorMapper.map(httpException(409, "not-json{{{"))
+        assertEquals(AppError.Rest.Conflict, result)
+    }
+
+    @Test
+    fun map_returnsRuleValidation_withFallbackMessage_whenErrorMessageMissing() {
+        val json = """{"errorCode": "INVALID_TURN_SUBMISSION", "violations": []}"""
+        val result = NetworkErrorMapper.map(httpException(409, json))
+        assertTrue(result is AppError.Rest.RuleValidation)
+        assertEquals("Submitted draft is invalid", (result as AppError.Rest.RuleValidation).message)
+    }
 }

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -12,6 +12,10 @@ import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.just
 import io.mockk.mockk
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.HttpException
+import retrofit2.Response
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
@@ -410,6 +414,40 @@ class GameViewModelTest {
         ))
         viewmodel.endTurn()
         advanceUntilIdle()
+    }
+
+    @Test
+    fun endTurn_setsRuleValidation_onInvalidTurnSubmission() = runTest {
+        setTestGameState()
+
+        val json = """{"errorCode":"INVALID_TURN_SUBMISSION","errorMessage":"Draft invalid","violations":[{"code":"RUN_NOT_CONSECUTIVE","message":"Not consecutive","boardSetId":"b1"},{"code":"INITIAL_MELD_TOO_SMALL","message":"Meld too small","boardSetId":null}]}"""
+        val response = Response.error<Any>(409, json.toResponseBody("application/json".toMediaType()))
+        coEvery { service.endTurn(any(), any(), any()) } throws HttpException(response)
+
+        viewmodel.onUIEvent(GameUIEvent.EndTurn)
+        advanceUntilIdle()
+
+        val state = viewmodel.uiState.value
+        assertTrue(state.loadState is LoadState.Success)
+        assertEquals("Draft invalid", state.ruleValidation.summaryMessage)
+        assertTrue(state.ruleValidation.violationsByBoardSetId.containsKey("b1"))
+        assertEquals(1, state.ruleValidation.globalViolations.size)
+    }
+
+    @Test
+    fun endTurn_clearsRuleValidation_onSuccess() = runTest {
+        setTestGameState()
+        viewmodel.setUiStateForTest(
+            viewmodel.uiState.value.copy(
+                ruleValidation = RuleValidationUiState(summaryMessage = "old error")
+            )
+        )
+        coEvery { service.endTurn(any(), any(), any()) } just Runs
+
+        viewmodel.onUIEvent(GameUIEvent.EndTurn)
+        advanceUntilIdle()
+
+        assertEquals(RuleValidationUiState(), viewmodel.uiState.value.ruleValidation)
     }
 
     @Test

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/util/ErrorUiMapperTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/util/ErrorUiMapperTest.kt
@@ -1,5 +1,6 @@
 package at.aau.serg.android.ui.util
 
+import at.aau.serg.android.core.errors.ApiRuleViolation
 import at.aau.serg.android.core.errors.AppError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -53,6 +54,16 @@ class ErrorUiMapperTest {
             "custom failure",
             ErrorUiMapper.toMessage(error)
         )
+    }
+
+    @Test
+    fun maps_rule_validation_error_with_message() {
+        val violation = ApiRuleViolation(code = "RUN_NOT_CONSECUTIVE", message = "Tiles must be consecutive", boardSetId = "set-1")
+        val error = AppError.Rest.RuleValidation(
+            message = "Draft is invalid",
+            violations = listOf(violation)
+        )
+        assertEquals("Draft is invalid", ErrorUiMapper.toMessage(error))
     }
 
     @Test


### PR DESCRIPTION
## Description

Extends the Android transport error layer to fully parse structured rule-validation failures from the backend. 

Adds ApiRuleViolation (code, message, boardSetId) and AppError.Rest.RuleValidation as a dedicated recoverable error type. 

Updates NetworkErrorMapper to detect `409 INVALID_TURN_SUBMISSION` responses and map them to RuleValidation instead of the generic Conflict error, with safe JSON parsing via runCatching. 

Covers the new behavior with four focused unit tests.

## Issues

- Closes #752 
- Closes #745 
- Closes #744
- Closes #746 
- Closes #747 
- Closes #748 
- Closes #616 
- Related to #584 
- Closes #585 
- Closes #586 
- Closes #588 
- Closes #564 
- Closes #565 
- Closes #566 
- Related to #501 
- 