### PR TITLE
ci(backend)(workflow)(security)(zap): extend zap automation framework scan to full api coverage

### DIFF
--- a/.github/scripts/generate_zap_af_endpoint_coverage.rb
+++ b/.github/scripts/generate_zap_af_endpoint_coverage.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "time"
+require "yaml"
+
+plan_path = ARGV.fetch(0)
+json_path = ARGV.fetch(1)
+output_path = ARGV.fetch(2)
+
+plan = YAML.load_file(plan_path)
+report = File.exist?(json_path) ? JSON.parse(File.read(json_path)) : {}
+
+def request_category(job_name, request)
+  url = request.fetch("url")
+  expected = request["responseCode"]
+
+  return "Public Endpoints" if job_name.start_with?("Public endpoint:")
+  return "Positive Lobby-State Endpoints" if url.include?("/api/lobbies/") && [200, 204].include?(expected)
+  return "Positive Game-State Endpoints" if url.include?("/api/games/") && expected == 200
+
+  "Negative-Path Endpoints"
+end
+
+def display_path(url)
+  url.sub(%r{\Ahttps://[^/]+}, "")
+end
+
+requests = plan.fetch("jobs", []).select { |job| job["type"] == "requestor" }.flat_map do |job|
+  (job["requests"] || []).map do |request|
+    {
+      job_name: job.fetch("name"),
+      method: request.fetch("method", "GET"),
+      url: request.fetch("url"),
+      expected_status: request["responseCode"],
+      category: request_category(job.fetch("name"), request)
+    }
+  end
+end
+
+grouped_requests = requests.group_by { |request| request[:category] }
+site_name = report.fetch("site", []).first&.fetch("@name", nil) || ENV.fetch("BACKEND_BASE_URL", "unknown")
+generated_at = report["@generated"] || Time.now.utc.rfc2822
+created_at = report["created"] || Time.now.utc.iso8601
+insights = Array(report["insights"])
+statistics = report["statistics"] || {}
+endpoint_total = insights.find { |insight| insight["key"] == "insight.endpoint.total" }&.fetch("statistic", nil)
+openapi_urls_added = statistics["openapi.urls.added"]
+site_statistics = report.fetch("site", []).first&.fetch("statistics", {}) || {}
+
+File.open(output_path, "w") do |file|
+  file.puts "# ZAP AF Endpoint Coverage"
+  file.puts
+  file.puts "## Metadata"
+  file.puts
+  file.puts "| Field | Value |"
+  file.puts "| --- | --- |"
+  file.puts "| Target site | `#{site_name}` |"
+  file.puts "| Automation plan | `#{plan_path}` |"
+  file.puts "| ZAP generated at | `#{generated_at}` |"
+  file.puts "| Report created at | `#{created_at}` |"
+  file.puts "| OpenAPI URLs added | `#{openapi_urls_added || 'n/a'}` |"
+  file.puts "| Total endpoints reported by ZAP | `#{endpoint_total || 'n/a'}` |"
+  file.puts
+  file.puts "## Coverage Summary"
+  file.puts
+  file.puts "- Layer 2 imports the generated OpenAPI contract from `/v3/api-docs`."
+  file.puts "- Layer 3 substitutes real fixture ids from `/internal/security/scan-fixture` into the generated plan before ZAP runs."
+  file.puts "- The inventory below is derived from the generated Automation Framework plan, not guessed from the markdown alert summary."
+  file.puts
+
+  [
+    "Public Endpoints",
+    "Positive Lobby-State Endpoints",
+    "Positive Game-State Endpoints",
+    "Negative-Path Endpoints"
+  ].each do |category|
+    entries = grouped_requests.fetch(category, [])
+    next if entries.empty?
+
+    file.puts "## #{category}"
+    file.puts
+    file.puts "| Request | Method | Path | Expected status |"
+    file.puts "| --- | --- | --- | --- |"
+    entries.each do |entry|
+      file.puts "| #{entry[:job_name]} | `#{entry[:method]}` | `#{display_path(entry[:url])}` | `#{entry[:expected_status]}` |"
+    end
+    file.puts
+  end
+
+  file.puts "## Response Profile"
+  file.puts
+  file.puts "| Statistic | Value |"
+  file.puts "| --- | --- |"
+  site_statistics.keys.sort.each do |key|
+    file.puts "| `#{key}` | `#{site_statistics[key]}` |"
+  end
+  file.puts
+
+  file.puts "## Interpretation"
+  file.puts
+  file.puts "- Positive lobby-state coverage runs against a real open lobby created by the dedicated scan-fixture endpoint."
+  file.puts "- Positive game-state coverage runs against a real active game and live draft created by the same fixture endpoint."
+  file.puts "- Negative-path requests remain in the plan so missing-id behavior stays visible alongside the positive-state traffic."
+end

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "apps/backend/**"
       - "docs/security.md"
+      - ".github/scripts/**"
       - ".github/workflows/backend-security-af.yml"
       - ".github/zap/backend-automation-plan.yaml"
   # Keep the default branch covered after merges as well.
@@ -15,6 +16,7 @@ on:
     paths:
       - "apps/backend/**"
       - "docs/security.md"
+      - ".github/scripts/**"
       - ".github/workflows/backend-security-af.yml"
       - ".github/zap/backend-automation-plan.yaml"
   # Separate scheduled scan from the Monday baseline run to keep the jobs and

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -58,42 +58,35 @@ jobs:
           echo "Backend was not reachable"
           exit 1
 
-      - name: Prepare dynamic lobby scan state
+      - name: Prepare dynamic scan fixture state
+        env:
+          ZAP_SCAN_FIXTURE_SECRET: ${{ secrets.ZAP_SCAN_FIXTURE_SECRET }}
         run: |
           set -euo pipefail
 
-          create_lobby() {
-            local user_id="$1"
-            local display_name="$2"
-
+          FIXTURE_JSON="$(
             curl -fsS \
-              -X POST "$BACKEND_BASE_URL/api/lobbies" \
-              -H "X-User-Id: $user_id" \
-              -H "Content-Type: application/json" \
-              -d "{\"displayName\":\"$display_name\",\"maxPlayers\":4,\"isPrivate\":false,\"allowGuests\":true}"
-          }
-
-          join_lobby() {
-            local lobby_id="$1"
-            local user_id="$2"
-            local display_name="$3"
-
-            curl -fsS \
-              -X POST "$BACKEND_BASE_URL/api/lobbies/$lobby_id/join" \
-              -H "Content-Type: application/json" \
-              -d "{\"userId\":\"$user_id\",\"displayName\":\"$display_name\"}" \
-              >/dev/null
-          }
-
-          MUTABLE_LOBBY_ID="$(
-            create_lobby "scan-host-user" "ZAP AF Host" | jq -r '.lobbyId'
+              -X POST "$BACKEND_BASE_URL/internal/security/scan-fixture" \
+              -H "X-Scan-Secret: $ZAP_SCAN_FIXTURE_SECRET"
           )"
-          join_lobby "$MUTABLE_LOBBY_ID" "scan-guest-user" "ZAP AF Guest"
 
-          echo "Prepared mutable lobby: $MUTABLE_LOBBY_ID"
+          SCAN_LOBBY_ID="$(echo "$FIXTURE_JSON" | jq -r '.lobbyId')"
+          SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
+          SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
+          SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
+
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
+            if [ -z "$value" ] || [ "$value" = "null" ]; then
+              echo "Scan fixture endpoint returned incomplete data"
+              exit 1
+            fi
+          done
 
           sed \
-            -e "s/__SCAN_MUTABLE_LOBBY_ID__/$MUTABLE_LOBBY_ID/g" \
+            -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
+            -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
+            -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
+            -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -102,12 +95,20 @@ jobs:
         with:
           plan: ".github/zap/backend-automation-plan.generated.yaml"
 
+      - name: Generate endpoint coverage artifact
+        if: always()
+        run: ruby .github/scripts/generate_zap_af_endpoint_coverage.rb .github/zap/backend-automation-plan.generated.yaml zap-af-report.json zap-af-endpoint-coverage.md
+
       - name: Publish AF summary
         if: always()
         run: |
           {
             echo "## OWASP ZAP Automation Framework Scan"
             echo
+            if [ -f zap-af-endpoint-coverage.md ]; then
+              cat zap-af-endpoint-coverage.md
+              echo
+            fi
             if [ -f zap-af-report.md ]; then
               cat zap-af-report.md
             else
@@ -122,6 +123,8 @@ jobs:
           name: zap-security-report-af
           retention-days: 14
           path: |
+            .github/zap/backend-automation-plan.generated.yaml
             zap-af-report.md
             zap-af-report.html
             zap-af-report.json
+            zap-af-endpoint-coverage.md

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -82,6 +82,13 @@ jobs:
             fi
           done
 
+          {
+            echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"
+            echo "SCAN_GAME_ID=$SCAN_GAME_ID"
+            echo "SCAN_HOST_USER_ID=$SCAN_HOST_USER_ID"
+            echo "SCAN_GUEST_USER_ID=$SCAN_GUEST_USER_ID"
+          } >> "$GITHUB_ENV"
+
           sed \
             -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
             -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
@@ -94,6 +101,19 @@ jobs:
         uses: zaproxy/action-af@v0.3.0
         with:
           plan: ".github/zap/backend-automation-plan.generated.yaml"
+
+      - name: Regenerate concrete AF plan for reporting
+        if: always()
+        run: |
+          set -euo pipefail
+
+          sed \
+            -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
+            -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
+            -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
+            -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+            .github/zap/backend-automation-plan.yaml \
+            > .github/zap/backend-automation-plan.generated.yaml
 
       - name: Generate endpoint coverage artifact
         if: always()

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -58,10 +58,49 @@ jobs:
           echo "Backend was not reachable"
           exit 1
 
+      - name: Prepare dynamic lobby scan state
+        run: |
+          set -euo pipefail
+
+          create_lobby() {
+            local user_id="$1"
+            local display_name="$2"
+
+            curl -fsS \
+              -X POST "$BACKEND_BASE_URL/api/lobbies" \
+              -H "X-User-Id: $user_id" \
+              -H "Content-Type: application/json" \
+              -d "{\"displayName\":\"$display_name\",\"maxPlayers\":4,\"isPrivate\":false,\"allowGuests\":true}"
+          }
+
+          join_lobby() {
+            local lobby_id="$1"
+            local user_id="$2"
+            local display_name="$3"
+
+            curl -fsS \
+              -X POST "$BACKEND_BASE_URL/api/lobbies/$lobby_id/join" \
+              -H "Content-Type: application/json" \
+              -d "{\"userId\":\"$user_id\",\"displayName\":\"$display_name\"}" \
+              >/dev/null
+          }
+
+          MUTABLE_LOBBY_ID="$(
+            create_lobby "scan-host-user" "ZAP AF Host" | jq -r '.lobbyId'
+          )"
+          join_lobby "$MUTABLE_LOBBY_ID" "scan-guest-user" "ZAP AF Guest"
+
+          echo "Prepared mutable lobby: $MUTABLE_LOBBY_ID"
+
+          sed \
+            -e "s/__SCAN_MUTABLE_LOBBY_ID__/$MUTABLE_LOBBY_ID/g" \
+            .github/zap/backend-automation-plan.yaml \
+            > .github/zap/backend-automation-plan.generated.yaml
+
       - name: Run ZAP Automation Framework plan
         uses: zaproxy/action-af@v0.3.0
         with:
-          plan: ".github/zap/backend-automation-plan.yaml"
+          plan: ".github/zap/backend-automation-plan.generated.yaml"
 
       - name: Publish AF summary
         if: always()

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -107,13 +107,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          sed \
-            -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
-            -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
-            -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
-            -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
-            .github/zap/backend-automation-plan.yaml \
-            > .github/zap/backend-automation-plan.generated.yaml
+          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ]; then
+            sed \
+              -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
+              -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
+              -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
+              -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+              .github/zap/backend-automation-plan.yaml \
+              > .github/zap/backend-automation-plan.generated.yaml
+          else
+            cp .github/zap/backend-automation-plan.yaml .github/zap/backend-automation-plan.generated.yaml
+          fi
 
       - name: Generate endpoint coverage artifact
         if: always()

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -75,7 +75,7 @@ jobs:
         responseCode: 200
 
   - type: requestor
-    name: Exercise create lobby endpoint without side effects
+    name: "Negative path: invalid create lobby request"
     requests:
       - url: https://se2-group-codebase.onrender.com/api/lobbies
         method: POST
@@ -84,9 +84,12 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
-            "displayName": "ZAP Scan"
+            "displayName": "",
+            "maxPlayers": 4,
+            "isPrivate": false,
+            "allowGuests": true
           }
-        responseCode: 200
+        responseCode: 400
 
   - type: requestor
     name: Exercise join lobby endpoint with missing fixture id

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -16,6 +16,7 @@ jobs:
     name: Passive scan configuration
     parameters:
       maxAlertsPerRule: 10
+      scanOnlyInScope: true
 
   - type: openapi
     name: Import generated OpenAPI contract
@@ -38,43 +39,193 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/
         method: GET
+        responseCode: 200
 
   - type: requestor
     name: Request robots metadata
     requests:
       - url: https://se2-group-codebase.onrender.com/robots.txt
         method: GET
+        responseCode: 200
 
   - type: requestor
     name: Request sitemap metadata
     requests:
       - url: https://se2-group-codebase.onrender.com/sitemap.xml
         method: GET
+        responseCode: 200
 
   - type: requestor
     name: Request health endpoint
     requests:
       - url: https://se2-group-codebase.onrender.com/actuator/health
         method: GET
+        responseCode: 200
 
-  - type: activeScan-config
-    name: Active scan configuration for imported API shape
-    parameters:
-      maxRuleDurationInMins: 1
-      maxScanDurationInMins: 5
-      maxAlertsPerRule: 10
-      defaultStrength: Low
-      defaultThreshold: High
-      handleAntiCSRFTokens: false
+  - type: requestor
+    name: Request leaderboard endpoint
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/leaderboard
+        method: GET
+        responseCode: 200
 
-  - type: activeScan
-    name: Active scan imported API context
-    parameters:
-      context: se2-backend
-      maxScanDurationInMins: 5
-      defaultStrength: Low
-      defaultThreshold: High
-      delayInMs: 200
+  - type: requestor
+    name: Request lobby collection
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies
+        method: GET
+        responseCode: 200
+
+  - type: requestor
+    name: Request seeded open lobby
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby
+        method: GET
+        responseCode: 200
+
+  - type: requestor
+    name: Exercise create lobby endpoint without side effects
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies
+        method: POST
+        headers:
+          - "X-User-Id:scan-ephemeral-user"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "displayName": "ZAP Scan"
+          }
+        responseCode: 400
+
+  - type: requestor
+    name: Exercise join lobby endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/join
+        method: POST
+        headers:
+          - "Content-Type:application/json"
+        data: |
+          {
+            "userId": "scan-join-user",
+            "displayName": "Scan Join User"
+          }
+        responseCode: 404
+
+  - type: requestor
+    name: Update seeded lobby settings
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/settings
+        method: PATCH
+        headers:
+          - "X-User-Id:scan-host-user"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "maxPlayers": 4,
+            "isPrivate": false,
+            "allowGuests": true
+          }
+        responseCode: 200
+
+  - type: requestor
+    name: Toggle seeded lobby ready state safely
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/ready
+        method: POST
+        headers:
+          - "X-User-Id:scan-guest-user"
+        responseCode: 200
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/unready
+        method: POST
+        headers:
+          - "X-User-Id:scan-guest-user"
+        responseCode: 200
+
+  - type: requestor
+    name: Exercise start lobby endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
+        method: POST
+        headers:
+          - "X-User-Id:scan-host-user"
+        responseCode: 404
+
+  - type: requestor
+    name: Exercise leave lobby endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
+        method: POST
+        headers:
+          - "X-User-Id:scan-guest-user"
+        responseCode: 404
+
+  - type: requestor
+    name: Exercise delete lobby endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
+        method: DELETE
+        headers:
+          - "X-User-Id:scan-host-user"
+        responseCode: 404
+
+  - type: requestor
+    name: Request seeded game state
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/scan-game-1
+        method: GET
+        responseCode: 200
+
+  - type: requestor
+    name: Update seeded turn draft
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/scan-game-1/draft
+        method: PUT
+        headers:
+          - "X-User-Id:scan-host-user"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "boardSets": [],
+            "rackTiles": [
+              {
+                "tileId": "scan-host-rack-red-5",
+                "color": "RED",
+                "number": 5,
+                "isJoker": false
+              },
+              {
+                "tileId": "scan-host-rack-blue-7",
+                "color": "BLUE",
+                "number": 7,
+                "isJoker": false
+              }
+            ]
+          }
+        responseCode: 200
+
+  - type: requestor
+    name: Exercise draw endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
+        method: POST
+        headers:
+          - "X-User-Id:scan-host-user"
+        responseCode: 404
+
+  - type: requestor
+    name: Exercise end turn endpoint with missing fixture id
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
+        method: POST
+        headers:
+          - "X-User-Id:scan-host-user"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "boardSets": [],
+            "rackTiles": []
+          }
+        responseCode: 404
 
   - type: passiveScan-wait
     name: Wait for passive scan completion

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -12,12 +12,26 @@ env:
     progressToStdout: true
 
 jobs:
+  - type: passiveScan-config
+    name: Passive scan configuration
+    parameters:
+      maxAlertsPerRule: 10
+
   - type: openapi
     name: Import generated OpenAPI contract
     parameters:
       apiUrl: https://se2-group-codebase.onrender.com/v3/api-docs
       targetUrl: https://se2-group-codebase.onrender.com
       context: se2-backend
