### PR TITLE
ci(backend)(workflow)(security)(zap): add zap automation framework scan workflow

### DIFF
--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -1,0 +1,88 @@
+name: Backend Security Scan (Automation Framework)
+
+on:
+  # Manual trigger is useful while the AF plan is still being tuned.
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "apps/backend/**"
+      - "docs/security.md"
+      - ".github/workflows/backend-security-af.yml"
+      - ".github/zap/backend-automation-plan.yaml"
+  # Keep the default branch covered after merges as well.
+  push:
+    branches: [main]
+    paths:
+      - "apps/backend/**"
+      - "docs/security.md"
+      - ".github/workflows/backend-security-af.yml"
+      - ".github/zap/backend-automation-plan.yaml"
+  # Separate scheduled scan from the Monday baseline run to keep the jobs and
+  # artifact streams easier to inspect.
+  schedule:
+    - cron: "0 8 * * 3"
+
+concurrency:
+  group: backend-security-af-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BACKEND_BASE_URL: https://se2-group-codebase.onrender.com
+  HEALTH_URL: https://se2-group-codebase.onrender.com/actuator/health
+
+jobs:
+  zap-automation-framework-scan:
+    name: OWASP ZAP Automation Framework Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Wait for deployed backend
+        run: |
+          for i in {1..30}; do
+            if curl -fsS "$HEALTH_URL"; then
+              echo "Backend is reachable"
+              exit 0
+            fi
+
+            echo "Waiting for backend to wake up..."
+            sleep 10
+          done
+
+          echo "Backend was not reachable"
+          exit 1
+
+      - name: Run ZAP Automation Framework plan
+        uses: zaproxy/action-af@v0.3.0
+        with:
+          plan: ".github/zap/backend-automation-plan.yaml"
+
+      - name: Publish AF summary
+        if: always()
+        run: |
+          {
+            echo "## OWASP ZAP Automation Framework Scan"
+            echo
+            if [ -f zap-af-report.md ]; then
+              cat zap-af-report.md
+            else
+              echo "No AF markdown report was generated."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload AF reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-security-report-af
+          retention-days: 14
+          path: |
+            zap-af-report.md
+            zap-af-report.html
+            zap-af-report.json

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -1,0 +1,74 @@
+env:
+  contexts:
+    - name: se2-backend
+      urls:
+        - https://se2-group-codebase.onrender.com
+      includePaths:
+        - https://se2-group-codebase.onrender.com.*
+
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  - type: requestor
+    name: Request root endpoint
+    requests:
+      - url: https://se2-group-codebase.onrender.com/
+        method: GET
+
+  - type: requestor
+    name: Request robots metadata
+    requests:
+      - url: https://se2-group-codebase.onrender.com/robots.txt
+        method: GET
+
+  - type: requestor
+    name: Request sitemap metadata
+    requests:
+      - url: https://se2-group-codebase.onrender.com/sitemap.xml
+        method: GET
+
+  - type: requestor
+    name: Request health endpoint
+    requests:
+      - url: https://se2-group-codebase.onrender.com/actuator/health
+        method: GET
+
+  - type: passiveScan-config
+    name: Passive scan configuration
+    parameters:
+      maxAlertsPerRule: 10
+
+  - type: passiveScan-wait
+    name: Wait for passive scan completion
+    parameters:
+      maxDuration: 10
+
+  - type: report
+    name: Generate markdown report
+    parameters:
+      template: traditional-md
+      reportDir: /zap/wrk
+      reportFile: zap-af-report.md
+
+  - type: report
+    name: Generate html report
+    parameters:
+      template: traditional-html
+      reportDir: /zap/wrk
+      reportFile: zap-af-report.html
+
+  - type: report
+    name: Generate json report
+    parameters:
+      template: traditional-json
+      reportDir: /zap/wrk
+      reportFile: zap-af-report.json
+
+  - type: exitStatus
+    name: Non-blocking initial exit policy
+    parameters:
+      warnLevel: High
+      errorLevel: High

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.kotlin.reflect)
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.5")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.h2database:h2")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
@@ -1,0 +1,54 @@
+package at.se2group.backend.api
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+/**
+ * End-to-end MVC coverage for the generated OpenAPI document exposed by Springdoc.
+ *
+ * The upcoming ZAP API coverage expansion depends on a stable machine-readable
+ * contract endpoint. This test verifies that the backend actually publishes
+ * `/v3/api-docs` and that the response looks like an OpenAPI document rather
+ * than just any JSON payload.
+ *
+ * Coverage goals in this test:
+ *
+ * - the OpenAPI endpoint is reachable at `/v3/api-docs`
+ * - the endpoint returns `200 OK`
+ * - the response is JSON
+ * - the payload contains the core top-level OpenAPI markers ZAP will rely on
+ * - the global response hardening still applies to the generated document
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class OpenApiDocsTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `openapi docs endpoint exposes generated api contract`() {
+        mockMvc.get("/v3/api-docs")
+            .andExpect {
+                status { isOk() }
+                // Lock down the structural markers of an OpenAPI document so the
+                // ZAP AF import step can depend on this endpoint confidently.
+                jsonPath("$.openapi") { exists() }
+                jsonPath("$.info") { exists() }
+                jsonPath("$.paths") { exists() }
+                header { string("Content-Type", org.hamcrest.Matchers.containsString("application/json")) }
+                header { string("X-Content-Type-Options", "nosniff") }
+                header { string("Cross-Origin-Resource-Policy", "same-origin") }
+                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
+                header { string("Cross-Origin-Opener-Policy", "same-origin") }
+                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
+                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
+                header { string("Pragma", "no-cache") }
+                header { string("Expires", "0") }
+            }
+    }
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,9 @@ The concrete implementation is:
 - the scan is performed with **OWASP ZAP**
 - the result is visible in CI
 - the reports are stored as workflow artifacts for later review
+- the repository now uses both:
+    - a simple **baseline scan**
+    - a plan-driven **Automation Framework scan**
 
 This is intentionally simple. The goal is not to build a full security platform, but to show a correct, automated, repeatable API security check that runs as part of the project workflow.
 
@@ -21,18 +24,33 @@ This is intentionally simple. The goal is not to build a full security platform,
 
 ## What Is Implemented
 
-The project uses the workflow:
+The project currently uses these workflows:
 
 ```text
 .github/workflows/backend-security.yml
+.github/workflows/backend-security-af.yml
 ```
 
-That workflow:
+The baseline workflow:
 
 1. waits until the deployed backend is reachable
 2. runs an **OWASP ZAP baseline scan** against the deployed API
 3. publishes the scan output into the GitHub Actions run summary
 4. uploads the full reports as CI artifacts
+
+The Automation Framework workflow:
+
+1. waits until the deployed backend is reachable
+2. runs a committed **Automation Framework plan** from the repository
+3. generates dedicated markdown, HTML, and JSON AF reports
+4. publishes the AF summary into the GitHub Actions run summary
+5. uploads the AF reports as separate artifacts
+
+The current plan file lives at:
+
+```text
+.github/zap/backend-automation-plan.yaml
+```
 
 This is enough to demonstrate that backend API security testing is:
 
@@ -112,7 +130,7 @@ OWASP ZAP is a widely used web and API security testing tool. For this project i
 - it can scan a deployed HTTP target automatically
 - it produces human-readable and machine-readable reports
 
-For this project, the **baseline scan** is the right choice.
+For this project, the **baseline scan** is the right starting choice.
 
 That matters because the baseline scan is:
 
@@ -122,11 +140,23 @@ That matters because the baseline scan is:
 
 This is a much better fit for a student project deployment than a full active attack scan against production.
 
+The **Automation Framework scan** builds on that baseline setup. It is useful because:
+
+- it keeps the scan design inside a committed YAML plan
+- it is easier to evolve deliberately over time
+- it can grow later into:
+    - richer passive scan configuration
+    - OpenAPI-driven scans
+    - authenticated scans
+    - stricter exit policies
+
+The initial AF rollout should still stay conservative and non-blocking.
+
 ---
 
 ## Security Scan Strategy
 
-The implemented flow is:
+The implemented baseline flow is:
 
 ```text
 GitHub Actions
@@ -142,6 +172,43 @@ This approach is deliberate:
 - the scan runs against the real deployed backend, not only a local mock
 - the scan result is directly visible in the CI run
 - the detailed reports remain downloadable afterwards
+
+The Automation Framework flow follows the same readiness and reporting pattern,
+but replaces the packaged baseline behavior with a committed scan plan:
+
+```text
+GitHub Actions
+    -> wake deployed backend
+    -> verify /actuator/health
+    -> run ZAP Automation Framework plan
+    -> publish CI summary
+    -> upload AF reports as artifacts
+```
+
+---
+
+## Baseline Scan vs Automation Framework Scan
+
+The repository now uses two ZAP-based scan layers for different purposes.
+
+### Baseline scan
+
+Use the baseline workflow when the goal is:
+
+- simple passive scanning
+- fast visibility in CI
+- stable recurring checks with minimal configuration
+
+### Automation Framework scan
+
+Use the AF workflow when the goal is:
+
+- versioned scan design in a repository plan file
+- more deliberate control over requests, reports, and exit behavior
+- a cleaner foundation for future security-scan expansion
+
+The AF workflow does **not** replace the baseline workflow. It extends the
+current security-scanning setup with a second, more structured layer.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,6 +59,15 @@ This is enough to demonstrate that backend API security testing is:
 - visible in CI
 - integrated into the repository
 
+What is important to understand, however, is that the current scan coverage is
+still **narrower than the full backend API surface**. The workflows are
+implemented correctly, but they do not yet exercise the entire game and lobby
+API described in:
+
+```text
+docs/game-api.md
+```
+
 ---
 
 ## Scan Target
@@ -89,6 +98,34 @@ Expected response:
 {
     "status": "UP"
 }
+```
+
+### What is actually being scanned right now
+
+In practice, the current ZAP setup mainly covers:
+
+- `/`
+- `/robots.txt`
+- `/sitemap.xml`
+- `/actuator/health`
+
+This is true for two different reasons:
+
+1. the baseline scan only discovers what it can reach automatically from the
+   deployed public surface
+2. the current Automation Framework plan explicitly requests only those public
+   GET endpoints
+
+That means the current scanning setup is best understood as:
+
+```text
+public endpoint and transport-layer security scanning
+```
+
+not yet as:
+
+```text
+full backend game API security scanning
 ```
 
 ---
@@ -257,6 +294,35 @@ Automation Framework useful for gradual future expansion, such as:
 - stricter exit rules
 - alert filtering
 - controlled active scan jobs
+
+### Why the current scans do not yet cover the full game API
+
+The backend game API is much more stateful than the small public endpoint
+surface that ZAP is currently hitting.
+
+Many backend endpoints require:
+
+- `X-User-Id`
+- path variables such as `gameId` or `lobbyId`
+- request bodies
+- existing backend state, such as:
+  - a real lobby
+  - a started game
+  - a current draft
+  - a valid active player
+
+Because of that, generic passive crawling is not enough to reach or exercise
+those endpoints meaningfully.
+
+To scan the real backend API more deeply, a future scan layer needs one of
+these approaches:
+
+- explicit Automation Framework request definitions for selected API endpoints
+- an OpenAPI-driven scan
+- authenticated/stateful scan setup in a controlled environment
+
+Until that follow-up exists, the current baseline and AF scans should be read
+as valuable but partial coverage.
 
 ---
 
@@ -654,6 +720,26 @@ automated passive API security scanning in CI
 ```
 
 That is still a valid and solid answer to the requirement.
+
+An equally important limitation is scope:
+
+```text
+the current ZAP workflows do not yet cover the full stateful game API.
+```
+
+They are currently strongest at:
+
+- public endpoint checks
+- response-header checks
+- cache-policy checks
+- transport-level observations
+
+They are not yet a substitute for a future deeper scan against:
+
+- game command endpoints
+- draft mutation endpoints
+- end-turn submission flows
+- stateful or authenticated API interactions
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -210,6 +210,54 @@ Use the AF workflow when the goal is:
 The AF workflow does **not** replace the baseline workflow. It extends the
 current security-scanning setup with a second, more structured layer.
 
+### Why the Automation Framework needs a plan file
+
+The difference in configuration model is important:
+
+- the **baseline scan** is a packaged scan with a small number of inputs such
+  as target URL and command options
+- the **Automation Framework scan** is a plan-driven scan where the repository
+  explicitly defines what ZAP should do
+
+For the baseline workflow, this is enough:
+
+```yaml
+with:
+    target: ${{ env.BACKEND_BASE_URL }}
+    cmd_options: "-a -I"
+```
+
+That works because the baseline action already knows its built-in scan flow.
+
+The Automation Framework is different. It needs a committed YAML plan because
+the plan is the scan definition itself. It describes things like:
+
+- which target context to use
+- which requests should be executed
+- which passive scan jobs should run
+- which reports should be generated
+- what exit behavior should be applied
+
+In other words:
+
+- baseline scan = run the standard packaged scan
+- Automation Framework scan = run the exact scan plan defined in the repository
+
+That is why the Automation Framework workflow uses:
+
+```text
+.github/zap/backend-automation-plan.yaml
+```
+
+The extra file is not accidental overhead. It is the mechanism that makes the
+Automation Framework useful for gradual future expansion, such as:
+
+- authenticated scan flows
+- OpenAPI-driven scans
+- stricter exit rules
+- alert filtering
+- controlled active scan jobs
+
 ---
 
 ## Workflow File


### PR DESCRIPTION
see #770 for full documentation on OWASP ZAP Automation Framework Scan CI Integration


## Summary
See [MarketPlace - ZAP Automation Framework Scan](https://github.com/marketplace/actions/zap-automation-framework-scan)

This PR adds a second backend security scan using the OWASP ZAP Automation Framework.

The repository already has a working baseline scan in:

* backend-security.yml

That workflow stays in place. The goal here is to add a separate, plan-driven scan that is easier to extend over time.

Initial rollout goals:

* scan the deployed Render backend
* use a committed Automation Framework plan file
* stay non-blocking at first
* publish readable CI output
* upload artifacts separately from the baseline scan

This PR introduces a more maintainable next scanning layer. It does not replace the baseline scan and does not add aggressive active scanning yet.

## Issues

- Closes #773 
- Closes #774 
- Closes #775 
- Closes #776 
- Closes #777 
- Closes #778 
- Closes #779 
- Closes #780 

---

⸻

## Why this PR exists

The baseline scan answers:

Do we scan the deployed backend automatically at all?

This PR answers the next question:

Can we define and evolve the scan explicitly with a versioned plan?

The Automation Framework is a good fit because it is:

* YAML plan based
* easier to extend than the packaged baseline scan
* suitable for later additions like:
    * passive scan tuning
    * path-specific behavior
    * OpenAPI-driven scans
    * authenticated scans
    * stricter exit logic

## Scope

#### Included

* new Automation Framework workflow
* new Automation Framework plan file
* separate summary and artifact publishing
* path filters for workflow and plan changes
* docs update explaining baseline vs AF scan
* initial non-blocking exit behavior

#### Not included

* removal of the baseline workflow
* authenticated scanning
* OpenAPI import
* active scan jobs
* strict failure policy

⸻

## Main design decisions

Keep baseline and AF scans separate

#### Recommended end state:

* backend-security.yml → baseline scan
* backend-security-af.yml → Automation Framework scan

#### Reason:

* baseline remains the simplest passive scan
* AF scan is for explicit, extensible scan design
* separate workflows are easier to review and maintain

Start passive and non-blocking

The first AF rollout should be conservative:

* deployed backend target
* passive discovery-oriented steps
* generated reports
* non-blocking CI behavior

## Version the plan file in the repo

Recommended location:

```text
.github/zap/backend-automation-plan.yaml
```

This keeps workflow and scan plan versioned together.

Publish separate artifacts

Recommended artifact name:
```text
zap-security-report-af
```
This keeps baseline and AF outputs clearly separated.

Recommended first plan

The first AF plan should stay intentionally conservative:

* request a few known endpoints
* run passive scan processing only
* generate markdown, HTML, and JSON reports
* use a non-blocking exit policy

That gives a safe first rollout without changing the existing baseline scan behavior.

## Important implementation notes

* reports must be written to /zap/wrk
* keep the first AF plan passive
* do not fail CI on ordinary warnings yet

## Validation checklist

This PR is complete when:

* the new workflow runs successfully in GitHub Actions
* the deployed backend is reachable from CI
* AF reports are generated and uploaded as artifacts
* the workflow summary shows readable output
* the baseline workflow still works unchanged
* docs/security.md explains baseline vs AF scanning


## Future follow-up work

Out of scope for this PR:

* authenticated scans
* OpenAPI import
* active scan jobs
* stricter failure policy
* alert filtering tuning

⸻

Final outcome

After this PR, the repository should have:

* the existing baseline ZAP scan
* a second, plan-driven Automation Framework scan
* separate reports for both
* a clear path toward richer security scanning later