### PR TITLE
feat(backend)(game): add reset-draft endpoint and draft reset flow

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
@@ -58,4 +58,12 @@ class GameController(
     ): GameResponse {
         return endTurnService.endTurn(gameId, userId, request).toResponse()
     }
+
+    @PostMapping("/{gameId}/reset-draft")
+    fun resetDraft(
+        @PathVariable gameId: String,
+        @RequestHeader("X-User-Id") userId: String
+    ): TurnDraftResponse {
+        return turnDraftService.resetDraft(gameId,userId).toResponse()
+    }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -143,8 +143,38 @@ class TurnDraftService(
         check(game.currentPlayerUserId == userId) { NOT_CURRENT_PLAYER }
         check(draftEntity.playerUserId == userId) { NOT_DRAFT_OWNER }
 
-        TODO("Build complete reset draft next")
+        val resetDraft = createDraftFromConfirmedGame(
+            game = game,
+            playerUserId = userId,
+            version = (draftEntity.version + 1)
+        )
 
+        val savedDraft = turnDraftRepository.save(resetDraft.toEntity(draftEntity)).toDomain()
+
+        afterCommitExecutor.execute {
+            gameBroadcastService.broadcastDraftUpdated(savedDraft)
+
+        }
+
+       return savedDraft
+
+    }
+
+    private fun createDraftFromConfirmedGame(
+        game: ConfirmedGame,
+        playerUserId: String,
+        version: Long
+    ): TurnDraft {
+        val activePlayer = game.players.first { it.userId == playerUserId }
+
+        return TurnDraft(
+            gameId = game.gameId,
+            playerUserId = playerUserId,
+            boardSets = game.boardSets,
+            rackTiles = activePlayer.rackTiles,
+            drawnTile = null,
+            version = version
+        )
     }
 
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -10,6 +10,7 @@ import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.TurnDraftRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.ConfirmedGame
 
 /**
  * Service responsible for loading and updating persisted live turn draft state.
@@ -95,7 +96,7 @@ class TurnDraftService(
     ): TurnDraft {
         val game = gameRepository.findById(gameId)
             .orElseThrow { NoSuchElementException(GAME_NOT_FOUND) }
-                .toGameDomain()
+            .toGameDomain()
 
         val draftEntity = turnDraftRepository.findByGameId(gameId)
             ?: throw NoSuchElementException(DRAFT_NOT_FOUND)
@@ -126,11 +127,25 @@ class TurnDraftService(
 
         return updatedDraft
     }
+
     @Transactional
     fun resetDraft(
         gameId: String,
         userId: String
     ): TurnDraft {
-        throw UnsupportedOperationException("resetDraft not yet implemented")
+        val game = gameRepository.findById(gameId)
+            .orElseThrow { NoSuchElementException(GAME_NOT_FOUND) }
+            .toGameDomain()
+
+        val draftEntity = turnDraftRepository.findByGameId(gameId)
+            ?: throw NoSuchElementException(DRAFT_NOT_FOUND)
+
+        check(game.currentPlayerUserId == userId) { NOT_CURRENT_PLAYER }
+        check(draftEntity.playerUserId == userId) { NOT_DRAFT_OWNER }
+
+        TODO("Build complete reset draft next")
+
     }
+
 }
+

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -165,7 +165,8 @@ class TurnDraftService(
         playerUserId: String,
         version: Long
     ): TurnDraft {
-        val activePlayer = game.players.first { it.userId == playerUserId }
+        val activePlayer = game.players.firstOrNull { it.userId == playerUserId }
+            ?: throw IllegalArgumentException("Player $playerUserId is not part of the game ${game.gameId}")
 
         return TurnDraft(
             gameId = game.gameId,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt
@@ -126,4 +126,11 @@ class TurnDraftService(
 
         return updatedDraft
     }
+    @Transactional
+    fun resetDraft(
+        gameId: String,
+        userId: String
+    ): TurnDraft {
+        throw UnsupportedOperationException("resetDraft not yet implemented")
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -424,7 +424,7 @@ class GameControllerTest {
     }
 
     @Test
-    fun `resetDraft returns 400 when game not found`() {
+    fun `resetDraft returns 404 when game not found`() {
         `when`(turnDraftService.resetDraft("missing", "user-1"))
             .thenThrow(NoSuchElementException("Game not found"))
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -402,4 +402,91 @@ class GameControllerTest {
             }
     }
 
+    @Test
+    fun `resetDraft returns 200 with TurnDraftResponse`() {
+        val draft = TurnDraft(
+            gameId = "game-1",
+            playerUserId = "user-1",
+            boardSets = emptyList(),
+            rackTiles = listOf(NumberedTile("rack-1", TileColor.RED,5)),
+            version = 4
+        )
+        `when`(turnDraftService.resetDraft("game-1", "user-1")).thenReturn(draft)
+
+        mockMvc.post("/api/games/game-1/reset-draft") {
+            header("X-User-Id", "user-1")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.gameId") { value("game-1") }
+            jsonPath("$.playerUserId") { value("user-1") }
+            jsonPath("$.version") { value("4") }
+        }
+    }
+
+    @Test
+    fun `resetDraft returns 400 when game not found`() {
+        `when`(turnDraftService.resetDraft("missing", "user-1"))
+            .thenThrow(NoSuchElementException("Game not found"))
+
+        mockMvc.post("/api/games/missing/reset-draft") {
+            header("X-User-Id", "user-1")
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.errorCode") { value("NOT_FOUND") }
+            jsonPath("$.errorMessage") { value("Game not found") }
+        }
+    }
+
+    @Test
+    fun `resetDraft returns 404 when draft not found`() {
+        `when`(turnDraftService.resetDraft("game-1", "user-1"))
+            .thenThrow(NoSuchElementException("Draft not found"))
+
+        mockMvc.post("/api/games/game-1/reset-draft") {
+            header("X-User-Id", "user-1")
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.errorCode") { value("NOT_FOUND") }
+            jsonPath("$.errorMessage") { value("Draft not found") }
+        }
+    }
+
+    @Test
+    fun `resetDraft returns 409 when user is not current player`() {
+        `when`(turnDraftService.resetDraft("game-1", "user-2"))
+            .thenThrow(IllegalStateException("User is not the current active player"))
+
+        mockMvc.post("/api/games/game-1/reset-draft") {
+            header("X-User-Id", "user-2")
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.errorCode") { value("CONFLICT") }
+            jsonPath("$.errorMessage") { value("User is not the current active player") }
+        }
+    }
+
+    @Test
+    fun `resetDraft returns 409 when draft belongs to different user`() {
+        `when`(turnDraftService.resetDraft("game-1", "user-2"))
+            .thenThrow(IllegalStateException("Draft belongs to a different user"))
+
+        mockMvc.post("/api/games/game-1/reset-draft") {
+            header("X-User-Id", "user-2")
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.errorCode") { value("CONFLICT") }
+            jsonPath("$.errorMessage") { value("Draft belongs to a different user") }
+        }
+    }
+
+    @Test
+    fun `resetDraft returns 400 when X-User-Id header is missing`() {
+        mockMvc.post("/api/games/game-1/reset-draft")
+            .andExpect {
+                status { isBadRequest() }
+        }
+
+    }
+
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
@@ -1,0 +1,70 @@
+package at.se2group.backend.game.service
+
+import at.se2group.backend.mapper.toEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.service.AfterCommitExecutor
+import at.se2group.backend.service.GameBroadcastService
+import at.se2group.backend.service.TileConservationService
+import at.se2group.backend.service.TurnDraftService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import shared.models.game.domain.*
+import java.time.Instant
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class TurnDraftServiceResetDraftTest {
+
+    @Mock
+    lateinit var gameRepository: GameRepository
+
+    @Mock
+    lateinit var turnDraftRepository: TurnDraftRepository
+
+    @Mock
+    lateinit var gameBroadcastService: GameBroadcastService
+
+    @Mock
+    lateinit var tileConservationService: TileConservationService
+
+    private lateinit var service: TurnDraftService
+
+    private val player = GamePlayer(
+        userId = "user-1",
+        displayName = "Alice",
+        turnOrder = 0,
+        rackTiles = emptyList(),
+        joinedAt = Instant.now()
+    )
+
+    private val confirmedGame = ConfirmedGame(
+        gameId = "game-1",
+        lobbyId = "lobby-1",
+        players = listOf(player),
+        boardSets = emptyList(),
+        currentPlayerUserId = "user-1",
+        status = GameStatus.ACTIVE
+    )
+
+    private val draftEntity = TurnDraftEntity(
+        gameId = "game-1",
+        playerUserId = "user-1",
+        version = 3L
+    )
+
+    @BeforeEach
+    fun setup() {
+        service = TurnDraftService(
+            gameRepository,
+            turnDraftRepository,
+            tileConservationService,
+            gameBroadcastService,
+            AfterCommitExecutor()
+        )
+    }
+
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
@@ -159,4 +159,11 @@ class TurnDraftServiceResetDraftTest {
         assertEquals("Draft belongs to a different user", exception.message)
     }
 
+    @Test
+    fun `broadcasts draft updated after successful reset`() {
+        givenGameAndDraft()
+        service.resetDraft("game-1", "user-1")
+        verify(gameBroadcastService).broadcastDraftUpdated(any())
+    }
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
@@ -1,5 +1,6 @@
 package at.se2group.backend.game.service
 
+import at.se2group.backend.mapper.toDomain
 import at.se2group.backend.mapper.toEntity
 import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.TurnDraftRepository
@@ -8,10 +9,16 @@ import at.se2group.backend.service.AfterCommitExecutor
 import at.se2group.backend.service.GameBroadcastService
 import at.se2group.backend.service.TileConservationService
 import at.se2group.backend.service.TurnDraftService
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import shared.models.game.domain.*
 import java.time.Instant
 import java.util.Optional
@@ -33,6 +40,10 @@ class TurnDraftServiceResetDraftTest {
 
     private lateinit var service: TurnDraftService
 
+    private val rackTile = NumberedTile("rack-1", TileColor.RED, 5)
+    private val boardTile = NumberedTile("board-1", TileColor.BLUE, 7)
+
+
     private val player = GamePlayer(
         userId = "user-1",
         displayName = "Alice",
@@ -45,7 +56,12 @@ class TurnDraftServiceResetDraftTest {
         gameId = "game-1",
         lobbyId = "lobby-1",
         players = listOf(player),
-        boardSets = emptyList(),
+        boardSets = listOf(
+            BoardSet(
+                boardSetId = "set-1",
+                tiles = listOf(boardTile)
+            )
+        ),
         currentPlayerUserId = "user-1",
         status = GameStatus.ACTIVE
     )
@@ -65,6 +81,49 @@ class TurnDraftServiceResetDraftTest {
             gameBroadcastService,
             AfterCommitExecutor()
         )
+    }
+    private fun givenGameAndDraft() {
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(confirmedGame.toEntity()))
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn((draftEntity))
+        whenever(turnDraftRepository.save(any()))
+                .thenAnswer { it.arguments[0] }
+    }
+
+    @Test
+    fun `resets board from confirmed game`() {
+        givenGameAndDraft()
+        val result = service.resetDraft("game-1", "user-1")
+        assertEquals(confirmedGame.boardSets, result.boardSets)
+    }
+
+    @Test
+    fun `resets rack from confirmed player rack`() {
+        givenGameAndDraft()
+        val result = service.resetDraft("game-1", "user-1")
+        assertEquals(player.rackTiles, result.rackTiles)
+    }
+
+    @Test
+    fun `increments draft version`() {
+        givenGameAndDraft()
+        val result = service.resetDraft("game-1", "user-1")
+        assertEquals(4, result.version)
+    }
+
+    @Test
+    fun `clears drawnTile`() {
+        givenGameAndDraft()
+        val result = service.resetDraft("game-1", "user-1")
+        assertNull(result.drawnTile)
+    }
+
+    @Test
+    fun `persists the reset draft`() {
+        givenGameAndDraft()
+        service.resetDraft("game-1", "user-1")
+        verify(turnDraftRepository).save(any())
     }
 
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/TurnDraftServiceResetDraftTest.kt
@@ -126,4 +126,37 @@ class TurnDraftServiceResetDraftTest {
         verify(turnDraftRepository).save(any())
     }
 
+    @Test
+    fun `rejects when game does not exist`() {
+        whenever(gameRepository.findById("missing")).thenReturn(Optional.empty())
+        assertThrows<NoSuchElementException> { service.resetDraft("missing", "user-1") }
+    }
+
+    @Test
+    fun `rejects when draft does not exist`() {
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(confirmedGame.toEntity()))
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(null)
+        assertThrows<NoSuchElementException> { service.resetDraft("game-1", "user-1") }
+    }
+
+    @Test
+    fun `rejects when user is not the current active player`() {
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(confirmedGame.toEntity()))
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(draftEntity)
+
+
+        val exception = assertThrows<IllegalStateException> { service.resetDraft("game-1", "user-2") }
+        assertEquals("User is not the current active player", exception.message)
+    }
+
+    @Test
+    fun `rejects when draft belongs to a different user`() {
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(confirmedGame.toEntity()))
+        val otherDraft = TurnDraftEntity(gameId = "game-1", playerUserId = "user-2", version = 1)
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(otherDraft)
+
+        val exception = assertThrows<IllegalStateException> { service.resetDraft("game-1", "user-1") }
+        assertEquals("Draft belongs to a different user", exception.message)
+    }
+
 }


### PR DESCRIPTION
## Summary

This PR implements the missing reset-draft feature behind:

```text
POST /api/games/{gameId}/reset-draft
```

The goal is to let the active player discard their current in-progress draft
changes and rebuild the live draft from the authoritative confirmed game state.

This closes the remaining gap in the live draft lifecycle between:

- draft creation
- draft updates
- draw-tile draft mutation
- end-turn draft submission

## Issues

- Closes #376 
- Closes #262 
- Closes #263 
- Closes #345 
- Closes #339 
- Closes #480 
- Closes #474 

## What this PR adds

- `POST /api/games/{gameId}/reset-draft`
- service-layer reset orchestration in `TurnDraftService`
- rebuilding the draft from confirmed game board and confirmed player rack
- clearing draft-only draw markers such as `drawnTile`
- persisting the refreshed draft on the existing entity
- broadcasting `game.draft.updated`
- controller and service tests for the reset flow

## Intended behavior

The reset action should:

1. load the confirmed game
2. load the active draft
3. verify that the acting user is the active player and draft owner
4. rebuild the draft from confirmed server state
5. increment the draft version
6. clear draft-only temporary state
7. save the updated draft
8. broadcast the refreshed draft
9. return `TurnDraftResponse`

## API shape

```kotlin
@PostMapping("/{gameId}/reset-draft")
fun resetDraft(
    @PathVariable gameId: String,
    @RequestHeader("X-User-Id") userId: String
): TurnDraftResponse
```

Expected responses:

- `200 OK` with `TurnDraftResponse`
- `404 NOT_FOUND` if game or active draft is missing
- `409 CONFLICT` if the user is not the current player or does not own the draft

## Important scope boundary

This PR does **not** change:

- confirmed game state
- rule validation
- end-turn commit logic
- score handling
- turn progression

It is only a live-draft reset feature.

## Main implementation location

Most of the logic belongs in:

- [`TurnDraftService.kt`](../apps/backend/src/main/kotlin/at/se2group/backend/service/TurnDraftService.kt)

Related backend context:

- [`GameController.kt`](../apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt)
- [`DrawTileService.kt`](../apps/backend/src/main/kotlin/at/se2group/backend/service/DrawTileService.kt)
- [`EndTurnService.kt`](../apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt)
- [`docs/pr-reset-draft.md`](./pr-reset-draft.md)