+    tests:
+      - name: Imported lobby collection endpoint
+        type: url
+        url: https://se2-group-codebase.onrender.com/api/lobbies
+        onFail: warn
+      - name: Imported leaderboard endpoint
+        type: url
+        url: https://se2-group-codebase.onrender.com/api/leaderboard
+        onFail: warn
 
   - type: requestor
     name: Request root endpoint
@@ -43,10 +57,24 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/actuator/health
         method: GET
 
-  - type: passiveScan-config
-    name: Passive scan configuration
+  - type: activeScan-config
+    name: Active scan configuration for imported API shape
     parameters:
+      maxRuleDurationInMins: 1
+      maxScanDurationInMins: 5
       maxAlertsPerRule: 10
+      defaultStrength: Low
+      defaultThreshold: High
+      handleAntiCSRFTokens: false
+
+  - type: activeScan
+    name: Active scan imported API context
+    parameters:
+      context: se2-backend
+      maxScanDurationInMins: 5
+      defaultStrength: Low
+      defaultThreshold: High
+      delayInMs: 200
 
   - type: passiveScan-wait
     name: Wait for passive scan completion

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -24,15 +24,6 @@ jobs:
       apiUrl: https://se2-group-codebase.onrender.com/v3/api-docs
       targetUrl: https://se2-group-codebase.onrender.com
       context: se2-backend
-    tests:
-      - name: Imported lobby collection endpoint
-        type: url
-        url: https://se2-group-codebase.onrender.com/api/lobbies
-        onFail: warn
-      - name: Imported leaderboard endpoint
-        type: url
-        url: https://se2-group-codebase.onrender.com/api/leaderboard
-        onFail: warn
 
   - type: requestor
     name: Request root endpoint

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -68,11 +68,11 @@ jobs:
         responseCode: 200
 
   - type: requestor
-    name: Request seeded open lobby
+    name: Exercise lobby get endpoint with missing fixture id
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: GET
-        responseCode: 200
+        responseCode: 404
 
   - type: requestor
     name: Exercise create lobby endpoint without side effects
@@ -86,7 +86,7 @@ jobs:
           {
             "displayName": "ZAP Scan"
           }
-        responseCode: 400
+        responseCode: 200
 
   - type: requestor
     name: Exercise join lobby endpoint with missing fixture id
@@ -103,9 +103,9 @@ jobs:
         responseCode: 404
 
   - type: requestor
-    name: Update seeded lobby settings
+    name: Exercise lobby settings endpoint with missing fixture id
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/settings
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/settings
         method: PATCH
         headers:
           - "X-User-Id:scan-host-user"
@@ -116,21 +116,21 @@ jobs:
             "isPrivate": false,
             "allowGuests": true
           }
-        responseCode: 200
+        responseCode: 404
 
   - type: requestor
-    name: Toggle seeded lobby ready state safely
+    name: Exercise lobby ready state endpoints with missing fixture id
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/ready
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/ready
         method: POST
         headers:
           - "X-User-Id:scan-guest-user"
-        responseCode: 200
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/scan-open-lobby/unready
+        responseCode: 404
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/unready
         method: POST
         headers:
           - "X-User-Id:scan-guest-user"
-        responseCode: 200
+        responseCode: 404
 
   - type: requestor
     name: Exercise start lobby endpoint with missing fixture id
@@ -160,16 +160,16 @@ jobs:
         responseCode: 404
 
   - type: requestor
-    name: Request seeded game state
+    name: Exercise game get endpoint with missing fixture id
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/games/scan-game-1
+      - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
-        responseCode: 200
+        responseCode: 404
 
   - type: requestor
-    name: Update seeded turn draft
+    name: Exercise turn draft update endpoint with missing fixture id
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/games/scan-game-1/draft
+      - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
           - "X-User-Id:scan-host-user"
@@ -192,7 +192,7 @@ jobs:
               }
             ]
           }
-        responseCode: 200
+        responseCode: 404
 
   - type: requestor
     name: Exercise draw endpoint with missing fixture id

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -68,11 +68,11 @@ jobs:
         responseCode: 200
 
   - type: requestor
-    name: Exercise lobby get endpoint with missing fixture id
+    name: Request prepared scan lobby
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__
         method: GET
-        responseCode: 404
+        responseCode: 200
 
   - type: requestor
     name: Exercise create lobby endpoint without side effects
@@ -103,9 +103,9 @@ jobs:
         responseCode: 404
 
   - type: requestor
-    name: Exercise lobby settings endpoint with missing fixture id
+    name: Update prepared scan lobby settings
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/settings
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/settings
         method: PATCH
         headers:
           - "X-User-Id:scan-host-user"
@@ -116,21 +116,39 @@ jobs:
             "isPrivate": false,
             "allowGuests": true
           }
-        responseCode: 404
+        responseCode: 200
 
   - type: requestor
-    name: Exercise lobby ready state endpoints with missing fixture id
+    name: Toggle prepared scan lobby ready state safely
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/ready
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/ready
         method: POST
         headers:
           - "X-User-Id:scan-guest-user"
-        responseCode: 404
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/unready
+        responseCode: 200
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/unready
         method: POST
         headers:
           - "X-User-Id:scan-guest-user"
-        responseCode: 404
+        responseCode: 200
+
+  - type: requestor
+    name: Exercise leave endpoint on prepared scan lobby
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/leave
+        method: POST
+        headers:
+          - "X-User-Id:scan-guest-user"
+        responseCode: 200
+
+  - type: requestor
+    name: Delete prepared scan lobby
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__
+        method: DELETE
+        headers:
+          - "X-User-Id:scan-host-user"
+        responseCode: 204
 
   - type: requestor
     name: Exercise start lobby endpoint with missing fixture id
@@ -233,14 +251,14 @@ jobs:
   - type: report
     name: Generate html report
     parameters:
-      template: traditional-html
+      template: traditional-html-plus
       reportDir: /zap/wrk
       reportFile: zap-af-report.html
 
   - type: report
     name: Generate json report
     parameters:
-      template: traditional-json
+      template: traditional-json-plus
       reportDir: /zap/wrk
       reportFile: zap-af-report.json
 

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -26,51 +26,51 @@ jobs:
       context: se2-backend
 
   - type: requestor
-    name: Request root endpoint
+    name: "Public endpoint: root"
     requests:
       - url: https://se2-group-codebase.onrender.com/
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request robots metadata
+    name: "Public endpoint: robots metadata"
     requests:
       - url: https://se2-group-codebase.onrender.com/robots.txt
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request sitemap metadata
+    name: "Public endpoint: sitemap metadata"
     requests:
       - url: https://se2-group-codebase.onrender.com/sitemap.xml
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request health endpoint
+    name: "Public endpoint: health"
     requests:
       - url: https://se2-group-codebase.onrender.com/actuator/health
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request leaderboard endpoint
+    name: "Public endpoint: leaderboard"
     requests:
       - url: https://se2-group-codebase.onrender.com/api/leaderboard
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request lobby collection
+    name: "Public endpoint: lobby collection"
     requests:
       - url: https://se2-group-codebase.onrender.com/api/lobbies
         method: GET
         responseCode: 200
 
   - type: requestor
-    name: Request prepared scan lobby
+    name: "Positive lobby state: get prepared scan lobby"
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: GET
         responseCode: 200
 
@@ -103,12 +103,12 @@ jobs:
         responseCode: 404
 
   - type: requestor
-    name: Update prepared scan lobby settings
+    name: "Positive lobby state: update prepared scan lobby settings"
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/settings
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
         method: PATCH
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
           - "Content-Type:application/json"
         data: |
           {
@@ -119,35 +119,35 @@ jobs:
         responseCode: 200
 
   - type: requestor
-    name: Toggle prepared scan lobby ready state safely
+    name: "Positive lobby state: toggle prepared scan lobby ready state"
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/ready
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/ready
         method: POST
         headers:
-          - "X-User-Id:scan-guest-user"
+          - "X-User-Id:__SCAN_GUEST_USER_ID__"
         responseCode: 200
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/unready
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/unready
         method: POST
         headers:
-          - "X-User-Id:scan-guest-user"
-        responseCode: 200
-
-  - type: requestor
-    name: Exercise leave endpoint on prepared scan lobby
-    requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__/leave
-        method: POST
-        headers:
-          - "X-User-Id:scan-guest-user"
+          - "X-User-Id:__SCAN_GUEST_USER_ID__"
         responseCode: 200
 
   - type: requestor
-    name: Delete prepared scan lobby
+    name: "Positive lobby state: leave prepared scan lobby"
     requests:
-      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_MUTABLE_LOBBY_ID__
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/leave
+        method: POST
+        headers:
+          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+        responseCode: 200
+
+  - type: requestor
+    name: "Positive lobby state: delete prepared scan lobby"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: DELETE
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
         responseCode: 204
 
   - type: requestor
@@ -156,7 +156,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
         method: POST
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
         responseCode: 404
 
   - type: requestor
@@ -165,7 +165,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
         method: POST
         headers:
-          - "X-User-Id:scan-guest-user"
+          - "X-User-Id:__SCAN_GUEST_USER_ID__"
         responseCode: 404
 
   - type: requestor
@@ -174,23 +174,97 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: DELETE
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
         responseCode: 404
 
   - type: requestor
-    name: Exercise game get endpoint with missing fixture id
+    name: "Positive game state: get prepared scan game"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__
+        method: GET
+        responseCode: 200
+
+  - type: requestor
+    name: "Positive game state: update prepared turn draft"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draft
+        method: PUT
+        headers:
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "boardSets": [],
+            "rackTiles": [
+              {
+                "tileId": "scan-host-rack-red-5",
+                "color": "RED",
+                "number": 5,
+                "isJoker": false
+              },
+              {
+                "tileId": "scan-host-rack-blue-7",
+                "color": "BLUE",
+                "number": 7,
+                "isJoker": false
+              }
+            ]
+          }
+        responseCode: 200
+
+  - type: requestor
+    name: "Positive game state: draw from prepared scan game"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
+        method: POST
+        headers:
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
+        responseCode: 200
+
+  - type: requestor
+    name: "Positive game state: end turn for prepared scan game"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/end-turn
+        method: POST
+        headers:
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "boardSets": [],
+            "rackTiles": [
+              {
+                "tileId": "scan-host-rack-red-5",
+                "color": "RED",
+                "number": 5,
+                "isJoker": false
+              },
+              {
+                "tileId": "scan-host-rack-blue-7",
+                "color": "BLUE",
+                "number": 7,
+                "isJoker": false
+              },
+              {
+                "tileId": "scan-draw-red-1",
+                "color": "RED",
+                "number": 1,
+                "isJoker": false
+              }
+            ]
+          }
+        responseCode: 200
+
+  - type: requestor
+    name: "Negative path: missing game endpoints"
     requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
         responseCode: 404
-
-  - type: requestor
-    name: Exercise turn draft update endpoint with missing fixture id
-    requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
           - "Content-Type:application/json"
         data: |
           {
@@ -211,23 +285,15 @@ jobs:
             ]
           }
         responseCode: 404
-
-  - type: requestor
-    name: Exercise draw endpoint with missing fixture id
-    requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
         method: POST
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
         responseCode: 404
-
-  - type: requestor
-    name: Exercise end turn endpoint with missing fixture id
-    requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
         method: POST
         headers:
