### PR TITLE
feat(backend)(rest-api)(security,zap): resolve security issues raised by owasp zap baseline scan

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilter.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilter.kt
@@ -1,0 +1,77 @@
+package at.se2group.backend.api
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Applies a small baseline set of defensive HTTP response headers to every backend response.
+ *
+ * The backend does not serve a large browser application, but it still exposes public HTTP
+ * endpoints such as `/`, `robots.txt`, `sitemap.xml`, actuator endpoints, and REST APIs.
+ * Those responses benefit from a consistent baseline hardening layer so transport-level security
+ * headers do not need to be repeated in individual controllers.
+ *
+ * This filter currently adds:
+ *
+ * - `X-Content-Type-Options: nosniff`
+ * - `Cross-Origin-Resource-Policy: same-origin`
+ * - `Cross-Origin-Embedder-Policy: require-corp`
+ * - `Cross-Origin-Opener-Policy: same-origin`
+ * - `Cache-Control: no-cache, no-store, must-revalidate, private`
+ * - `Pragma: no-cache`
+ * - `Expires: 0`
+ * - `Strict-Transport-Security`
+ *
+ * Two implementation details matter:
+ *
+ * 1. Headers are applied in a `finally` block so they also appear on error responses produced by
+ *    Spring MVC exception handling.
+ * 2. Existing explicit headers are preserved. If a future endpoint needs a different caching
+ *    policy or resource-sharing policy, that endpoint can set the header itself and this filter
+ *    will not overwrite it.
+ */
+@Component
+class ResponseSecurityHeadersFilter : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            applyHeaderIfMissing(response, "X-Content-Type-Options", "nosniff")
+            applyHeaderIfMissing(response, "Cross-Origin-Resource-Policy", "same-origin")
+            applyHeaderIfMissing(response, "Cross-Origin-Embedder-Policy", "require-corp")
+            applyHeaderIfMissing(response, "Cross-Origin-Opener-Policy", "same-origin")
+
+            // Conservative cache directives are appropriate for API and metadata responses because
+            // they prevent intermediate caches from storing stale or sensitive payloads by default.
+            applyHeaderIfMissing(response, "Cache-Control", "no-cache, no-store, must-revalidate, private")
+            applyHeaderIfMissing(response, "Pragma", "no-cache")
+            applyHeaderIfMissing(response, "Expires", "0")
+
+            // The deployed backend is exposed over HTTPS, and setting HSTS here avoids depending
+            // on proxy-specific forwarded-header handling before the header reaches the client.
+            applyHeaderIfMissing(
+                response,
+                "Strict-Transport-Security",
+                "max-age=31536000; includeSubDomains"
+            )
+        }
+    }
+
+    private fun applyHeaderIfMissing(
+        response: HttpServletResponse,
+        name: String,
+        value: String
+    ) {
+        if (!response.containsHeader(name)) {
+            response.setHeader(name, value)
+        }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/ActuatorSecurityHeadersTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/ActuatorSecurityHeadersTest.kt
@@ -1,0 +1,39 @@
+package at.se2group.backend.api
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+/**
+ * End-to-end MVC coverage for the deployed health endpoint contract targeted by the ZAP scan.
+ *
+ * The security scan explicitly reported findings on `/actuator/health`, so this test verifies
+ * that the global response-header hardening also reaches actuator responses, not only normal
+ * application controllers and MVC error payloads.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ActuatorSecurityHeadersTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `health endpoint returns hardened security headers`() {
+        mockMvc.get("/actuator/health")
+            .andExpect {
+                status { isOk() }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
+            }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -61,6 +61,10 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Missing required header: X-Probe-User") }
                 jsonPath("$.violations.length()") { value(0) }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
             }
     }
 
@@ -107,6 +111,10 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
                 jsonPath("$.errorMessage") { value("An unexpected error occurred") }
                 jsonPath("$.violations.length()") { value(0) }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
             }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -63,8 +63,12 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.violations.length()") { value(0) }
                 header { string("X-Content-Type-Options", "nosniff") }
                 header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
                 header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
                 header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
             }
     }
 
@@ -113,8 +117,12 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.violations.length()") { value(0) }
                 header { string("X-Content-Type-Options", "nosniff") }
                 header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
                 header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
                 header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
             }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilterTest.kt
@@ -1,0 +1,106 @@
+package at.se2group.backend.api
+
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+/**
+ * Unit tests for [ResponseSecurityHeadersFilter].
+ *
+ * These tests cover the baseline hardening contract independently from MVC so the global header
+ * behavior stays verified even if controller tests change. The key things to lock down are:
+ *
+ * - the filter adds the expected defensive headers
+ * - HSTS is added only for secure requests
+ * - explicit endpoint-provided headers are not overwritten
+ * - headers are still written when downstream code throws
+ */
+class ResponseSecurityHeadersFilterTest {
+
+    private val filter = ResponseSecurityHeadersFilter()
+
+    @Test
+    fun `adds baseline security headers for secure requests`() {
+        val request = MockHttpServletRequest("GET", "/").apply {
+            isSecure = true
+        }
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, FilterChain { _, res ->
+            (res as MockHttpServletResponse).status = HttpStatus.OK.value()
+        })
+
+        assertEquals("nosniff", response.getHeader("X-Content-Type-Options"))
+        assertEquals("same-origin", response.getHeader("Cross-Origin-Resource-Policy"))
+        assertEquals("require-corp", response.getHeader("Cross-Origin-Embedder-Policy"))
+        assertEquals("same-origin", response.getHeader("Cross-Origin-Opener-Policy"))
+        assertEquals("no-cache, no-store, must-revalidate, private", response.getHeader("Cache-Control"))
+        assertEquals("no-cache", response.getHeader("Pragma"))
+        assertEquals("0", response.getHeader("Expires"))
+        assertEquals(
+            "max-age=31536000; includeSubDomains",
+            response.getHeader("Strict-Transport-Security")
+        )
+    }
+
+    @Test
+    fun `adds hsts even when request is not marked secure`() {
+        val request = MockHttpServletRequest("GET", "/").apply {
+            isSecure = false
+        }
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, FilterChain { _, res ->
+            (res as MockHttpServletResponse).status = HttpStatus.OK.value()
+        })
+
+        assertEquals(
+            "max-age=31536000; includeSubDomains",
+            response.getHeader("Strict-Transport-Security")
+        )
+        assertEquals("nosniff", response.getHeader("X-Content-Type-Options"))
+    }
+
+    @Test
+    fun `keeps explicit downstream headers`() {
+        val request = MockHttpServletRequest("GET", "/").apply {
+            isSecure = true
+        }
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, FilterChain { _, res ->
+            res as MockHttpServletResponse
+            // Preserve downstream intent if a future endpoint opts into a custom header policy.
+            res.setHeader("Cache-Control", "public, max-age=60")
+            res.setHeader("Cross-Origin-Resource-Policy", "cross-origin")
+            res.status = HttpStatus.OK.value()
+        })
+
+        assertEquals("public, max-age=60", response.getHeader("Cache-Control"))
+        assertEquals("cross-origin", response.getHeader("Cross-Origin-Resource-Policy"))
+        assertEquals("nosniff", response.getHeader("X-Content-Type-Options"))
+    }
+
+    @Test
+    fun `adds headers even when downstream throws`() {
+        val request = MockHttpServletRequest("GET", "/").apply {
+            isSecure = true
+        }
+        val response = MockHttpServletResponse()
+
+        runCatching {
+            filter.doFilter(request, response, FilterChain { _, _ ->
+                throw IllegalStateException("boom")
+            })
+        }
+
+        assertEquals("nosniff", response.getHeader("X-Content-Type-Options"))
+        assertEquals(
+            "max-age=31536000; includeSubDomains",
+            response.getHeader("Strict-Transport-Security")
+        )
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/RootControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/RootControllerTest.kt
@@ -40,6 +40,14 @@ class RootControllerTest {
                 // root response remain intentional.
                 jsonPath("$.service") { value("SE2 Rummikub Backend") }
                 jsonPath("$.status") { value("running") }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
             }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SiteMetadataControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SiteMetadataControllerTest.kt
@@ -48,6 +48,14 @@ class SiteMetadataControllerTest {
                         """.trimIndent()
                     )
                 }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
             }
     }
 
@@ -71,6 +79,14 @@ class SiteMetadataControllerTest {
                         """.trimIndent()
                     )
                 }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
             }
     }
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -548,6 +548,72 @@ The ZAP scan should be understood as one layer only.
 
 Actual backend security still depends on the application code rejecting invalid or unauthorized requests.
 