-          - "X-User-Id:scan-host-user"
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
           - "Content-Type:application/json"
         data: |
           {

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -12,6 +12,13 @@ env:
     progressToStdout: true
 
 jobs:
+  - type: openapi
+    name: Import generated OpenAPI contract
+    parameters:
+      apiUrl: https://se2-group-codebase.onrender.com/v3/api-docs
+      targetUrl: https://se2-group-codebase.onrender.com
+      context: se2-backend
+
   - type: requestor
     name: Request root endpoint
     requests:

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
@@ -1,0 +1,51 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.service.SecurityScanFixtureService
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Hidden
+@RestController
+@RequestMapping("/internal/security")
+@ConditionalOnProperty(
+    prefix = "app.scan-fixture",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false
+)
+class SecurityScanFixtureController(
+    private val securityScanFixtureService: SecurityScanFixtureService,
+    @Value("\${app.scan-fixture.secret:}") private val expectedSecret: String
+) {
+
+    @PostMapping("/scan-fixture")
+    fun createScanFixture(
+        @RequestHeader("X-Scan-Secret", required = false) providedSecret: String?
+    ): SecurityScanFixtureResponse {
+        if (providedSecret.isNullOrBlank() || expectedSecret.isBlank() || providedSecret != expectedSecret) {
+            throw SecurityException("Invalid scan fixture secret")
+        }
+
+        val state = securityScanFixtureService.recreateFixture()
+        return SecurityScanFixtureResponse(
+            lobbyId = state.lobbyId,
+            hostUserId = state.hostUserId,
+            guestUserId = state.guestUserId,
+            gameId = state.gameId,
+            draftOwnerUserId = state.draftOwnerUserId
+        )
+    }
+}
+
+data class SecurityScanFixtureResponse(
+    val lobbyId: String,
+    val hostUserId: String,
+    val guestUserId: String,
+    val gameId: String,
+    val draftOwnerUserId: String
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
@@ -1,0 +1,232 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.mapper.toEntity
+import at.se2group.backend.mapper.toEmbeddable
+import at.se2group.backend.mapper.toEntity as toLobbyEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftRepository
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+import shared.models.game.domain.TurnDraft
+import shared.models.lobby.domain.Lobby
+import shared.models.lobby.domain.LobbyPlayer
+import shared.models.lobby.domain.LobbySettings
+import shared.models.lobby.domain.LobbyStatus
+import java.time.Instant
+
+/**
+ * Seeds a small deterministic backend state used by the security scan workflows.
+ *
+ * The ZAP Automation Framework can import the API contract from `/v3/api-docs`,
+ * but a few stateful endpoints still need real identifiers and valid existing
+ * backend state to produce meaningful traffic. This bootstrap creates that
+ * narrow scan-safe fixture so the AF plan can exercise representative lobby and
+ * game flows without depending on ad hoc manual data.
+ *
+ * The fixture is intentionally small:
+ *
+ * - one open lobby for valid lobby reads and idempotent ready/settings flows
+ * - one active game with a current draft for valid game reads and draft updates
+ *
+ * The data is recreated idempotently on startup using fixed identifiers. Tests
+ * disable this component through `app.scan-fixtures.enabled=false` so the
+ * fixture does not pollute unrelated backend test scenarios.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "app.scan-fixtures",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+class SecurityScanFixtureBootstrap(
+    private val lobbyRepository: LobbyRepository,
+    private val gameRepository: GameRepository,
+    private val turnDraftRepository: TurnDraftRepository
+) : CommandLineRunner {
+
+    override fun run(vararg args: String?) {
+        seedFixtures()
+    }
+
+    @Transactional
+    fun seedFixtures() {
+        deleteIfPresent()
+        seedOpenLobby()
+        seedActiveGame()
+    }
+
+    private fun deleteIfPresent() {
+        if (turnDraftRepository.existsById(SCAN_GAME_ID)) {
+            turnDraftRepository.deleteById(SCAN_GAME_ID)
+        }
+        if (gameRepository.existsById(SCAN_GAME_ID)) {
+            gameRepository.deleteById(SCAN_GAME_ID)
+        }
+        if (lobbyRepository.existsById(SCAN_ACTIVE_LOBBY_ID)) {
+            lobbyRepository.deleteById(SCAN_ACTIVE_LOBBY_ID)
+        }
+        if (lobbyRepository.existsById(SCAN_OPEN_LOBBY_ID)) {
+            lobbyRepository.deleteById(SCAN_OPEN_LOBBY_ID)
+        }
+    }
+
+    private fun seedOpenLobby() {
+        val openLobby = Lobby(
+            lobbyId = SCAN_OPEN_LOBBY_ID,
+            hostUserId = SCAN_HOST_USER_ID,
+            players = listOf(
+                LobbyPlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    isReady = false
+                ),
+                LobbyPlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    isReady = false
+                )
+            ),
+            status = LobbyStatus.OPEN,
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            )
+        )
+
+        lobbyRepository.save(openLobby.toLobbyEntity())
+    }
+
+    private fun seedActiveGame() {
+        val activeLobby = Lobby(
+            lobbyId = SCAN_ACTIVE_LOBBY_ID,
+            hostUserId = SCAN_HOST_USER_ID,
+            players = listOf(
+                LobbyPlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    isReady = true
+                ),
+                LobbyPlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    isReady = true
+                )
+            ),
+            status = LobbyStatus.IN_GAME,
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            )
+        )
+
+        lobbyRepository.save(activeLobby.toLobbyEntity())
+
+        val hostRack = listOf(
+            NumberedTile(
+                tileId = "scan-host-rack-red-5",
+                color = TileColor.RED,
+                number = 5
+            ),
+            NumberedTile(
+                tileId = "scan-host-rack-blue-7",
+                color = TileColor.BLUE,
+                number = 7
+            )
+        )
+
+        val guestRack = listOf(
+            NumberedTile(
+                tileId = "scan-guest-rack-black-3",
+                color = TileColor.BLACK,
+                number = 3
+            ),
+            NumberedTile(
+                tileId = "scan-guest-rack-orange-9",
+                color = TileColor.ORANGE,
+                number = 9
+            )
+        )
+
+        val confirmedGame = ConfirmedGame(
+            gameId = SCAN_GAME_ID,
+            lobbyId = SCAN_ACTIVE_LOBBY_ID,
+            players = listOf(
+                GamePlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    turnOrder = 0,
+                    rackTiles = hostRack
+                ),
+                GamePlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    turnOrder = 1,
+                    rackTiles = guestRack
+                )
+            ),
+            boardSets = emptyList(),
+            drawPile = listOf(
+                NumberedTile(
+                    tileId = "scan-draw-red-1",
+                    color = TileColor.RED,
+                    number = 1
+                ),
+                NumberedTile(
+                    tileId = "scan-draw-blue-2",
+                    color = TileColor.BLUE,
+                    number = 2
+                ),
+                NumberedTile(
+                    tileId = "scan-draw-black-4",
+                    color = TileColor.BLACK,
+                    number = 4
+                )
+            ),
+            currentPlayerUserId = SCAN_HOST_USER_ID,
+            status = GameStatus.ACTIVE,
+            createdAt = FIXTURE_TIME,
+            startedAt = FIXTURE_TIME
+        )
+
+        gameRepository.save(confirmedGame.toEntity())
+
+        val draft = TurnDraft(
+            gameId = SCAN_GAME_ID,
+            playerUserId = SCAN_HOST_USER_ID,
+            boardSets = emptyList(),
+            rackTiles = hostRack,
+            version = 0
+        )
+
+        turnDraftRepository.save(
+            TurnDraftEntity(
+                gameId = draft.gameId,
+                playerUserId = draft.playerUserId,
+                version = draft.version,
+                boardSets = mutableListOf(),
+                rackTiles = draft.rackTiles.map { it.toEmbeddable() }.toMutableList()
+            )
+        )
+    }
+
+    companion object {
+        const val SCAN_OPEN_LOBBY_ID = "scan-open-lobby"
+        const val SCAN_ACTIVE_LOBBY_ID = "scan-active-lobby"
+        const val SCAN_GAME_ID = "scan-game-1"
+        const val SCAN_HOST_USER_ID = "scan-host-user"
+        const val SCAN_GUEST_USER_ID = "scan-guest-user"
+        val FIXTURE_TIME: Instant = Instant.parse("2026-01-01T00:00:00Z")
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
@@ -1,27 +1,8 @@
 package at.se2group.backend.service
 
-import at.se2group.backend.mapper.toEntity
-import at.se2group.backend.mapper.toEmbeddable
-import at.se2group.backend.mapper.toEntity as toLobbyEntity
-import at.se2group.backend.persistence.GameRepository
-import at.se2group.backend.persistence.LobbyRepository
-import at.se2group.backend.persistence.TurnDraftEntity
-import at.se2group.backend.persistence.TurnDraftRepository
 import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
-import shared.models.game.domain.ConfirmedGame
-import shared.models.game.domain.GamePlayer
-import shared.models.game.domain.GameStatus
-import shared.models.game.domain.NumberedTile
-import shared.models.game.domain.TileColor
-import shared.models.game.domain.TurnDraft
-import shared.models.lobby.domain.Lobby
-import shared.models.lobby.domain.LobbyPlayer
-import shared.models.lobby.domain.LobbySettings
-import shared.models.lobby.domain.LobbyStatus
-import java.time.Instant
 
 /**
  * Seeds a small deterministic backend state used by the security scan workflows.
@@ -38,195 +19,21 @@ import java.time.Instant
  * - one active game with a current draft for valid game reads and draft updates
  *
  * The data is recreated idempotently on startup using fixed identifiers. Tests
- * disable this component through `app.scan-fixtures.enabled=false` so the
+ * disable this component through `app.scan-fixture.enabled=false` so the
  * fixture does not pollute unrelated backend test scenarios.
  */
 @Component
 @ConditionalOnProperty(
-    prefix = "app.scan-fixtures",
+    prefix = "app.scan-fixture",
     name = ["enabled"],
     havingValue = "true",
-    matchIfMissing = true
+    matchIfMissing = false
 )
 class SecurityScanFixtureBootstrap(
-    private val lobbyRepository: LobbyRepository,
-    private val gameRepository: GameRepository,
-    private val turnDraftRepository: TurnDraftRepository
+    private val securityScanFixtureService: SecurityScanFixtureService
 ) : CommandLineRunner {
 
     override fun run(vararg args: String?) {
-        seedFixtures()
-    }
-
-    @Transactional
-    fun seedFixtures() {
-        deleteIfPresent()
-        seedOpenLobby()
-        seedActiveGame()
-    }
-
-    private fun deleteIfPresent() {
-        if (turnDraftRepository.existsById(SCAN_GAME_ID)) {
-            turnDraftRepository.deleteById(SCAN_GAME_ID)
-        }
-        if (gameRepository.existsById(SCAN_GAME_ID)) {
-            gameRepository.deleteById(SCAN_GAME_ID)
-        }
-        if (lobbyRepository.existsById(SCAN_ACTIVE_LOBBY_ID)) {
-            lobbyRepository.deleteById(SCAN_ACTIVE_LOBBY_ID)
-        }
-        if (lobbyRepository.existsById(SCAN_OPEN_LOBBY_ID)) {
-            lobbyRepository.deleteById(SCAN_OPEN_LOBBY_ID)
-        }
-    }
-
-    private fun seedOpenLobby() {
-        val openLobby = Lobby(
-            lobbyId = SCAN_OPEN_LOBBY_ID,
-            hostUserId = SCAN_HOST_USER_ID,
-            players = listOf(
-                LobbyPlayer(
-                    userId = SCAN_HOST_USER_ID,
-                    displayName = "Scan Host",
-                    isReady = false
-                ),
-                LobbyPlayer(
-                    userId = SCAN_GUEST_USER_ID,
-                    displayName = "Scan Guest",
-                    isReady = false
-                )
-            ),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
-            )
-        )
-
-        lobbyRepository.save(openLobby.toLobbyEntity())
-    }
-
-    private fun seedActiveGame() {
-        val activeLobby = Lobby(
-            lobbyId = SCAN_ACTIVE_LOBBY_ID,
-            hostUserId = SCAN_HOST_USER_ID,
-            players = listOf(
-                LobbyPlayer(
-                    userId = SCAN_HOST_USER_ID,
-                    displayName = "Scan Host",
-                    isReady = true
-                ),
-                LobbyPlayer(
-                    userId = SCAN_GUEST_USER_ID,
-                    displayName = "Scan Guest",
-                    isReady = true
-                )
-            ),
-            status = LobbyStatus.IN_GAME,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
-            )
-        )
-
-        lobbyRepository.save(activeLobby.toLobbyEntity())
-
-        val hostRack = listOf(
-            NumberedTile(
-                tileId = "scan-host-rack-red-5",
-                color = TileColor.RED,
-                number = 5
-            ),
-            NumberedTile(
-                tileId = "scan-host-rack-blue-7",
-                color = TileColor.BLUE,
-                number = 7
-            )
-        )
-
-        val guestRack = listOf(
-            NumberedTile(
-                tileId = "scan-guest-rack-black-3",
-                color = TileColor.BLACK,
-                number = 3
-            ),
-            NumberedTile(
-                tileId = "scan-guest-rack-orange-9",
-                color = TileColor.ORANGE,
-                number = 9
-            )
-        )
-
-        val confirmedGame = ConfirmedGame(
-            gameId = SCAN_GAME_ID,
-            lobbyId = SCAN_ACTIVE_LOBBY_ID,
-            players = listOf(
-                GamePlayer(
-                    userId = SCAN_HOST_USER_ID,
-                    displayName = "Scan Host",
-                    turnOrder = 0,
-                    rackTiles = hostRack
-                ),
-                GamePlayer(
-                    userId = SCAN_GUEST_USER_ID,
-                    displayName = "Scan Guest",
-                    turnOrder = 1,
-                    rackTiles = guestRack
-                )
-            ),
-            boardSets = emptyList(),
-            drawPile = listOf(
-                NumberedTile(
-                    tileId = "scan-draw-red-1",
-                    color = TileColor.RED,
-                    number = 1
-                ),
-                NumberedTile(
-                    tileId = "scan-draw-blue-2",
-                    color = TileColor.BLUE,
-                    number = 2
-                ),
-                NumberedTile(
-                    tileId = "scan-draw-black-4",
-                    color = TileColor.BLACK,
-                    number = 4
-                )
-            ),
-            currentPlayerUserId = SCAN_HOST_USER_ID,
-            status = GameStatus.ACTIVE,
-            createdAt = FIXTURE_TIME,
-            startedAt = FIXTURE_TIME
-        )
-
-        gameRepository.save(confirmedGame.toEntity())
-
-        val draft = TurnDraft(
-            gameId = SCAN_GAME_ID,
-            playerUserId = SCAN_HOST_USER_ID,
-            boardSets = emptyList(),
-            rackTiles = hostRack,
-            version = 0
-        )
-
-        turnDraftRepository.save(
-            TurnDraftEntity(
-                gameId = draft.gameId,
-                playerUserId = draft.playerUserId,
-                version = draft.version,
-                boardSets = mutableListOf(),
-                rackTiles = draft.rackTiles.map { it.toEmbeddable() }.toMutableList()
-            )
-        )
-    }
-
-    companion object {
-        const val SCAN_OPEN_LOBBY_ID = "scan-open-lobby"
-        const val SCAN_ACTIVE_LOBBY_ID = "scan-active-lobby"
-        const val SCAN_GAME_ID = "scan-game-1"
-        const val SCAN_HOST_USER_ID = "scan-host-user"
-        const val SCAN_GUEST_USER_ID = "scan-guest-user"
-        val FIXTURE_TIME: Instant = Instant.parse("2026-01-01T00:00:00Z")
+        securityScanFixtureService.recreateFixture()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt
@@ -1,0 +1,226 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.mapper.toEmbeddable
+import at.se2group.backend.mapper.toEntity
+import at.se2group.backend.mapper.toEntity as toLobbyEntity
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.persistence.TurnDraftEntity
+import at.se2group.backend.persistence.TurnDraftRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+import shared.models.game.domain.TurnDraft
+import shared.models.lobby.domain.Lobby
+import shared.models.lobby.domain.LobbyPlayer
+import shared.models.lobby.domain.LobbySettings
+import shared.models.lobby.domain.LobbyStatus
+import java.time.Instant
+
+@Service
+class SecurityScanFixtureService(
+    private val lobbyRepository: LobbyRepository,
+    private val gameRepository: GameRepository,
+    private val turnDraftRepository: TurnDraftRepository
+) {
+
+    @Transactional
+    fun recreateFixture(): SecurityScanFixtureState {
+        deleteIfPresent()
+        seedOpenLobby()
+        seedActiveGame()
+
+        return SecurityScanFixtureState(
+            lobbyId = SCAN_OPEN_LOBBY_ID,
+            hostUserId = SCAN_HOST_USER_ID,
+            guestUserId = SCAN_GUEST_USER_ID,
+            gameId = SCAN_GAME_ID,
+            draftOwnerUserId = SCAN_HOST_USER_ID
+        )
+    }
+
+    private fun deleteIfPresent() {
+        if (turnDraftRepository.existsById(SCAN_GAME_ID)) {
+            turnDraftRepository.deleteById(SCAN_GAME_ID)
+        }
+        if (gameRepository.existsById(SCAN_GAME_ID)) {
+            gameRepository.deleteById(SCAN_GAME_ID)
+        }
+        if (lobbyRepository.existsById(SCAN_ACTIVE_LOBBY_ID)) {
+            lobbyRepository.deleteById(SCAN_ACTIVE_LOBBY_ID)
+        }
+        if (lobbyRepository.existsById(SCAN_OPEN_LOBBY_ID)) {
+            lobbyRepository.deleteById(SCAN_OPEN_LOBBY_ID)
+        }
+    }
+
+    private fun seedOpenLobby() {
+        val openLobby = Lobby(
+            lobbyId = SCAN_OPEN_LOBBY_ID,
+            hostUserId = SCAN_HOST_USER_ID,
+            players = listOf(
+                LobbyPlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    isReady = false
+                ),
+                LobbyPlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    isReady = false
+                )
+            ),
+            status = LobbyStatus.OPEN,
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            )
+        )
+
+        lobbyRepository.save(openLobby.toLobbyEntity())
+    }
+
+    private fun seedActiveGame() {
+        val activeLobby = Lobby(
+            lobbyId = SCAN_ACTIVE_LOBBY_ID,
+            hostUserId = SCAN_HOST_USER_ID,
+            players = listOf(
+                LobbyPlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    isReady = true
+                ),
+                LobbyPlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    isReady = true
+                )
+            ),
+            status = LobbyStatus.IN_GAME,
+            settings = LobbySettings(
+                maxPlayers = 4,
+                isPrivate = false,
+                allowGuests = true
+            )
+        )
+
+        lobbyRepository.save(activeLobby.toLobbyEntity())
+
+        val hostRack = preDrawRack()
+        val guestRack = listOf(
+            NumberedTile(
+                tileId = "scan-guest-rack-black-3",
+                color = TileColor.BLACK,
+                number = 3
+            ),
+            NumberedTile(
+                tileId = "scan-guest-rack-orange-9",
+                color = TileColor.ORANGE,
+                number = 9
+            )
+        )
+
+        val confirmedGame = ConfirmedGame(
+            gameId = SCAN_GAME_ID,
+            lobbyId = SCAN_ACTIVE_LOBBY_ID,
+            players = listOf(
+                GamePlayer(
+                    userId = SCAN_HOST_USER_ID,
+                    displayName = "Scan Host",
+                    turnOrder = 0,
+                    rackTiles = hostRack
+                ),
+                GamePlayer(
+                    userId = SCAN_GUEST_USER_ID,
+                    displayName = "Scan Guest",
+                    turnOrder = 1,
+                    rackTiles = guestRack
+                )
+            ),
+            boardSets = emptyList(),
+            drawPile = listOf(
+                NumberedTile(
+                    tileId = SCAN_DRAWN_TILE_ID,
+                    color = TileColor.RED,
+                    number = 1
+                ),
+                NumberedTile(
+                    tileId = "scan-draw-blue-2",
+                    color = TileColor.BLUE,
+                    number = 2
+                ),
+                NumberedTile(
+                    tileId = "scan-draw-black-4",
+                    color = TileColor.BLACK,
+                    number = 4
+                )
+            ),
+            currentPlayerUserId = SCAN_HOST_USER_ID,
+            status = GameStatus.ACTIVE,
+            createdAt = FIXTURE_TIME,
+            startedAt = FIXTURE_TIME
+        )
+
+        gameRepository.save(confirmedGame.toEntity())
+
+        val draft = TurnDraft(
+            gameId = SCAN_GAME_ID,
+            playerUserId = SCAN_HOST_USER_ID,
+            boardSets = emptyList(),
+            rackTiles = hostRack,
+            version = 0
+        )
+
+        turnDraftRepository.save(
+            TurnDraftEntity(
+                gameId = draft.gameId,
+                playerUserId = draft.playerUserId,
+                version = draft.version,
+                boardSets = mutableListOf(),
+                rackTiles = draft.rackTiles.map { it.toEmbeddable() }.toMutableList()
+            )
+        )
+    }
+
+    data class SecurityScanFixtureState(
+        val lobbyId: String,
+        val hostUserId: String,
+        val guestUserId: String,
+        val gameId: String,
+        val draftOwnerUserId: String
+    )
+
+    companion object {
+        const val SCAN_OPEN_LOBBY_ID = "scan-open-lobby"
+        const val SCAN_ACTIVE_LOBBY_ID = "scan-active-lobby"
+        const val SCAN_GAME_ID = "scan-game-1"
+        const val SCAN_HOST_USER_ID = "scan-host-user"
+        const val SCAN_GUEST_USER_ID = "scan-guest-user"
+        const val SCAN_DRAWN_TILE_ID = "scan-draw-red-1"
+        val FIXTURE_TIME: Instant = Instant.parse("2026-01-01T00:00:00Z")
+
+        fun preDrawRack() = listOf(
+            NumberedTile(
+                tileId = "scan-host-rack-red-5",
+                color = TileColor.RED,
+                number = 5
+            ),
+            NumberedTile(
+                tileId = "scan-host-rack-blue-7",
+                color = TileColor.BLUE,
+                number = 7
+            )
+        )
+
+        fun postDrawRack() = preDrawRack() + NumberedTile(
+            tileId = SCAN_DRAWN_TILE_ID,
+            color = TileColor.RED,
+            number = 1
+        )
+    }
+}

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -4,3 +4,8 @@ spring:
 
 server:
   port: 8080
+
+app:
+  scan-fixture:
+    enabled: ${APP_SCAN_FIXTURE_ENABLED:false}
+    secret: ${APP_SCAN_FIXTURE_SECRET:}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
@@ -40,6 +40,11 @@ class OpenApiDocsTest {
                 jsonPath("$.openapi") { exists() }
                 jsonPath("$.info") { exists() }
                 jsonPath("$.paths") { exists() }
+                jsonPath("$['paths']['/api/games/{gameId}/draft']") { exists() }
+                jsonPath("$['paths']['/api/games/{gameId}/draw']") { exists() }
+                jsonPath("$['paths']['/api/games/{gameId}/end-turn']") { exists() }
+                jsonPath("$['paths']['/api/lobbies']") { exists() }
+                jsonPath("$['paths']['/api/lobbies/{lobbyId}/join']") { exists() }
                 header { string("Content-Type", org.hamcrest.Matchers.containsString("application/json")) }
                 header { string("X-Content-Type-Options", "nosniff") }
                 header { string("Cross-Origin-Resource-Policy", "same-origin") }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
@@ -40,11 +40,15 @@ class OpenApiDocsTest {
                 jsonPath("$.openapi") { exists() }
                 jsonPath("$.info") { exists() }
                 jsonPath("$.paths") { exists() }
+                jsonPath("$['paths']['/api/games/{gameId}']") { exists() }
                 jsonPath("$['paths']['/api/games/{gameId}/draft']") { exists() }
                 jsonPath("$['paths']['/api/games/{gameId}/draw']") { exists() }
                 jsonPath("$['paths']['/api/games/{gameId}/end-turn']") { exists() }
                 jsonPath("$['paths']['/api/lobbies']") { exists() }
+                jsonPath("$['paths']['/api/lobbies/{lobbyId}']") { exists() }
+                jsonPath("$['paths']['/api/lobbies/{lobbyId}/settings']") { exists() }
                 jsonPath("$['paths']['/api/lobbies/{lobbyId}/join']") { exists() }
+                jsonPath("$['paths']['/internal/security/scan-fixture']") { doesNotExist() }
                 header { string("Content-Type", org.hamcrest.Matchers.containsString("application/json")) }
                 header { string("X-Content-Type-Options", "nosniff") }
                 header { string("Cross-Origin-Resource-Policy", "same-origin") }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureBootstrapTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureBootstrapTest.kt
@@ -1,14 +1,17 @@
 package at.se2group.backend.api
 
-import at.se2group.backend.service.SecurityScanFixtureBootstrap
 import at.se2group.backend.persistence.GameRepository
 import at.se2group.backend.persistence.LobbyRepository
 import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.service.SecurityScanFixtureService
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.GameStatus
+import shared.models.lobby.domain.LobbyStatus
 
 /**
  * Integration coverage for the startup security-scan fixtures.
@@ -18,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional
  * bootstrap explicitly and verifies that the known lobby, game, and draft ids
  * are present after the application context starts.
  */
-@SpringBootTest(properties = ["app.scan-fixtures.enabled=true"])
+@SpringBootTest(properties = ["app.scan-fixture.enabled=true", "app.scan-fixture.secret=test-secret"])
 @Transactional
 class SecurityScanFixtureBootstrapTest {
 
@@ -33,14 +36,23 @@ class SecurityScanFixtureBootstrapTest {
 
     @Test
     fun `security scan fixtures are seeded deterministically`() {
-        val openLobby = lobbyRepository.findById(SecurityScanFixtureBootstrap.SCAN_OPEN_LOBBY_ID).orElse(null)
-        val activeLobby = lobbyRepository.findById(SecurityScanFixtureBootstrap.SCAN_ACTIVE_LOBBY_ID).orElse(null)
-        val game = gameRepository.findById(SecurityScanFixtureBootstrap.SCAN_GAME_ID).orElse(null)
-        val draft = turnDraftRepository.findByGameId(SecurityScanFixtureBootstrap.SCAN_GAME_ID)
+        val openLobby = lobbyRepository.findById(SecurityScanFixtureService.SCAN_OPEN_LOBBY_ID).orElse(null)
+        val activeLobby = lobbyRepository.findById(SecurityScanFixtureService.SCAN_ACTIVE_LOBBY_ID).orElse(null)
+        val game = gameRepository.findById(SecurityScanFixtureService.SCAN_GAME_ID).orElse(null)
+        val draft = turnDraftRepository.findByGameId(SecurityScanFixtureService.SCAN_GAME_ID)
 
         assertNotNull(openLobby)
         assertNotNull(activeLobby)
         assertNotNull(game)
         assertNotNull(draft)
+        assertEquals(SecurityScanFixtureService.SCAN_HOST_USER_ID, openLobby?.hostUserId)
+        assertEquals(LobbyStatus.OPEN, openLobby?.status)
+        assertEquals(SecurityScanFixtureService.SCAN_HOST_USER_ID, activeLobby?.hostUserId)
+        assertEquals(LobbyStatus.IN_GAME, activeLobby?.status)
+        assertEquals(SecurityScanFixtureService.SCAN_ACTIVE_LOBBY_ID, game?.lobbyId)
+        assertEquals(SecurityScanFixtureService.SCAN_HOST_USER_ID, game?.currentPlayerUserId)
+        assertEquals(GameStatus.ACTIVE, game?.status)
+        assertEquals(SecurityScanFixtureService.SCAN_HOST_USER_ID, draft?.playerUserId)
+        assertEquals(0L, draft?.version)
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureBootstrapTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureBootstrapTest.kt
@@ -1,0 +1,46 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.service.SecurityScanFixtureBootstrap
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.persistence.TurnDraftRepository
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Integration coverage for the startup security-scan fixtures.
+ *
+ * The ZAP API coverage workflow depends on a small deterministic backend state
+ * for a handful of valid Layer 3 requests. This test enables the fixture
+ * bootstrap explicitly and verifies that the known lobby, game, and draft ids
+ * are present after the application context starts.
+ */
+@SpringBootTest(properties = ["app.scan-fixtures.enabled=true"])
+@Transactional
+class SecurityScanFixtureBootstrapTest {
+
+    @Autowired
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Autowired
+    lateinit var gameRepository: GameRepository
+
+    @Autowired
+    lateinit var turnDraftRepository: TurnDraftRepository
+
+    @Test
+    fun `security scan fixtures are seeded deterministically`() {
+        val openLobby = lobbyRepository.findById(SecurityScanFixtureBootstrap.SCAN_OPEN_LOBBY_ID).orElse(null)
+        val activeLobby = lobbyRepository.findById(SecurityScanFixtureBootstrap.SCAN_ACTIVE_LOBBY_ID).orElse(null)
+        val game = gameRepository.findById(SecurityScanFixtureBootstrap.SCAN_GAME_ID).orElse(null)
+        val draft = turnDraftRepository.findByGameId(SecurityScanFixtureBootstrap.SCAN_GAME_ID)
+
+        assertNotNull(openLobby)
+        assertNotNull(activeLobby)
+        assertNotNull(game)
+        assertNotNull(draft)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
@@ -1,0 +1,80 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.service.SecurityScanFixtureService
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "app.scan-fixture.enabled=true",
+        "app.scan-fixture.secret=test-scan-secret"
+    ]
+)
+@AutoConfigureMockMvc
+@Transactional
+class SecurityScanFixtureControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Autowired
+    lateinit var gameRepository: GameRepository
+
+    @Autowired
+    lateinit var turnDraftRepository: TurnDraftRepository
+
+    @Test
+    fun `returns 403 when scan secret header is missing`() {
+        mockMvc.post("/internal/security/scan-fixture")
+            .andExpect {
+                status { isForbidden() }
+                jsonPath("$.errorCode") { value("FORBIDDEN") }
+                jsonPath("$.errorMessage") { value("Invalid scan fixture secret") }
+            }
+    }
+
+    @Test
+    fun `returns 403 when scan secret header is wrong`() {
+        mockMvc.post("/internal/security/scan-fixture") {
+            header("X-Scan-Secret", "wrong-secret")
+        }
+            .andExpect {
+                status { isForbidden() }
+                jsonPath("$.errorCode") { value("FORBIDDEN") }
+                jsonPath("$.errorMessage") { value("Invalid scan fixture secret") }
+            }
+    }
+
+    @Test
+    fun `returns fixture ids when scan secret is valid`() {
+        mockMvc.post("/internal/security/scan-fixture") {
+            header("X-Scan-Secret", "test-scan-secret")
+        }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.lobbyId") { value(SecurityScanFixtureService.SCAN_OPEN_LOBBY_ID) }
+                jsonPath("$.hostUserId") { value(SecurityScanFixtureService.SCAN_HOST_USER_ID) }
+                jsonPath("$.guestUserId") { value(SecurityScanFixtureService.SCAN_GUEST_USER_ID) }
+                jsonPath("$.gameId") { value(SecurityScanFixtureService.SCAN_GAME_ID) }
+                jsonPath("$.draftOwnerUserId") { value(SecurityScanFixtureService.SCAN_HOST_USER_ID) }
+            }
+
+        assertTrue(lobbyRepository.findById(SecurityScanFixtureService.SCAN_OPEN_LOBBY_ID).isPresent)
+        assertTrue(lobbyRepository.findById(SecurityScanFixtureService.SCAN_ACTIVE_LOBBY_ID).isPresent)
+        assertTrue(gameRepository.findById(SecurityScanFixtureService.SCAN_GAME_ID).isPresent)
+        assertTrue(turnDraftRepository.findById(SecurityScanFixtureService.SCAN_GAME_ID).isPresent)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureServiceTest.kt
@@ -1,0 +1,113 @@
+package at.se2group.backend.api
+
+import at.se2group.backend.persistence.GameRepository
+import at.se2group.backend.persistence.LobbyRepository
+import at.se2group.backend.persistence.TurnDraftRepository
+import at.se2group.backend.service.DrawTileService
+import at.se2group.backend.service.EndTurnService
+import at.se2group.backend.service.GameService
+import at.se2group.backend.service.SecurityScanFixtureService
+import at.se2group.backend.service.TurnDraftService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import shared.models.game.domain.NumberedTile
+import shared.models.game.request.EndTurnRequest
+import shared.models.game.request.TileRequest
+import shared.models.game.request.UpdateDraftRequest
+
+@SpringBootTest(properties = ["app.scan-fixture.enabled=false"])
+@Transactional
+class SecurityScanFixtureServiceTest {
+
+    @Autowired
+    lateinit var securityScanFixtureService: SecurityScanFixtureService
+
+    @Autowired
+    lateinit var lobbyRepository: LobbyRepository
+
+    @Autowired
+    lateinit var gameRepository: GameRepository
+
+    @Autowired
+    lateinit var turnDraftRepository: TurnDraftRepository
+
+    @Autowired
+    lateinit var gameService: GameService
+
+    @Autowired
+    lateinit var turnDraftService: TurnDraftService
+
+    @Autowired
+    lateinit var drawTileService: DrawTileService
+
+    @Autowired
+    lateinit var endTurnService: EndTurnService
+
+    @Test
+    fun `recreates deterministic fixture state idempotently`() {
+        val first = securityScanFixtureService.recreateFixture()
+        val second = securityScanFixtureService.recreateFixture()
+
+        assertEquals(first, second)
+        assertTrue(lobbyRepository.findById(first.lobbyId).isPresent)
+        assertTrue(lobbyRepository.findById(SecurityScanFixtureService.SCAN_ACTIVE_LOBBY_ID).isPresent)
+        assertTrue(gameRepository.findById(first.gameId).isPresent)
+        assertTrue(turnDraftRepository.findById(first.gameId).isPresent)
+    }
+
+    @Test
+    fun `fixture supports positive game get draft draw and end turn flow`() {
+        val fixture = securityScanFixtureService.recreateFixture()
+
+        val game = gameService.getGame(fixture.gameId)
+        assertEquals(fixture.gameId, game.gameId)
+        assertEquals(fixture.hostUserId, game.currentPlayerUserId)
+
+        val updatedDraft = turnDraftService.updateDraft(
+            fixture.gameId,
+            fixture.draftOwnerUserId,
+            UpdateDraftRequest(
+                boardSets = emptyList(),
+                rackTiles = SecurityScanFixtureService.preDrawRack().map { it.toRequest() }
+            )
+        )
+        assertEquals(fixture.draftOwnerUserId, updatedDraft.playerUserId)
+        assertEquals(
+            SecurityScanFixtureService.preDrawRack().map { it.tileId },
+            updatedDraft.rackTiles.map { it.tileId }
+        )
+
+        val drawnGame = drawTileService.drawTile(fixture.gameId, fixture.hostUserId)
+        val hostAfterDraw = drawnGame.players.first { it.userId == fixture.hostUserId }
+        assertEquals(
+            SecurityScanFixtureService.postDrawRack().map { it.tileId },
+            hostAfterDraw.rackTiles.map { it.tileId }
+        )
+
+        val endedTurnGame = endTurnService.endTurn(
+            fixture.gameId,
+            fixture.hostUserId,
+            EndTurnRequest(
+                boardSets = emptyList(),
+                rackTiles = SecurityScanFixtureService.postDrawRack().map { it.toRequest() }
+            )
+        )
+        assertEquals(fixture.guestUserId, endedTurnGame.currentPlayerUserId)
+
+        val nextDraft = turnDraftRepository.findByGameId(fixture.gameId)
+        assertNotNull(nextDraft)
+        assertEquals(fixture.guestUserId, nextDraft?.playerUserId)
+    }
+
+    private fun NumberedTile.toRequest() = TileRequest(
+        tileId = tileId,
+        color = color.name,
+        number = number,
+        isJoker = false
+    )
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceUpdateDraftTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceUpdateDraftTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import java.time.Instant
+import shared.models.game.domain.BoardSetType
+import shared.models.game.domain.TileColor
 import java.util.Optional
 import shared.models.game.validation.invalid
 import shared.models.game.validation.valid

--- a/apps/backend/src/test/resources/application.yml
+++ b/apps/backend/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+app:
+  scan-fixtures:
+    enabled: false

--- a/apps/backend/src/test/resources/application.yml
+++ b/apps/backend/src/test/resources/application.yml
@@ -1,3 +1,3 @@
 app:
-  scan-fixtures:
+  scan-fixture:
     enabled: false

--- a/docs/security.md
+++ b/docs/security.md
@@ -337,6 +337,198 @@ scan the whole backend API shape
 
 layer.
 
+#### Why the committed plan file matters
+
+The committed Automation Framework plan:
+
+```text
+.github/zap/backend-automation-plan.yaml
+```
+
+is the actual scan definition for the AF workflow.
+
+Unlike the baseline scan, which mostly takes a small set of inputs and then
+executes packaged behavior, the Automation Framework needs an explicit
+repository-owned plan that tells ZAP:
+
+- which context exists
+- which base URLs are in scope
+- which jobs run and in what order
+- which requests should be sent
+- which responses are expected
+- which report formats should be written
+- which exit policy should be used
+
+At the top of the file, the plan defines the scan context and scope:
+
+```yaml
+env:
+  contexts:
+    - name: se2-backend
+      urls:
+        - https://se2-group-codebase.onrender.com
+      includePaths:
+        - https://se2-group-codebase.onrender.com.*
+
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+```
+
+This block matters because it establishes three important operational rules:
+
+1. the scan is anchored to the deployed backend, not a local host
+2. only that backend is considered in scope
+3. warnings stay visible without making the first rollout overly brittle
+
+The plan then starts with the passive-scan configuration and OpenAPI import:
+
+```yaml
+jobs:
+  - type: passiveScan-config
+    name: Passive scan configuration
+    parameters:
+      maxAlertsPerRule: 10
+      scanOnlyInScope: true
+
+  - type: openapi
+    name: Import generated OpenAPI contract
+    parameters:
+      apiUrl: https://se2-group-codebase.onrender.com/v3/api-docs
+      targetUrl: https://se2-group-codebase.onrender.com
+      context: se2-backend
+```
+
+This pairing is deliberate.
+
+The `openapi` job teaches ZAP the backend API shape, but by itself that would
+still be too abstract for good scan reporting. The later `requestor` jobs are
+what turn the imported schema into real HTTP traffic that the passive scanner
+can inspect and that the generated reports can display.
+
+The public-surface requestors look like this:
+
+```yaml
+  - type: requestor
+    name: "Public endpoint: leaderboard"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/leaderboard
+        method: GET
+        responseCode: 200
+```
+
+These jobs are intentionally simple:
+
+- one job name describes the intent
+- each request declares the exact URL
+- the HTTP method is explicit
+- the expected status is explicit
+
+That makes the plan readable as both:
+
+- machine configuration
+- human review document
+
+#### How the plan is split conceptually
+
+The committed plan is easiest to understand if it is read in four slices.
+
+##### 1. Public endpoint slice
+
+These requestors exercise the public GET surface and root metadata:
+
+- `/`
+- `/robots.txt`
+- `/sitemap.xml`
+- `/actuator/health`
+- `/api/leaderboard`
+- `GET /api/lobbies`
+
+##### 2. Positive lobby-state slice
+
+These requestors use a real `lobbyId` injected by the workflow:
+
+```yaml
+  - type: requestor
+    name: "Positive lobby state: update prepared scan lobby settings"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
+        method: PATCH
+        headers:
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Content-Type:application/json"
+        data: |
+          {
+            "maxPlayers": 4,
+            "isPrivate": false,
+            "allowGuests": true
+          }
+        responseCode: 200
+```
+
+This is where the plan stops being a generic crawler configuration and becomes
+a deliberate API test harness. The placeholders are not valid by themselves;
+they are replaced in CI after the fixture endpoint returns real ids.
+
+##### 3. Positive game-state slice
+
+These requestors use a real `gameId` and the prepared host player:
+
+```yaml
+  - type: requestor
+    name: "Positive game state: draw from prepared scan game"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
+        method: POST
+        headers:
+          - "X-User-Id:__SCAN_HOST_USER_ID__"
+        responseCode: 200
+```
+
+The same pattern is used for:
+
+- `GET /api/games/{gameId}`
+- `PUT /api/games/{gameId}/draft`
+- `POST /api/games/{gameId}/draw`
+- `POST /api/games/{gameId}/end-turn`
+
+The important detail is that these are not fake examples. They are aligned to
+the deterministic fixture state created before the scan.
+
+##### 4. Negative-path slice
+
+The plan also keeps stable failure-path coverage:
+
+```yaml
+  - type: requestor
+    name: "Negative path: missing game endpoints"
+    requests:
+      - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
+        method: GET
+        responseCode: 404
+```
+
+This is useful for two reasons:
+
+- it keeps error-path regressions visible
+- it distinguishes "we exercised the happy path" from "we also verified
+  missing-id behavior"
+
+#### Why the plan stays committed to the repository
+
+Keeping the plan file committed instead of generating the whole thing in shell
+has several benefits:
+
+- the scan logic is code-reviewed like any other source file
+- changes to endpoint coverage are visible in diffs
+- the current intended scan surface is understandable without opening CI logs
+- the workflow only has to inject dynamic values, not rebuild the entire scan
+  structure from scratch
+
+That last point is important. The workflow should orchestrate execution. The
+plan file should define scanning behavior.
+
 ### Layer 3: Positive stateful flows
 
 Layer 3 uses the dedicated fixture endpoint to recreate deterministic state and
@@ -428,6 +620,189 @@ It surfaces:
 
 This artifact is more useful than the raw markdown report when the goal is to
 see exactly which endpoint inventory the AF run exercised.
+
+#### How the endpoint coverage script works
+
+The endpoint inventory artifact is generated by:
+
+```text
+.github/scripts/generate_zap_af_endpoint_coverage.rb
+```
+
+This script exists because the raw ZAP markdown report is not a good source of
+truth for endpoint inventory. It is good at summarizing alerts, but weaker at
+answering:
+
+- which exact requestors ran
+- which endpoint groups were exercised
+- which expected statuses were declared in the plan
+
+So the repository adds a small post-processing step that combines:
+
+1. the generated concrete AF plan
+2. the ZAP JSON report
+
+and writes a reviewer-friendly markdown artifact.
+
+#### Inputs and top-level structure
+
+The script starts by loading three runtime arguments:
+
+```ruby
+plan_path = ARGV.fetch(0)
+json_path = ARGV.fetch(1)
+output_path = ARGV.fetch(2)
+
+plan = YAML.load_file(plan_path)
+report = File.exist?(json_path) ? JSON.parse(File.read(json_path)) : {}
+```
+
+This is intentionally simple.
+
+- `plan_path` points to the generated plan with real substituted ids
+- `json_path` points to `zap-af-report.json`
+- `output_path` is the markdown artifact to write
+
+The script therefore operates on the **actual run configuration**, not the
+placeholder template plan.
+
+#### Request categorization logic
+
+The first important piece of logic is `request_category`:
+
+```ruby
+def request_category(job_name, request)
+  url = request.fetch("url")
+  expected = request["responseCode"]
+
+  return "Public Endpoints" if job_name.start_with?("Public endpoint:")
+  return "Positive Lobby-State Endpoints" if url.include?("/api/lobbies/") && [200, 204].include?(expected)
+  return "Positive Game-State Endpoints" if url.include?("/api/games/") && expected == 200
+
+  "Negative-Path Endpoints"
+end
+```
+
+This function is doing the conceptual flattening that ZAP itself does not do
+for you.
+
+Instead of dumping one long unsorted request list, it groups the scan into the
+same logical layers the rest of the documentation uses:
+
+- public endpoints
+- positive lobby-state endpoints
+- positive game-state endpoints
+- negative-path endpoints
+
+That is why the artifact reads like an implementation summary instead of a raw
+machine log.
+
+#### Path normalization and request extraction
+
+The script then normalizes request paths and extracts requestor jobs from the
+plan:
+
+```ruby
+def display_path(url)
+  url.sub(%r{\Ahttps://[^/]+}, "")
+end
+
+requests = plan.fetch("jobs", []).select { |job| job["type"] == "requestor" }.flat_map do |job|
+  (job["requests"] || []).map do |request|
+    {
+      job_name: job.fetch("name"),
+      method: request.fetch("method", "GET"),
+      url: request.fetch("url"),
+      expected_status: request["responseCode"],
+      category: request_category(job.fetch("name"), request)
+    }
+  end
+end
+```
+
+This block is the core bridge between the Automation Framework plan and the
+final human-readable artifact.
+
+It converts nested YAML job definitions into a flat inventory where each row
+knows:
+
+- which logical job it came from
+- which method it uses
+- which path it targets
+- which status it expects
+- which documentation category it belongs to
+
+#### Report metadata extraction
+
+The script also pulls useful metadata from the JSON report:
+
+```ruby
+site_name = report.fetch("site", []).first&.fetch("@name", nil) || ENV.fetch("BACKEND_BASE_URL", "unknown")
+generated_at = report["@generated"] || Time.now.utc.rfc2822
+created_at = report["created"] || Time.now.utc.iso8601
+insights = Array(report["insights"])
+statistics = report["statistics"] || {}
+endpoint_total = insights.find { |insight| insight["key"] == "insight.endpoint.total" }&.fetch("statistic", nil)
+openapi_urls_added = statistics["openapi.urls.added"]
+site_statistics = report.fetch("site", []).first&.fetch("statistics", {}) || {}
+```
+
+This is what lets the artifact say more than just "here are the requests."
+
+It can also report:
+
+- target site
+- generation timestamps
+- imported OpenAPI URL count
+- total endpoint count seen by ZAP
+- response-profile statistics
+
+That gives the markdown artifact both:
+
+- structural inventory from the plan
+- execution context from the report
+
+#### Markdown generation strategy
+
+The file output section is straightforward by design:
+
+```ruby
+File.open(output_path, "w") do |file|
+  file.puts "# ZAP AF Endpoint Coverage"
+  ...
+  file.puts "## Metadata"
+  ...
+  file.puts "## Coverage Summary"
+  ...
+  file.puts "## Response Profile"
+  ...
+  file.puts "## Interpretation"
+end
+```
+
+The script does not try to be clever with templates or external gems. That is
+intentional. This repository only needs a deterministic internal reporting
+utility, not a second report-generation framework layered on top of ZAP.
+
+#### Why this script is part of the feature, not just a nice extra
+
+This script is not cosmetic.
+
+It solves a real review problem:
+
+- the AF plan is rich and stateful
+- the raw ZAP reports are alert-centric
+- reviewers need a direct answer to "what exactly did this run cover?"
+
+Without this script, that answer would require manually cross-reading:
+
+- the committed plan
+- the generated plan
+- the JSON report
+- the markdown report
+
+The script reduces that to one additional markdown artifact that stays aligned
+with the executed plan.
 
 ---
 
@@ -580,7 +955,7 @@ The workflow currently needs only:
 
 ```yaml
 permissions:
-  contents: read
+    contents: read
 ```
 
 This is the correct least-privilege model for the current implementation. The workflow does not need issue-writing behavior.
@@ -771,10 +1146,10 @@ The current deterministic identifiers are:
 The service seeds:
 
 - a host rack before draw:
-  - `scan-host-rack-red-5`
-  - `scan-host-rack-blue-7`
+    - `scan-host-rack-red-5`
+    - `scan-host-rack-blue-7`
 - a known first draw tile:
-  - `scan-draw-red-1`
+    - `scan-draw-red-1`
 
 That allows the AF plan to do:
 
@@ -1009,10 +1384,10 @@ zap-af-endpoint-coverage.md
 - report generation timestamps
 - endpoint count reported by ZAP
 - grouped inventory by:
-  - public endpoints
-  - positive lobby-state endpoints
-  - positive game-state endpoints
-  - negative-path endpoints
+    - public endpoints
+    - positive lobby-state endpoints
+    - positive game-state endpoints
+    - negative-path endpoints
 - expected method and status per request
 - response profile statistics from the JSON report
 
@@ -1124,10 +1499,10 @@ Verifies:
 - fixture recreation is idempotent
 - the service creates deterministic state
 - the positive game flow is valid for:
-  - get game
-  - update draft
-  - draw tile
-  - end turn
+    - get game
+    - update draft
+    - draw tile
+    - end turn
 
 This test is especially important because it proves that the AF plan’s positive game-state requests are not arbitrary. They are grounded in a real backend state that the service constructs intentionally.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,10 +41,13 @@ The baseline workflow:
 The Automation Framework workflow:
 
 1. waits until the deployed backend is reachable
-2. runs a committed **Automation Framework plan** from the repository
-3. generates dedicated markdown, HTML, and JSON AF reports
-4. publishes the AF summary into the GitHub Actions run summary
-5. uploads the AF reports as separate artifacts
+2. creates a dedicated scan fixture through an internal backend-only endpoint
+3. substitutes the returned ids into a generated Automation Framework plan
+4. runs a committed **Automation Framework plan** from the repository
+5. generates dedicated markdown, HTML, and JSON AF reports
+6. generates a separate endpoint-inventory markdown artifact
+7. publishes the AF summary into the GitHub Actions run summary
+8. uploads the AF reports and endpoint inventory as separate artifacts
 
 The current plan file lives at:
 
@@ -58,15 +61,8 @@ This is enough to demonstrate that backend API security testing is:
 - repeatable
 - visible in CI
 - integrated into the repository
-
-What is important to understand, however, is that the current scan coverage is
-still **narrower than the full backend API surface**. The workflows are
-implemented correctly, but they do not yet exercise the entire game and lobby
-API described in:
-
-```text
-docs/game-api.md
-```
+- aligned with the real REST API contract exposed through `/v3/api-docs`
+- able to acquire a real positive-state `gameId` automatically before the AF run
 
 ---
 
@@ -102,31 +98,24 @@ Expected response:
 
 ### What is actually being scanned right now
 
-In practice, the current ZAP setup mainly covers:
+The two ZAP workflows now cover different layers:
 
-- `/`
-- `/robots.txt`
-- `/sitemap.xml`
-- `/actuator/health`
+1. the baseline scan still provides passive public-surface and transport-layer checks
+2. the Automation Framework scan imports the generated OpenAPI contract and then
+   sends explicit request traffic across public, positive lobby-state, positive
+   game-state, and negative-path endpoint groups
 
-This is true for two different reasons:
+The AF workflow now exercises the real REST API shape, including positive-state
+coverage for:
 
-1. the baseline scan only discovers what it can reach automatically from the
-   deployed public surface
-2. the current Automation Framework plan explicitly requests only those public
-   GET endpoints
+- `GET /api/games/{gameId}`
+- `PUT /api/games/{gameId}/draft`
+- `POST /api/games/{gameId}/draw`
+- `POST /api/games/{gameId}/end-turn`
 
-That means the current scanning setup is best understood as:
-
-```text
-public endpoint and transport-layer security scanning
-```
-
-not yet as:
-
-```text
-full backend game API security scanning
-```
+That positive game coverage is possible because the workflow no longer relies on
+hard-coded public fixture ids. Instead, it creates fresh scan-safe state through
+an internal fixture endpoint before each AF run.
 
 ---
 
@@ -217,6 +206,8 @@ but replaces the packaged baseline behavior with a committed scan plan:
 GitHub Actions
     -> wake deployed backend
     -> verify /actuator/health
+    -> call /internal/security/scan-fixture with X-Scan-Secret
+    -> substitute returned ids into a generated AF plan
     -> run ZAP Automation Framework plan
     -> publish CI summary
     -> upload AF reports as artifacts
@@ -295,132 +286,78 @@ Automation Framework useful for gradual future expansion, such as:
 - alert filtering
 - controlled active scan jobs
 
-### Why the current scans do not yet cover the full game API
+### Dedicated scan-fixture endpoint
 
-The backend game API is much more stateful than the small public endpoint
-surface that ZAP is currently hitting.
-
-Many backend endpoints require:
-
-- `X-User-Id`
-- path variables such as `gameId` or `lobbyId`
-- request bodies
-- existing backend state, such as:
-    - a real lobby
-    - a started game
-    - a current draft
-    - a valid active player
-
-Because of that, generic passive crawling is not enough to reach or exercise
-those endpoints meaningfully.
-
-To scan the real backend API more deeply, a future scan layer needs one of
-these layered approaches:
-
-- **Layer 2 — API-wide coverage**
-    - generate an OpenAPI spec from the backend
-    - import that spec into the existing AF plan through an AF `openapi` job
-    - actively explore the imported API context in a bounded way so ZAP
-      produces real request/response traffic for the API surface
-    - use this as the:
-        ```text
-        scan the whole backend API shape
-        ```
-        layer
-- **Layer 3 — Stateful flows**
-    - add explicit AF `requestor` jobs only for flows that need:
-        - `X-User-Id`
-        - specific ids such as `gameId`
-        - valid request bodies
-        - existing backend state
-
-This is the correct split because OpenAPI import can define the broad API
-shape cheaply, while explicit `requestor` flows should be reserved for the
-smaller set of truly stateful interactions.
-
-One important detail: importing the OpenAPI definition by itself is **not**
-enough to produce meaningful passive scan coverage in the reports. The passive
-scanner only analyzes real HTTP requests and responses. That means Layer 2 must
-combine:
-
-- import of the generated OpenAPI contract
-- explicit requests that actually produce request/response traffic over the
-  imported REST surface
-
-The repository now implements Layer 2 like this:
-
-1. the backend exposes a generated OpenAPI document at:
-
-   ```text
-   /v3/api-docs
-   ```
-
-2. the Automation Framework plan imports that contract from:
-
-   ```text
-   .github/zap/backend-automation-plan.yaml
-   ```
-
-3. the same plan sends explicit `requestor` traffic to the documented REST
-   endpoints so the resulting AF reports contain real HTTP messages instead of
-   only a contract import
-
-### How the AF workflow now prepares real state before the scan
-
-One practical problem showed up when the AF plan was first expanded to stateful
-endpoints: the deployed Render backend did **not** contain the fixed scan IDs
-that existed in local fixture code, such as:
-
-- `scan-open-lobby`
-- `scan-game-1`
-
-That made a purely static AF plan brittle. Requests like:
-
-- `GET /api/lobbies/scan-open-lobby`
-- `PATCH /api/lobbies/scan-open-lobby/settings`
-- `GET /api/games/scan-game-1`
-
-failed on the deployed environment because those resources were not actually
-present.
-
-The workflow therefore now prepares **dynamic lobby scan state** before ZAP
-runs.
-
-The current flow inside:
+The repository now exposes one internal infrastructure endpoint for the
+Automation Framework workflow:
 
 ```text
-.github/workflows/backend-security-af.yml
+POST /internal/security/scan-fixture
 ```
 
-is:
+This endpoint is not part of the public gameplay API. It exists only so the
+workflow can create deterministic, scan-safe backend state immediately before
+the AF run.
 
-1. wait for the deployed backend to become reachable
-2. create a real lobby by calling:
-   - `POST /api/lobbies`
-3. join a real guest player by calling:
-   - `POST /api/lobbies/{lobbyId}/join`
-4. extract the returned `lobbyId`
-5. generate a temporary plan file where placeholder tokens are replaced with
-   that real `lobbyId`
-6. run the AF scan against the generated plan
+The endpoint is protected by:
 
-This keeps the stateful lobby coverage real without requiring hard-coded,
-pre-seeded persistent IDs on Render.
+- request header:
+    - `X-Scan-Secret`
+- backend property:
+    - `app.scan-fixture.secret`
 
-### What the generated-plan placeholders are used for
+If the header is missing or wrong, the backend returns `403 FORBIDDEN`.
 
-The committed plan file contains placeholder values such as:
+The endpoint is only registered when:
 
 ```text
-__SCAN_MUTABLE_LOBBY_ID__
+app.scan-fixture.enabled=true
 ```
 
-Before ZAP starts, the workflow replaces that placeholder with the real lobby
-that was just created for the scan run.
+If the feature is not enabled, the endpoint is absent from routing and behaves
+like a normal `404`.
 
-That generated plan is then passed to the ZAP AF action.
+### Layer 2: API-wide coverage
 
-This allows the AF plan to run positive lobby flows such as:
+Layer 2 is implemented through the generated OpenAPI document:
+
+```text
+/v3/api-docs
+```
+
+The Automation Framework plan imports that contract and then sends explicit
+request traffic so the AF reports contain real HTTP messages instead of only a
+schema import.
+
+This is the repository’s:
+
+```text
+scan the whole backend API shape
+```
+
+layer.
+
+### Layer 3: Positive stateful flows
+
+Layer 3 uses the dedicated fixture endpoint to recreate deterministic state and
+return:
+
+- `lobbyId`
+- `hostUserId`
+- `guestUserId`
+- `gameId`
+- `draftOwnerUserId`
+
+The workflow substitutes those values into a generated plan before ZAP runs.
+
+The placeholders currently used are:
+
+- `__SCAN_LOBBY_ID__`
+- `__SCAN_GAME_ID__`
+- `__SCAN_HOST_USER_ID__`
+- `__SCAN_GUEST_USER_ID__`
+
+This allows the AF run to execute positive real-state requests for:
 
 - `GET /api/lobbies/{lobbyId}`
 - `PATCH /api/lobbies/{lobbyId}/settings`
@@ -428,70 +365,69 @@ This allows the AF plan to run positive lobby flows such as:
 - `POST /api/lobbies/{lobbyId}/unready`
 - `POST /api/lobbies/{lobbyId}/leave`
 - `DELETE /api/lobbies/{lobbyId}`
+- `GET /api/games/{gameId}`
+- `PUT /api/games/{gameId}/draft`
+- `POST /api/games/{gameId}/draw`
+- `POST /api/games/{gameId}/end-turn`
 
-against a **real** existing resource rather than a guessed static ID.
+The fixture guarantees a known pre-draw host rack and first draw tile:
 
-### Why the workflow does not create a real game yet
+- pre-draw rack:
+    - `scan-host-rack-red-5`
+    - `scan-host-rack-blue-7`
+- first draw tile:
+    - `scan-draw-red-1`
 
-The same technique is not cleanly available for game coverage yet.
+That is why the plan can run:
 
-The backend can create and mutate real lobby state over REST, but the current
-public REST API does not expose a simple reliable way for the workflow to:
+- a valid positive `PUT /draft` request before draw
+- a valid positive `POST /draw`
+- a valid positive `POST /end-turn` request with the post-draw rack
 
-- start a lobby,
-- obtain the resulting `gameId`,
-- and then feed that `gameId` back into the AF plan
+Negative-path requests are still kept in the plan so missing-id behavior
+remains visible alongside the positive-state coverage.
 
-without introducing more persistent side effects or much more complex
-orchestration.
+### Authentication scope
 
-Because of that, the current AF implementation uses:
+This implementation does **not** add real backend authentication.
 
-- **positive real-state coverage** for the lobby flows that can be created
-  safely before the scan
-- **negative-path coverage** for game endpoints that still need a reliable game
-  identifier strategy
+Gameplay requests still rely on the backend’s current trusted-header identity
+model:
 
-That means the AF workflow already exercises:
+```text
+X-User-Id
+```
 
-- API-wide contract shape through OpenAPI import
-- real positive lobby stateful flows
-- negative-path game endpoint behavior
+Only the fixture setup endpoint uses the additional `X-Scan-Secret` header.
+Authenticated scan flows remain follow-up work.
 
-but it does **not yet** provide fully positive created-state coverage for the
-game and draft endpoints on the deployed backend.
+### Endpoint coverage artifact
 
-### Current practical coverage model
+The workflow now generates an extra artifact:
 
-The current AF workflow should therefore be read as:
+```text
+zap-af-endpoint-coverage.md
+```
 
-- **Layer 2**
-  - generated OpenAPI import
-  - broad REST endpoint-shape traffic
-- **Layer 3 (implemented in part)**
-  - real positive lobby-state flows created dynamically in the workflow
-  - negative-path game-state requests until a reliable `gameId` strategy exists
+This file is produced from:
 
-This is materially stronger than the earlier public-endpoint-only scan, but it
-is still not the final end state for stateful game coverage.
+- the generated AF plan used in the run
+- the AF JSON report, when present
 
-### The remaining follow-up for full positive stateful game coverage
+It surfaces:
 
-To complete Layer 3 for game endpoints, one of these needs to be added in a
-future PR:
+- target site metadata
+- imported OpenAPI URL count
+- explicit endpoint inventory
+- grouping by:
+    - public endpoints
+    - positive lobby-state endpoints
+    - positive game-state endpoints
+    - negative-path endpoints
+- response-profile statistics from the ZAP JSON output
 
-- a reliable REST-visible way to discover the created `gameId` after starting a
-  lobby
-- a dedicated scan-fixture endpoint or environment for controlled game setup
-- a more advanced AF/script chaining approach that can extract and reuse
-  created game identifiers safely
-
-Until then, the AF workflow should be treated as:
-
-- complete for public endpoint coverage
-- complete for OpenAPI-driven REST shape coverage
-- complete for dynamic positive lobby-state coverage
-- partial for positive game/draft-state coverage
+This artifact is more useful than the raw markdown report when the goal is to
+see exactly which endpoint inventory the AF run exercised.
 
 ---
 
@@ -501,13 +437,7 @@ The workflows are implemented in:
 
 ```text
 .github/workflows/backend-security.yml
-.github/workflows/backend-security-af.yml
 ```
-
-- `backend-security.yml` contains the **baseline scan** workflow.
-- `backend-security-af.yml` contains the **Automation Framework scan** workflow.
-
-The code example below is the **baseline scan** workflow. The AF workflow follows the same overall readiness and reporting pattern, but runs the committed Automation Framework plan instead of the packaged baseline action.
 
 Recommended structure:
 
@@ -600,7 +530,7 @@ jobs:
 
 ---
 
-## Why The Workflows Are Structured This Way
+## Why The Workflow Is Structured This Way
 
 ### `pull_request`
 
@@ -764,9 +694,7 @@ Together, that gives:
 
 ## Generated Reports
 
-The workflows upload separate report sets.
-
-### Baseline scan reports
+The workflow uploads:
 
 ```text
 report_html.html
@@ -774,30 +702,10 @@ report_md.md
 report_json.json
 ```
 
-These are uploaded under the artifact:
-
-```text
-zap-security-report
-```
-
-### Automation Framework scan reports
-
-```text
-zap-af-report.html
-zap-af-report.md
-zap-af-report.json
-```
-
-These are uploaded under the artifact:
-
-```text
-zap-security-report-af
-```
-
 ### HTML
 
 ```text
-report_html.html / zap-af-report.html
+report_html.html
 ```
 
 Best for manual review in a browser.
@@ -805,7 +713,7 @@ Best for manual review in a browser.
 ### Markdown
 
 ```text
-report_md.md / zap-af-report.md
+report_md.md
 ```
 
 Best for CI summaries, PR discussion, and issue creation.
@@ -813,7 +721,7 @@ Best for CI summaries, PR discussion, and issue creation.
 ### JSON
 
 ```text
-report_json.json / zap-af-report.json
+report_json.json
 ```
 
 Best for machine processing or future automation.

--- a/docs/security.md
+++ b/docs/security.md
@@ -336,10 +336,16 @@ This is the correct split because OpenAPI import can cover broad API shape
 cheaply, while explicit `requestor` flows should be reserved for the smaller
 set of truly stateful interactions.
 
+The repository now implements the start of Layer 2 by exposing `/v3/api-docs`
+from the backend and importing that generated OpenAPI document in:
 
-- explicit Automation Framework request definitions for selected API endpoints
-- an OpenAPI-driven scan
-- authenticated/stateful scan setup in a controlled environment
+```text
+.github/zap/backend-automation-plan.yaml
+```
+
+The next remaining expansion is Layer 3, where explicit AF `requestor` jobs
+cover the smaller set of flows that need valid headers, ids, request bodies,
+and existing backend state.
 
 Until that follow-up exists, the current baseline and AF scans should be read
 as valuable but partial coverage.

--- a/docs/security.md
+++ b/docs/security.md
@@ -433,449 +433,729 @@ see exactly which endpoint inventory the AF run exercised.
 
 ## Workflow Files
 
-The workflows are implemented in:
+The implemented security-testing files are:
 
 ```text
 .github/workflows/backend-security.yml
+.github/workflows/backend-security-af.yml
+.github/zap/backend-automation-plan.yaml
+.github/scripts/generate_zap_af_endpoint_coverage.rb
+apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
+apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt
+apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
+apps/backend/src/main/resources/application.yml
 ```
 
-Recommended structure:
+Supporting verification lives in:
+
+```text
+apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
+apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
+apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureBootstrapTest.kt
+apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureServiceTest.kt
+```
+
+---
+
+## End-to-End Strategy
+
+The final security-testing design has two scan layers.
+
+### Layer 1: Baseline passive scan
+
+Purpose:
+
+- cheap recurring CI visibility
+- passive checks against the deployed backend
+- transport and header observations
+- low operational risk
+
+Implementation:
+
+- workflow: `.github/workflows/backend-security.yml`
+- action: `zaproxy/action-baseline`
+- target: deployed Render backend
+
+### Layer 2 and Layer 3: Automation Framework scan
+
+Purpose:
+
+- versioned scan design in the repository
+- OpenAPI-driven API-shape coverage
+- positive real-state request coverage for game and lobby flows
+- explicit endpoint inventory artifact
+
+Implementation:
+
+- workflow: `.github/workflows/backend-security-af.yml`
+- plan: `.github/zap/backend-automation-plan.yaml`
+- report post-processing: `.github/scripts/generate_zap_af_endpoint_coverage.rb`
+
+The design is deliberate:
+
+- **Layer 2** answers: "Can we scan the whole backend API shape?"
+- **Layer 3** answers: "Can we exercise the stateful flows that need valid ids and existing backend state?"
+
+This split keeps the scan understandable and maintainable. OpenAPI import provides breadth. The fixture endpoint provides the minimum amount of controlled state needed for depth.
+
+---
+
+## Baseline Workflow
+
+The baseline workflow exists for stable recurring passive coverage.
+
+Its structure is:
+
+```text
+checkout
+-> wake deployed backend
+-> wait for /actuator/health
+-> run ZAP baseline scan
+-> publish markdown summary
+-> upload HTML / Markdown / JSON artifacts
+```
+
+Important characteristics:
+
+- it scans the deployed backend, not a local process
+- it is safe to run regularly against Render
+- it stays simple on purpose
+- it does not try to create or mutate gameplay state
+
+The baseline layer is not intended to understand game flow semantics. It is intended to keep passive HTTP security observations visible in CI.
+
+---
+
+## Automation Framework Workflow
+
+The Automation Framework workflow is the main implementation of the full REST API scan strategy.
+
+Its structure is:
+
+```text
+checkout
+-> wake deployed backend
+-> wait for /actuator/health
+-> call /internal/security/scan-fixture with X-Scan-Secret
+-> extract lobby/game/user ids
+-> generate concrete AF plan from placeholders
+-> run ZAP Automation Framework
+-> regenerate concrete plan for reporting
+-> generate endpoint inventory markdown
+-> publish summary
+-> upload artifacts
+```
+
+The current workflow file is:
+
+```text
+.github/workflows/backend-security-af.yml
+```
+
+### Why the workflow is structured this way
+
+#### `workflow_dispatch`
+
+Manual runs are necessary while tuning scan design, debugging report output, or validating the deployed scan state.
+
+#### `pull_request`
+
+This is the primary CI integration point. It proves security scanning is part of normal backend development work.
+
+#### `push` on `main`
+
+This re-checks the merged mainline state. It matters because Render deploys from the main branch, not from an isolated pull request workspace.
+
+#### `schedule`
+
+The AF workflow also runs on a schedule so the scan does not depend only on developer activity.
+
+#### `concurrency`
+
+The AF scan mutates real prepared scan state. Overlapping runs on the same branch or pull request would make the artifact stream noisier and could hide failures. The concurrency group prevents that.
+
+#### `permissions`
+
+The workflow currently needs only:
 
 ```yaml
-name: Backend Security Scan
-
-on:
-    workflow_dispatch:
-    pull_request:
-        paths:
-            - "apps/backend/**"
-            - "docs/security.md"
-            - ".github/workflows/backend-security.yml"
-    push:
-        branches: [main]
-        paths:
-            - "apps/backend/**"
-            - "docs/security.md"
-            - ".github/workflows/backend-security.yml"
-    schedule:
-        - cron: "0 6 * * 1"
-
-concurrency:
-    group: backend-security-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
-
 permissions:
-    contents: read
-    issues: write
+  contents: read
+```
 
-env:
-    BACKEND_BASE_URL: https://se2-group-codebase.onrender.com
-    HEALTH_URL: https://se2-group-codebase.onrender.com/actuator/health
+This is the correct least-privilege model for the current implementation. The workflow does not need issue-writing behavior.
 
-jobs:
-    zap-baseline-scan:
-        name: OWASP ZAP Baseline Scan
-        runs-on: ubuntu-latest
-        timeout-minutes: 20
+---
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+## Readiness and Deployment Assumptions
 
-            - name: Wait for deployed backend
-              run: |
-                  for i in {1..30}; do
-                    if curl -fsS "$HEALTH_URL"; then
-                      echo "Backend is reachable"
-                      exit 0
-                    fi
+Both workflows scan the deployed backend:
 
-                    echo "Waiting for backend to wake up..."
-                    sleep 10
-                  done
+```text
+https://se2-group-codebase.onrender.com
+```
 
-                  echo "Backend was not reachable"
-                  exit 1
+Both wait for:
 
-            - name: Run OWASP ZAP baseline scan
-              uses: zaproxy/action-baseline@v0.14.0
-              with:
-                  target: ${{ env.BACKEND_BASE_URL }}
-                  cmd_options: "-a -I"
+```text
+https://se2-group-codebase.onrender.com/actuator/health
+```
 
-            - name: Publish ZAP summary
-              if: always()
-              run: |
-                  {
-                    echo "## OWASP ZAP Baseline Scan"
-                    echo
-                    if [ -f report_md.md ]; then
-                      cat report_md.md
-                    else
-                      echo "No markdown report was generated."
-                    fi
-                  } >> "$GITHUB_STEP_SUMMARY"
+The wake-up loop exists because Render deployments may be cold or sleeping. Without a readiness step, scan failures would often be deployment-timing failures rather than security-scan failures.
 
-            - name: Upload ZAP report
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: zap-security-report
-                  retention-days: 14
-                  path: |
-                      report_html.html
-                      report_md.md
-                      report_json.json
+The health polling loop gives the deployment up to five minutes to wake up:
+
+```text
+30 attempts x 10 seconds
 ```
 
 ---
 
-## Why The Workflow Is Structured This Way
+## OpenAPI Generation and Layer 2 Coverage
 
-### `pull_request`
+Layer 2 depends on the backend exposing a generated OpenAPI document at:
 
-```yaml
-pull_request:
+```text
+/v3/api-docs
 ```
 
-This makes the scan visible in normal CI whenever backend-relevant code changes.
+That endpoint is the backend’s machine-readable API contract.
 
-That is the most important trigger for the professor’s requirement, because it proves the scan is part of the development workflow and not only a one-off manual action.
+It is used so ZAP can understand the REST API shape even when the backend does not expose a browsable HTML surface that would naturally reveal routes through links or forms.
 
-### `push` on `main`
+### Why this matters
 
-```yaml
-push:
-    branches: [main]
+A passive crawler can discover:
+
+- `/`
+- `/robots.txt`
+- `/sitemap.xml`
+- `/actuator/health`
+
+but it cannot infer complex game/lobby routes reliably from that alone.
+
+OpenAPI import fixes that by telling ZAP which routes and methods exist.
+
+### Why OpenAPI import alone is not enough
+
+Importing a contract is necessary, but not sufficient.
+
+The AF report becomes meaningful only when ZAP observes real HTTP traffic. That is why the plan also includes explicit `requestor` jobs after the import. The scan design is therefore:
+
+```text
+OpenAPI import
+-> explicit traffic over the imported route set
+-> passive analysis and reporting
 ```
 
-This verifies the merged mainline state as well. It is useful because a green pull request alone does not prove the deployed branch remains clean after merge.
+This is the repository’s:
 
-### `workflow_dispatch`
-
-```yaml
-workflow_dispatch:
+```text
+scan the whole backend API shape
 ```
 
-This allows manual reruns before demos, reviews, or submission.
-
-### `schedule`
-
-```yaml
-schedule:
-    - cron: "0 6 * * 1"
-```
-
-This keeps the check alive even when no pull request is open.
-
-### `concurrency`
-
-```yaml
-concurrency:
-```
-
-This prevents multiple overlapping ZAP scans for the same branch or pull request. Without that, CI can waste time scanning the same target several times in parallel.
-
-### `permissions`
-
-```yaml
-permissions:
-    contents: read
-    issues: write
-```
-
-The workflow needs repository read access to check out the project and run the scan configuration. It also grants issue write access so OWASP ZAP can create or update GitHub issues for detected security findings, making important scan results visible directly in GitHub. This is intended.
+layer.
 
 ---
 
-## Wake-Up Step
+## Dedicated Scan-Fixture Endpoint and Layer 3 Coverage
 
-Render deployments may sleep when idle, so the scan must not start immediately.
+The stateful gameplay routes cannot be exercised reliably by a generic crawler.
 
-The workflow first polls the health endpoint:
+They need:
 
-```yaml
-- name: Wait for deployed backend
-  run: |
-      for i in {1..30}; do
-        if curl -fsS "$HEALTH_URL"; then
-          echo "Backend is reachable"
-          exit 0
-        fi
+- a real `lobbyId`
+- a real `gameId`
+- valid acting user ids
+- a draft owned by the correct player
+- a known pre-draw rack
+- a known post-draw rack for end-turn
 
-        echo "Waiting for backend to wake up..."
-        sleep 10
-      done
-
-      echo "Backend was not reachable"
-      exit 1
-```
-
-This gives the deployment up to:
+That is why the implementation introduces one internal infrastructure endpoint:
 
 ```text
-30 attempts x 10 seconds = 300 seconds
+POST /internal/security/scan-fixture
 ```
 
-That makes the workflow much more reliable than starting the scan immediately.
+This endpoint is intentionally not part of the public gameplay API.
+
+### Security model of the fixture endpoint
+
+The endpoint is protected by:
+
+- header: `X-Scan-Secret`
+- backend property: `app.scan-fixture.secret`
+
+If:
+
+- the header is missing
+- the header is wrong
+- the configured secret is blank
+
+then the backend returns:
+
+```text
+403 FORBIDDEN
+```
+
+The endpoint is only registered when:
+
+```text
+app.scan-fixture.enabled=true
+```
+
+If that property is false, the endpoint is not present at all.
+
+This keeps the fixture mechanism separate from the public API and prevents accidental exposure in environments where it is not intended to run.
+
+### Why a dedicated fixture endpoint was chosen
+
+A public-API-only setup would have required something like:
+
+```text
+POST /api/lobbies
+-> POST /api/lobbies/{id}/join
+-> POST /api/lobbies/{id}/start
+-> somehow discover the resulting gameId
+-> somehow guarantee a valid draft state
+```
+
+That is much more brittle in CI because:
+
+- the resulting `gameId` is not the central product of the public lobby API
+- the scan would be sensitive to business-logic timing and evolving gameplay rules
+- the workflow would need to derive state from multiple responses instead of one controlled endpoint
+
+The dedicated fixture endpoint is therefore the pragmatic choice. It creates scan-safe state directly and returns the exact identifiers the plan needs.
 
 ---
 
-## OWASP ZAP Baseline Scan
+## Fixture Service Design
 
-The main scan step is:
-
-```yaml
-- name: Run OWASP ZAP baseline scan
-  uses: zaproxy/action-baseline@v0.14.0
-  with:
-      target: ${{ env.BACKEND_BASE_URL }}
-      cmd_options: "-a -I"
-```
-
-Important options:
-
-### `-a`
+The actual fixture creation logic lives in:
 
 ```text
--a
+apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt
 ```
 
-Enables additional passive scan rules.
+The service does three things:
 
-This makes the scan more useful without turning it into an aggressive active attack.
+1. deletes any previous scan fixture state if present
+2. recreates one open lobby and one active lobby/game pair
+3. creates a live turn draft for the active game
 
-### `-I`
+### Why the service recreates state idempotently
 
-```text
--I
-```
+The goal is deterministic CI behavior.
 
-Prevents the workflow from failing only because ZAP produced warnings.
+Each scan run should start from the same known state instead of depending on:
 
-That is a good default for this project because:
+- leftover previous runs
+- unknown demo data
+- user-created lobbies and games
 
-- the scan should remain visible in CI
-- findings should be reviewable
-- low-level warnings should not automatically break every pull request
+The service therefore deletes by fixed ids first, then recreates.
 
-If the team later wants stricter enforcement, this can be tightened with custom ZAP rules or by removing `-I`.
+### Fixed fixture identifiers
+
+The current deterministic identifiers are:
+
+- open lobby: `scan-open-lobby`
+- active lobby: `scan-active-lobby`
+- game: `scan-game-1`
+- host user: `scan-host-user`
+- guest user: `scan-guest-user`
+
+### Deterministic game state
+
+The service seeds:
+
+- a host rack before draw:
+  - `scan-host-rack-red-5`
+  - `scan-host-rack-blue-7`
+- a known first draw tile:
+  - `scan-draw-red-1`
+
+That allows the AF plan to do:
+
+- valid positive `PUT /api/games/{gameId}/draft`
+- valid positive `POST /api/games/{gameId}/draw`
+- valid positive `POST /api/games/{gameId}/end-turn`
+
+with known payload expectations.
+
+### Returned fixture state
+
+The fixture endpoint returns:
+
+- `lobbyId`
+- `hostUserId`
+- `guestUserId`
+- `gameId`
+- `draftOwnerUserId`
+
+The workflow uses those values as substitution inputs for the AF plan.
 
 ---
 
-## Making The Result Visible In CI
+## Bootstrap Behavior
 
-The professor’s requirement is not only about running the scan, but about making the result visible.
+The repository also contains:
 
-The workflow now does that in two ways:
-
-### 1. GitHub Actions step summary
-
-```yaml
-- name: Publish ZAP summary
+```text
+apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureBootstrap.kt
 ```
 
-This writes the Markdown report into the Actions job summary, so reviewers can see the result directly inside CI without downloading artifacts first.
+This bootstrap is intentionally thin.
 
-### 2. Uploaded artifacts
+It does not contain its own seeding logic anymore. It delegates to `SecurityScanFixtureService`.
 
-```yaml
-- name: Upload ZAP report
+This matters for maintainability because:
+
+- the internal fixture endpoint
+- the bootstrap
+- backend tests
+
+all rely on the same fixture-building implementation rather than duplicating seeded state logic in multiple places.
+
+The bootstrap is guarded by:
+
+```text
+app.scan-fixture.enabled=true
 ```
 
-This preserves the full reports for later inspection.
+and is disabled in tests by default through:
 
-Together, that gives:
+```text
+apps/backend/src/test/resources/application.yml
+```
 
-- fast visibility in CI
-- persistent full reports for manual review
+so unrelated test scenarios are not polluted by scan-fixture data.
 
 ---
 
-## Generated Reports
+## Placeholder-Based AF Plan Generation
 
-The workflow uploads:
+The committed AF plan contains placeholders instead of hard-coded live ids:
 
-```text
-report_html.html
-report_md.md
-report_json.json
-```
+- `__SCAN_LOBBY_ID__`
+- `__SCAN_GAME_ID__`
+- `__SCAN_HOST_USER_ID__`
+- `__SCAN_GUEST_USER_ID__`
 
-### HTML
+The workflow:
 
-```text
-report_html.html
-```
-
-Best for manual review in a browser.
-
-### Markdown
+1. calls `/internal/security/scan-fixture`
+2. parses the JSON response with `jq`
+3. stores the values in `GITHUB_ENV`
+4. runs `sed` substitution against the committed plan
+5. writes:
 
 ```text
-report_md.md
+.github/zap/backend-automation-plan.generated.yaml
 ```
 
-Best for CI summaries, PR discussion, and issue creation.
+That generated file is the concrete plan executed by ZAP for that run.
 
-### JSON
+The workflow later regenerates the same concrete plan for reporting so the post-processing step can always read the exact substituted endpoint set.
 
-```text
-report_json.json
-```
-
-Best for machine processing or future automation.
+If fixture variables are missing, the workflow falls back to copying the committed template plan so reporting can still degrade gracefully instead of crashing on an absent file.
 
 ---
 
-## How To Use This In Practice
+## Automation Framework Plan Structure
 
-### Manual run
+The AF plan is committed in:
 
-1. Open the repository in GitHub.
-2. Go to **Actions**.
-3. Select **Backend Security Scan**.
-4. Click **Run workflow**.
-5. Wait for the job to finish.
-6. Read the CI summary.
-7. Download the `zap-security-report` artifact if deeper inspection is needed.
+```text
+.github/zap/backend-automation-plan.yaml
+```
 
-### Pull request flow
+Its high-level structure is:
 
-1. Change backend code.
-2. Open or update the pull request.
-3. Let **Backend Security Scan** run automatically.
-4. Review the summary and artifact.
-5. Decide whether findings should be fixed now or tracked explicitly.
+```text
+env context
+-> passiveScan-config
+-> openapi import
+-> requestor jobs
+-> passiveScan-wait
+-> report jobs
+-> exitStatus
+```
+
+### Context definition
+
+The plan defines a `se2-backend` context rooted at the deployed Render base URL.
+
+This keeps the scan scoped to the actual backend host.
+
+### Passive scan configuration
+
+The plan limits passive alert volume and keeps scanning in-scope:
+
+- `maxAlertsPerRule: 10`
+- `scanOnlyInScope: true`
+
+### OpenAPI import job
+
+The `openapi` job imports:
+
+```text
+https://se2-group-codebase.onrender.com/v3/api-docs
+```
+
+against:
+
+```text
+https://se2-group-codebase.onrender.com
+```
+
+inside the `se2-backend` context.
+
+### Requestor groups
+
+The requestor jobs are organized intentionally into four groups.
+
+#### Public endpoints
+
+- `/`
+- `/robots.txt`
+- `/sitemap.xml`
+- `/actuator/health`
+- `/api/leaderboard`
+- `/api/lobbies`
+
+#### Positive lobby-state endpoints
+
+- `GET /api/lobbies/{lobbyId}`
+- `PATCH /api/lobbies/{lobbyId}/settings`
+- `POST /api/lobbies/{lobbyId}/ready`
+- `POST /api/lobbies/{lobbyId}/unready`
+- `POST /api/lobbies/{lobbyId}/leave`
+- `DELETE /api/lobbies/{lobbyId}`
+
+#### Positive game-state endpoints
+
+- `GET /api/games/{gameId}`
+- `PUT /api/games/{gameId}/draft`
+- `POST /api/games/{gameId}/draw`
+- `POST /api/games/{gameId}/end-turn`
+
+#### Negative-path endpoints
+
+- create/join/start/leave/delete cases against missing lobby ids where useful
+- missing game get/draft/draw/end-turn cases
+
+The negative-path coverage remains in the plan because a scan should not only show happy-path behavior. It is useful to keep visible how the API behaves when resources do not exist.
+
+### Why the plan includes both positive and negative requests
+
+The point of the AF plan is not just to make ZAP touch endpoints. It is to make the report communicate:
+
+- which routes exist
+- which routes succeed with valid state
+- which routes reject missing resources correctly
+
+That is why the report inventory is grouped the same way.
+
+### Report jobs
+
+The plan generates:
+
+- Markdown: `traditional-md`
+- HTML: `traditional-html-plus`
+- JSON: `traditional-json-plus`
+
+The `plus` variants are used for HTML and JSON because they preserve richer request/response information than the traditional minimal variants.
+
+### Exit behavior
+
+The first rollout stays intentionally non-blocking at the warning level:
+
+```text
+warnLevel: High
+errorLevel: High
+```
+
+That means the workflow is still informative rather than aggressively enforcement-driven.
 
 ---
 
-## How To Interpret Findings
+## Endpoint Coverage Post-Processing
 
-Typical ZAP findings are grouped into levels like:
+The raw ZAP Markdown report is useful, but weak as an endpoint inventory.
 
-```text
-Informational
-Low
-Medium
-High
-```
-
-A finding does not automatically mean the backend is broken or exploitable.
-
-The team should review each finding and decide whether it is:
+That is why the repository adds:
 
 ```text
-real and should be fixed
-acceptable in this project context
-a false positive
-future hardening work
+.github/scripts/generate_zap_af_endpoint_coverage.rb
 ```
 
-Examples of findings that can appear:
+This script reads:
+
+- the generated concrete AF plan
+- the ZAP JSON report
+
+and emits:
 
 ```text
-Missing Anti-clickjacking Header
-Missing Content Security Policy
-Server Leaks Version Information
-X-Content-Type-Options Header Missing
+zap-af-endpoint-coverage.md
 ```
 
-Some of these are more relevant for browser-facing applications than for a pure Android client, but they are still valid security observations and worth documenting.
+### What the generated endpoint artifact contains
+
+- target site metadata
+- automation plan path
+- report generation timestamps
+- endpoint count reported by ZAP
+- grouped inventory by:
+  - public endpoints
+  - positive lobby-state endpoints
+  - positive game-state endpoints
+  - negative-path endpoints
+- expected method and status per request
+- response profile statistics from the JSON report
+
+This artifact exists because reviewers often need to know exactly what the scan exercised, not just whether alerts were found.
 
 ---
 
-## What This Setup Proves
+## Artifacts and CI Visibility
 
-This implementation proves that:
+### Baseline workflow artifacts
 
-- backend API security testing is automated
-- the scan is integrated into GitHub Actions
-- the scan result is visible inside CI
-- the full reports are retained as artifacts
-- the check can run on pull requests, on demand, and on a schedule
+The baseline workflow uploads:
 
-That is a defensible and concrete implementation of the professor’s requirement.
+- `report_html.html`
+- `report_md.md`
+- `report_json.json`
 
----
+### Automation Framework workflow artifacts
 
-## Limitations
+The AF workflow uploads:
 
-This setup is useful, but deliberately limited.
+- `.github/zap/backend-automation-plan.generated.yaml`
+- `zap-af-report.md`
+- `zap-af-report.html`
+- `zap-af-report.json`
+- `zap-af-endpoint-coverage.md`
 
-It does **not** replace:
+### Why both summary and artifacts are kept
 
-```text
-authentication
-authorization
-input validation
-DTO validation
-membership and turn checks
-secret handling
-manual security review
-secure deployment configuration
-```
+The GitHub Actions summary is optimized for quick review.
 
-It also does **not** perform an aggressive active attack against the backend. That is intentional. Running active security attacks against a small deployed student backend would be harder to control and easier to misuse.
+The artifacts are optimized for:
 
-The current setup is therefore best described as:
+- later inspection
+- PR discussion
+- formatted documentation
+- comparing one scan run with another
 
-```text
-automated passive API security scanning in CI
-```
-
-That is still a valid and solid answer to the requirement.
-
-An equally important limitation is scope:
-
-```text
-the current ZAP workflows do not yet cover the full stateful game API.
-```
-
-They are currently strongest at:
-
-- public endpoint checks
-- response-header checks
-- cache-policy checks
-- transport-level observations
-
-They are not yet a substitute for a future deeper scan against:
-
-- game command endpoints
-- draft mutation endpoints
-- end-turn submission flows
-- stateful or authenticated API interactions
+The workflow therefore does both instead of choosing only one output path.
 
 ---
 
-## Relation To Backend Security In The Codebase
+## External Configuration Required for the AF Workflow
 
-The ZAP scan should be understood as one layer only.
+The AF workflow depends on live deployed backend configuration.
 
-Actual backend security still depends on the application code rejecting invalid or unauthorized requests.
+### Render environment variables
 
-### Current Request Identity Model
+The deployed backend must have:
 
-Most backend game and lobby endpoints currently receive the acting user through:
+```text
+APP_SCAN_FIXTURE_ENABLED=true
+APP_SCAN_FIXTURE_SECRET=<shared-secret>
+```
+
+### GitHub Actions secret
+
+The repository must have:
+
+```text
+ZAP_SCAN_FIXTURE_SECRET=<same shared-secret>
+```
+
+If these are not configured consistently:
+
+- the fixture endpoint will not exist, or
+- the fixture call will be rejected with `403`, or
+- the workflow will not receive real ids for plan substitution
+
+That is the main operational dependency for the stateful AF scan.
+
+---
+
+## Verification and Regression Coverage
+
+The repository locks this feature down with targeted backend tests.
+
+### `OpenApiDocsTest`
+
+Verifies:
+
+- `/v3/api-docs` is reachable
+- the response is a real OpenAPI document
+- key gameplay and lobby paths are present
+- the internal fixture endpoint is hidden from the public OpenAPI document
+- response security headers still apply to the generated docs endpoint
+
+### `SecurityScanFixtureControllerTest`
+
+Verifies:
+
+- missing `X-Scan-Secret` returns `403`
+- wrong secret returns `403`
+- valid secret returns the expected ids
+- the fixture endpoint actually creates the expected lobby/game/draft state
+
+### `SecurityScanFixtureBootstrapTest`
+
+Verifies:
+
+- bootstrap seeding is enabled only when requested
+- the deterministic open lobby, active lobby, game, and draft are present
+- the seeded entities match the latest intended fixture contract
+
+### `SecurityScanFixtureServiceTest`
+
+Verifies:
+
+- fixture recreation is idempotent
+- the service creates deterministic state
+- the positive game flow is valid for:
+  - get game
+  - update draft
+  - draw tile
+  - end turn
+
+This test is especially important because it proves that the AF plan’s positive game-state requests are not arbitrary. They are grounded in a real backend state that the service constructs intentionally.
+
+---
+
+## Relation to Backend Authorization
+
+The security workflows are one layer only.
+
+Actual request-level authorization still depends on backend application logic.
+
+### Current request identity model
+
+Most gameplay and lobby endpoints receive the acting user through:
 
 ```kotlin
 @RequestHeader("X-User-Id") userId: String
 ```
 
-That header is then used for application-level security and ownership checks in
-the service layer.
+That enables checks such as:
 
-Examples of the kinds of checks this enables:
+- player belongs to game
+- player belongs to lobby
+- acting player owns the draft
+- acting player is the current player
+- acting player is the lobby host when a host-only action is attempted
 
-- only the active player may draw, reset a draft, or end a turn
-- only the owning player may mutate their current `TurnDraft`
-- only users who belong to a game may access or mutate that game
-- only users who belong to a lobby may interact with lobby-backed game state
-- only the lobby host may start the lobby
-- per-turn limits such as one draw per turn can be enforced against the acting
-  user identity
-
-Typical service-level checks look like this:
+Typical service-level checks look like:
 
 ```kotlin
 fun requirePlayerInGame(game: ConfirmedGame, userId: String) {
@@ -897,73 +1177,87 @@ fun requireDraftOwner(draft: TurnDraft, userId: String) {
 }
 ```
 
-This is a valid lightweight authorization model for the current backend, but it
-has an important limit:
+This is still not full authentication.
+
+Important limitation:
 
 ```text
 X-User-Id is only trustworthy if the caller environment is trusted.
 ```
 
-In other words, this is not full authentication by itself. If an arbitrary
-external client can choose any header value freely, the client can impersonate
-another user unless an upstream trusted system constrains that header.
+The AF scan does not change that. It uses the same `X-User-Id` model for gameplay requests and only adds `X-Scan-Secret` for the dedicated internal fixture endpoint.
 
-So the current model should be understood as:
+So the current security model is:
 
-- suitable for controlled development, demos, tests, and trusted integration
-  scenarios
-- useful for enforcing game membership, turn ownership, and host-only actions
-- not equivalent to real end-user authentication
+- useful for controlled development and CI scanning
+- useful for service-level authorization checks
+- not equivalent to production-grade end-user authentication
 
-That distinction matters when discussing backend security. The CI security scan
-checks the deployed API surface, but the correctness of user-level access
-control still depends on the service layer enforcing these `X-User-Id`-based
-authorization checks consistently.
+Authenticated security scanning remains future work.
 
-Examples:
+---
 
-```kotlin
-fun requirePlayerInGame(game: ConfirmedGame, userId: String) {
-    if (game.players.none { it.userId == userId }) {
-        throw SecurityException("Player is not part of this game")
-    }
-}
+## Limitations and Non-Goals
 
-fun requireCurrentPlayer(game: ConfirmedGame, userId: String) {
-    if (game.currentPlayerUserId != userId) {
-        throw SecurityException("It is not this player's turn")
-    }
-}
-```
+This implementation is intentionally strong in some areas and intentionally narrow in others.
 
-And for REST behavior:
+### What it does well
 
-```kotlin
-@ExceptionHandler(SecurityException::class)
-fun handleSecurity(ex: SecurityException): ResponseEntity<ApiErrorResponse> {
-    return ResponseEntity
-        .status(HttpStatus.FORBIDDEN)
-        .body(
-            ApiErrorResponse(
-                errorCode = "FORBIDDEN",
-                errorMessage = ex.message ?: "Access denied"
-            )
-        )
-}
-```
+- automated CI visibility
+- deployed-environment scanning
+- passive header and transport checks
+- OpenAPI-driven API-shape coverage
+- positive stateful lobby and game coverage
+- explicit endpoint inventory reporting
 
-The security workflow complements these protections. It does not replace them.
+### What it does not replace
+
+- authentication
+- authorization design
+- DTO validation
+- business-rule validation
+- secure secret management
+- secure deployment hardening
+- manual security review
+
+### What it does not currently cover
+
+- websocket traffic
+- full browser-oriented frontend security behavior
+- aggressive active attack scanning
+- richer authenticated user-session models
+
+This is intentional. The goal is a correct, automated, repeatable API security-scanning layer, not a full security platform.
+
+---
+
+## What This Setup Proves
+
+This implementation proves all of the following:
+
+- backend API security testing is automated
+- the scan is integrated into GitHub Actions
+- the deployed Render backend is the real scan target
+- the repository uses both a baseline and a plan-driven scan layer
+- the backend publishes an OpenAPI contract that the scan can import
+- the AF workflow can acquire a real `lobbyId` and `gameId` automatically
+- stateful game and lobby flows are exercised with deterministic valid state
+- CI exposes both high-level summaries and detailed downloadable artifacts
+
+That is a concrete and defensible implementation of automated API security testing for this project.
 
 ---
 
 ## Minimal Submission Statement
 
-If this needs to be explained very briefly in a submission or demo:
+If this needs to be summarized briefly in a submission or demo:
 
 ```text
 The backend API is automatically scanned with OWASP ZAP through GitHub Actions.
-The workflow waits for the deployed Render backend, runs a passive baseline
-security scan, publishes the result in the CI summary, and uploads HTML,
-Markdown, and JSON reports as artifacts. This provides automated API security
-testing that is visible and repeatable in CI.
+The project uses two scan layers: a passive baseline scan and a plan-driven
+Automation Framework scan. The AF workflow imports the generated OpenAPI
+document, creates dedicated scan-safe backend state through an internal
+secret-gated fixture endpoint, substitutes the resulting lobby and game ids
+into a generated plan, runs the scan against the deployed Render backend, and
+publishes both human-readable summaries and downloadable scan artifacts.
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -358,6 +358,11 @@ The AF plan then performs a bounded active scan over the imported context so
 the resulting AF reports reflect real API-surface traffic rather than only the
 small public requestor set.
 
+For the next layer of valid stateful requests, the backend also seeds a small
+deterministic scan fixture at startup. That fixture provides stable ids such as
+the scan lobby and scan game used by the AF plan when it needs real existing
+backend state instead of only contract-shape coverage.
+
 The next remaining expansion is Layer 3, where explicit AF `requestor` jobs
 cover the smaller set of flows that need valid headers, ids, request bodies,
 and existing backend state.

--- a/docs/security.md
+++ b/docs/security.md
@@ -341,34 +341,157 @@ smaller set of truly stateful interactions.
 One important detail: importing the OpenAPI definition by itself is **not**
 enough to produce meaningful passive scan coverage in the reports. The passive
 scanner only analyzes real HTTP requests and responses. That means Layer 2 must
-do both:
+combine:
 
-- import the OpenAPI contract
-- run a bounded scan over the imported context so the API endpoints are actually
-  requested
+- import of the generated OpenAPI contract
+- explicit requests that actually produce request/response traffic over the
+  imported REST surface
 
-The repository now implements the start of Layer 2 by exposing `/v3/api-docs`
-from the backend and importing that generated OpenAPI document in:
+The repository now implements Layer 2 like this:
+
+1. the backend exposes a generated OpenAPI document at:
+
+   ```text
+   /v3/api-docs
+   ```
+
+2. the Automation Framework plan imports that contract from:
+
+   ```text
+   .github/zap/backend-automation-plan.yaml
+   ```
+
+3. the same plan sends explicit `requestor` traffic to the documented REST
+   endpoints so the resulting AF reports contain real HTTP messages instead of
+   only a contract import
+
+### How the AF workflow now prepares real state before the scan
+
+One practical problem showed up when the AF plan was first expanded to stateful
+endpoints: the deployed Render backend did **not** contain the fixed scan IDs
+that existed in local fixture code, such as:
+
+- `scan-open-lobby`
+- `scan-game-1`
+
+That made a purely static AF plan brittle. Requests like:
+
+- `GET /api/lobbies/scan-open-lobby`
+- `PATCH /api/lobbies/scan-open-lobby/settings`
+- `GET /api/games/scan-game-1`
+
+failed on the deployed environment because those resources were not actually
+present.
+
+The workflow therefore now prepares **dynamic lobby scan state** before ZAP
+runs.
+
+The current flow inside:
 
 ```text
-.github/zap/backend-automation-plan.yaml
+.github/workflows/backend-security-af.yml
 ```
 
-The AF plan then performs a bounded active scan over the imported context so
-the resulting AF reports reflect real API-surface traffic rather than only the
-small public requestor set.
+is:
 
-For the next layer of valid stateful requests, the backend also seeds a small
-deterministic scan fixture at startup. That fixture provides stable ids such as
-the scan lobby and scan game used by the AF plan when it needs real existing
-backend state instead of only contract-shape coverage.
+1. wait for the deployed backend to become reachable
+2. create a real lobby by calling:
+   - `POST /api/lobbies`
+3. join a real guest player by calling:
+   - `POST /api/lobbies/{lobbyId}/join`
+4. extract the returned `lobbyId`
+5. generate a temporary plan file where placeholder tokens are replaced with
+   that real `lobbyId`
+6. run the AF scan against the generated plan
 
-The next remaining expansion is Layer 3, where explicit AF `requestor` jobs
-cover the smaller set of flows that need valid headers, ids, request bodies,
-and existing backend state.
+This keeps the stateful lobby coverage real without requiring hard-coded,
+pre-seeded persistent IDs on Render.
 
-Until that follow-up exists, the current baseline and AF scans should be read
-as valuable but partial coverage.
+### What the generated-plan placeholders are used for
+
+The committed plan file contains placeholder values such as:
+
+```text
+__SCAN_MUTABLE_LOBBY_ID__
+```
+
+Before ZAP starts, the workflow replaces that placeholder with the real lobby
+that was just created for the scan run.
+
+That generated plan is then passed to the ZAP AF action.
+
+This allows the AF plan to run positive lobby flows such as:
+
+- `GET /api/lobbies/{lobbyId}`
+- `PATCH /api/lobbies/{lobbyId}/settings`
+- `POST /api/lobbies/{lobbyId}/ready`
+- `POST /api/lobbies/{lobbyId}/unready`
+- `POST /api/lobbies/{lobbyId}/leave`
+- `DELETE /api/lobbies/{lobbyId}`
+
+against a **real** existing resource rather than a guessed static ID.
+
+### Why the workflow does not create a real game yet
+
+The same technique is not cleanly available for game coverage yet.
+
+The backend can create and mutate real lobby state over REST, but the current
+public REST API does not expose a simple reliable way for the workflow to:
+
+- start a lobby,
+- obtain the resulting `gameId`,
+- and then feed that `gameId` back into the AF plan
+
+without introducing more persistent side effects or much more complex
+orchestration.
+
+Because of that, the current AF implementation uses:
+
+- **positive real-state coverage** for the lobby flows that can be created
+  safely before the scan
+- **negative-path coverage** for game endpoints that still need a reliable game
+  identifier strategy
+
+That means the AF workflow already exercises:
+
+- API-wide contract shape through OpenAPI import
+- real positive lobby stateful flows
+- negative-path game endpoint behavior
+
+but it does **not yet** provide fully positive created-state coverage for the
+game and draft endpoints on the deployed backend.
+
+### Current practical coverage model
+
+The current AF workflow should therefore be read as:
+
+- **Layer 2**
+  - generated OpenAPI import
+  - broad REST endpoint-shape traffic
+- **Layer 3 (implemented in part)**
+  - real positive lobby-state flows created dynamically in the workflow
+  - negative-path game-state requests until a reliable `gameId` strategy exists
+
+This is materially stronger than the earlier public-endpoint-only scan, but it
+is still not the final end state for stateful game coverage.
+
+### The remaining follow-up for full positive stateful game coverage
+
+To complete Layer 3 for game endpoints, one of these needs to be added in a
+future PR:
+
+- a reliable REST-visible way to discover the created `gameId` after starting a
+  lobby
+- a dedicated scan-fixture endpoint or environment for controlled game setup
+- a more advanced AF/script chaining approach that can extract and reuse
+  created game identifiers safely
+
+Until then, the AF workflow should be treated as:
+
+- complete for public endpoint coverage
+- complete for OpenAPI-driven REST shape coverage
+- complete for dynamic positive lobby-state coverage
+- partial for positive game/draft-state coverage
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -320,6 +320,8 @@ these layered approaches:
 - **Layer 2 — API-wide coverage**
     - generate an OpenAPI spec from the backend
     - import that spec into the existing AF plan through an AF `openapi` job
+    - actively explore the imported API context in a bounded way so ZAP
+      produces real request/response traffic for the API surface
     - use this as the:
         ```text
         scan the whole backend API shape
@@ -332,9 +334,18 @@ these layered approaches:
         - valid request bodies
         - existing backend state
 
-This is the correct split because OpenAPI import can cover broad API shape
-cheaply, while explicit `requestor` flows should be reserved for the smaller
-set of truly stateful interactions.
+This is the correct split because OpenAPI import can define the broad API
+shape cheaply, while explicit `requestor` flows should be reserved for the
+smaller set of truly stateful interactions.
+
+One important detail: importing the OpenAPI definition by itself is **not**
+enough to produce meaningful passive scan coverage in the reports. The passive
+scanner only analyzes real HTTP requests and responses. That means Layer 2 must
+do both:
+
+- import the OpenAPI contract
+- run a bounded scan over the imported context so the API endpoints are actually
+  requested
 
 The repository now implements the start of Layer 2 by exposing `/v3/api-docs`
 from the backend and importing that generated OpenAPI document in:
@@ -342,6 +353,10 @@ from the backend and importing that generated OpenAPI document in:
 ```text
 .github/zap/backend-automation-plan.yaml
 ```
+
+The AF plan then performs a bounded active scan over the imported context so
+the resulting AF reports reflect real API-surface traffic rather than only the
+small public requestor set.
 
 The next remaining expansion is Layer 3, where explicit AF `requestor` jobs
 cover the smaller set of flows that need valid headers, ids, request bodies,

--- a/docs/security.md
+++ b/docs/security.md
@@ -306,16 +306,36 @@ Many backend endpoints require:
 - path variables such as `gameId` or `lobbyId`
 - request bodies
 - existing backend state, such as:
-  - a real lobby
-  - a started game
-  - a current draft
-  - a valid active player
+    - a real lobby
+    - a started game
+    - a current draft
+    - a valid active player
 
 Because of that, generic passive crawling is not enough to reach or exercise
 those endpoints meaningfully.
 
 To scan the real backend API more deeply, a future scan layer needs one of
-these approaches:
+these layered approaches:
+
+- **Layer 2 — API-wide coverage**
+    - generate an OpenAPI spec from the backend
+    - import that spec into the existing AF plan through an AF `openapi` job
+    - use this as the:
+        ```text
+        scan the whole backend API shape
+        ```
+        layer
+- **Layer 3 — Stateful flows**
+    - add explicit AF `requestor` jobs only for flows that need:
+        - `X-User-Id`
+        - specific ids such as `gameId`
+        - valid request bodies
+        - existing backend state
+
+This is the correct split because OpenAPI import can cover broad API shape
+cheaply, while explicit `requestor` flows should be reserved for the smaller
+set of truly stateful interactions.
+
 
 - explicit Automation Framework request definitions for selected API endpoints
 - an OpenAPI-driven scan
@@ -326,13 +346,19 @@ as valuable but partial coverage.
 
 ---
 
-## Workflow File
+## Workflow Files
 
-The workflow is implemented in:
+The workflows are implemented in:
 
 ```text
 .github/workflows/backend-security.yml
+.github/workflows/backend-security-af.yml
 ```
+
+- `backend-security.yml` contains the **baseline scan** workflow.
+- `backend-security-af.yml` contains the **Automation Framework scan** workflow.
+
+The code example below is the **baseline scan** workflow. The AF workflow follows the same overall readiness and reporting pattern, but runs the committed Automation Framework plan instead of the packaged baseline action.
 
 Recommended structure:
 
@@ -425,7 +451,7 @@ jobs:
 
 ---
 
-## Why The Workflow Is Structured This Way
+## Why The Workflows Are Structured This Way
 
 ### `pull_request`
 
@@ -589,7 +615,9 @@ Together, that gives:
 
 ## Generated Reports
 
-The workflow uploads:
+The workflows upload separate report sets.
+
+### Baseline scan reports
 
 ```text
 report_html.html
@@ -597,10 +625,30 @@ report_md.md
 report_json.json
 ```
 
+These are uploaded under the artifact:
+
+```text
+zap-security-report
+```
+
+### Automation Framework scan reports
+
+```text
+zap-af-report.html
+zap-af-report.md
+zap-af-report.json
+```
+
+These are uploaded under the artifact:
+
+```text
+zap-security-report-af
+```
+
 ### HTML
 
 ```text
-report_html.html
+report_html.html / zap-af-report.html
 ```
 
 Best for manual review in a browser.
@@ -608,7 +656,7 @@ Best for manual review in a browser.
 ### Markdown
 
 ```text
-report_md.md
+report_md.md / zap-af-report.md
 ```
 
 Best for CI summaries, PR discussion, and issue creation.
@@ -616,7 +664,7 @@ Best for CI summaries, PR discussion, and issue creation.
 ### JSON
 
 ```text
-report_json.json
+report_json.json / zap-af-report.json
 ```
 
 Best for machine processing or future automation.


### PR DESCRIPTION
## Summary

This PR expands the current ZAP setup beyond the small public GET surface and introduces the next two scanning layers for the backend API:

- **Layer 2 — API-wide coverage**
- **Layer 3 — Stateful flows**

The goal is to move from only scanning `/`, `/robots.txt`, `/sitemap.xml`, and `/actuator/health` toward meaningful backend API coverage in the right order.

## Issues

- Closes #783 
- Closes #784 
- Closes #785 
- Closes #786 
- Closes #787 
- Closes #788 
- Closes #789 

## Why this PR exists

The current baseline scan and Automation Framework scan confirm that the deployed backend is being scanned at all, but they do **not** yet provide meaningful coverage of the actual game API.

The backend API is:
- stateful
- header-driven
- path-variable-driven
- request-body-driven

Many endpoints require:
- `X-User-Id`
- valid `gameId` / `lobbyId`
- existing backend state
- valid JSON bodies

Because of that, this PR should expand coverage in two steps:
1. import and scan the backend API shape through **OpenAPI**
2. add a **small number of explicit AF requestor jobs** for stateful flows

## Scope

### Included

- generate and expose a backend OpenAPI spec
- verify a stable `/v3/api-docs` endpoint
- import that spec into the existing Automation Framework plan
- extend the AF plan with selected `requestor` jobs for real API flows
- add required headers like `X-User-Id`
- add example request bodies where needed
- keep the scan **non-blocking** at first
- document which API flows are covered

### Not included

- replacing the existing public endpoint scan
- websocket scanning
- authenticated session-based scanning
- aggressive active scans
- complete stateful coverage of every gameplay endpoint

## Main design

### Layer 2 — API-wide coverage

Use a generated OpenAPI spec as the broad backend API-shape coverage layer.

Implementation direction:
- add Springdoc to the backend
- expose `/v3/api-docs`
- import that spec into the existing AF plan via the `openapi` job

This provides wide structural coverage of the backend REST contract without turning the AF plan into a large brittle manual request list.

### Layer 3 — Stateful flows

Use AF `requestor` jobs only for the small set of endpoints that need:
- trusted headers
- real path IDs
- request bodies
- existing backend state

This keeps the design clean:
- **OpenAPI** covers broad API shape
- **requestor jobs** cover the narrow stateful gap

## Suggested first stateful targets

Start with a small, stable subset such as:

- `GET /api/games/{gameId}`
- `POST /api/games/{gameId}/reset-draft`
- `POST /api/games/{gameId}/draw`

These are central enough to be useful, but still small enough to keep the first rollout manageable.

## Files expected to change

- `apps/backend/build.gradle.kts`
- `.github/zap/backend-automation-plan.yaml`
- `.github/workflows/backend-security-af.yml`
- `docs/security.md`

## Implementation order

1. add OpenAPI generation to the backend
2. deploy and verify `/v3/api-docs`
3. add AF `openapi` import to the existing plan
4. confirm API-shape coverage appears in AF reports
5. add the first small Layer 3 `requestor` set
6. rerun the AF workflow and verify both layers
7. update security docs

## Validation checklist

This PR is complete when:

- the backend exposes `/v3/api-docs`
- the AF workflow still runs successfully
- the OpenAPI spec is imported successfully
- AF reports now cover more than only the public metadata/health endpoints
- selected real stateful API endpoints are reached
- `X-User-Id` is included where required
- reports/artifacts are still generated successfully
- the workflow remains non-blocking
- docs explain the Layer 2 / Layer 3 model clearly

## Expected outcome

After this PR, the repository should have:

- a generated backend OpenAPI spec
- an OpenAPI-driven API-shape scan layer
- a small explicit Layer 3 AF request set for truly stateful flows

This is a much cleaner long-term direction than trying to model the full backend API only through one large manual AF `requestor` plan.