+### Current Request Identity Model
+
+Most backend game and lobby endpoints currently receive the acting user through:
+
+```kotlin
+@RequestHeader("X-User-Id") userId: String
+```
+
+That header is then used for application-level security and ownership checks in
+the service layer.
+
+Examples of the kinds of checks this enables:
+
+- only the active player may draw, reset a draft, or end a turn
+- only the owning player may mutate their current `TurnDraft`
+- only users who belong to a game may access or mutate that game
+- only users who belong to a lobby may interact with lobby-backed game state
+- only the lobby host may start the lobby
+- per-turn limits such as one draw per turn can be enforced against the acting
+  user identity
+
+Typical service-level checks look like this:
+
+```kotlin
+fun requirePlayerInGame(game: ConfirmedGame, userId: String) {
+    if (game.players.none { it.userId == userId }) {
+        throw SecurityException("Player is not part of this game")
+    }
+}
+
+fun requireCurrentPlayer(game: ConfirmedGame, userId: String) {
+    if (game.currentPlayerUserId != userId) {
+        throw SecurityException("It is not this player's turn")
+    }
+}
+
+fun requireDraftOwner(draft: TurnDraft, userId: String) {
+    if (draft.playerUserId != userId) {
+        throw SecurityException("Draft does not belong to this player")
+    }
+}
+```
+
+This is a valid lightweight authorization model for the current backend, but it
+has an important limit:
+
+```text
+X-User-Id is only trustworthy if the caller environment is trusted.
+```
+
+In other words, this is not full authentication by itself. If an arbitrary
+external client can choose any header value freely, the client can impersonate
+another user unless an upstream trusted system constrains that header.
+
+So the current model should be understood as:
+
+- suitable for controlled development, demos, tests, and trusted integration
+  scenarios
+- useful for enforcing game membership, turn ownership, and host-only actions
+- not equivalent to real end-user authentication
+
+That distinction matters when discussing backend security. The CI security scan
+checks the deployed API surface, but the correctness of user-level access
+control still depends on the service layer enforcing these `X-User-Id`-based
+authorization checks consistently.
+
 Examples:
 
 ```kotlin


### PR DESCRIPTION
# PR Description: OWASP ZAP Security Scan and Response Hardening

## Summary

This PR closes the first backend security-scanning loop around our current
OWASP ZAP baseline scan setup.

The workflow was already able to scan the deployed backend and produce a report,
 but the latest scan surfaced a cluster of low-risk transport-level findings on
the public GET surface:

- `/`
- `/robots.txt`
- `/sitemap.xml`
- `/actuator/health`

This PR addresses the findings that are actually backend-fixable, adds test
coverage around the fixes, and documents the scan outcome in a readable form.

## Issues

- Closes #766 
- Closes #767 
- Closes #768 
- Closes #769 

## What this PR includes

### 1. Global backend response hardening

Adds a dedicated backend filter that applies a baseline set of defensive HTTP
response headers to all responses:

```kotlin
X-Content-Type-Options: nosniff
Cross-Origin-Resource-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Cache-Control: no-cache, no-store, must-revalidate, private
Pragma: no-cache
Expires: 0
```

This is implemented centrally so the hardening applies consistently across:

- normal controller responses
- metadata endpoints
- actuator responses
- MVC error responses

### 2. Test coverage for the new header contract

Adds and extends tests to verify that the new security headers are actually
present on the responses the ZAP scan reported on:

- root endpoint
- `robots.txt`
- `sitemap.xml`
- `/actuator/health`
- mapped `400` / `500` MVC error responses

### 3. Security workflow and documentation alignment

Aligns the backend security documentation with the real workflow behavior and
keeps the scan setup focused on CI visibility through:

- workflow summary output
- uploaded scan artifacts

### 4. Formatted scan report

Adds a readable Markdown report that summarizes:

- the scan result
- which alerts were fixed in code
- which alerts were mitigated
- which alerts are informational only and not backend-fixable

## Alerts addressed

### Fixed in backend

- `Cross-Origin-Embedder-Policy Header Missing or Invalid`
- `Cross-Origin-Opener-Policy Header Missing or Invalid`
- `Cross-Origin-Resource-Policy Header Missing or Invalid`
- `Strict-Transport-Security Header Not Set`
- `X-Content-Type-Options Header Missing`

### Mitigated in backend

- `Re-examine Cache-control Directives`
- `Storable and Cacheable Content`

### Left informational by design

These are request-side or scanner-side and are not resolved by changing
backend response code:

- `Sec-Fetch-Dest Header is Missing`
- `Sec-Fetch-Mode Header is Missing`
- `Sec-Fetch-Site Header is Missing`
- `Sec-Fetch-User Header is Missing`

## Main files

### Production

- `apps/backend/src/main/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilter.kt`

### Tests

- `apps/backend/src/test/kotlin/at/se2group/backend/api/ResponseSecurityHeadersFilterTest.kt`
- `apps/backend/src/test/kotlin/at/se2group/backend/api/RootControllerTest.kt`
- `apps/backend/src/test/kotlin/at/se2group/backend/api/SiteMetadataControllerTest.kt`
- `apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt`
- `apps/backend/src/test/kotlin/at/se2group/backend/api/ActuatorSecurityHeadersTest.kt`

### Documentation

- `docs/security.md`
- `docs/zap-security-report-2026-06-02.md`

## Validation

Verified with focused backend tests covering:

- the new response security headers filter
- success responses
- actuator responses
- error responses

## Why this PR stops here

This PR is intentionally limited to:

- baseline ZAP scan integration already in place
- direct response-header and cache-related fixes from the current report
- documentation and verification of those fixes

It does **not** yet expand into:

- ZAP Automation Framework
- authenticated scanning
- full active scans
- broader backend security hardening beyond the current scan findings

That follow-up should happen in a separate PR so the current scope stays tight
and reviewable.

## Follow-up after merge

After deployment, the backend security scan should be run again so we can
confirm which low-risk findings have disappeared from the new ZAP report.
