### PR TITLE
ci(android,backend)(workflow)(release): add coordinated backend deploy and android apk release workflows

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,303 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: "Release channel"
+        required: true
+        default: "preview"
+        type: choice
+        options:
+          - preview
+          - internal
+          - production
+      version_name:
+        description: "Android versionName"
+        required: true
+      version_code:
+        description: "Android versionCode"
+        required: true
+      publish_to_itch:
+        description: "Publish APK to Itch.io"
+        required: true
+        default: false
+        type: boolean
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+    paths:
+      - "apps/android/**"
+      - "gradle/**"
+      - "gradlew"
+      - "gradlew.bat"
+      - "settings.gradle.kts"
+      - "build.gradle.kts"
+      - ".github/workflows/android-release.yml"
+      - "docs/release-management.md"
+      - "docs/workflows.md"
+
+concurrency:
+  group: android-release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      release_channel: ${{ steps.meta.outputs.release_channel }}
+      version_name: ${{ steps.meta.outputs.version_name }}
+      version_code: ${{ steps.meta.outputs.version_code }}
+      apk_name: ${{ steps.meta.outputs.apk_name }}
+      itch_channel: ${{ steps.meta.outputs.itch_channel }}
+      publish_to_itch: ${{ steps.meta.outputs.publish_to_itch }}
+      publish_github_release: ${{ steps.meta.outputs.publish_github_release }}
+      release_name: ${{ steps.meta.outputs.release_name }}
+    steps:
+      - id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+          INPUT_RELEASE_CHANNEL: ${{ inputs.release_channel }}
+          INPUT_VERSION_NAME: ${{ inputs.version_name }}
+          INPUT_VERSION_CODE: ${{ inputs.version_code }}
+          INPUT_PUBLISH_TO_ITCH: ${{ inputs.publish_to_itch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$REF_TYPE" = "tag" ]; then
+            RELEASE_CHANNEL="production"
+            VERSION_NAME="${REF_NAME#v}"
+            VERSION_CODE="$RUN_NUMBER"
+            PUBLISH_TO_ITCH="true"
+            PUBLISH_GITHUB_RELEASE="true"
+            RELEASE_NAME="Android ${VERSION_NAME}"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RELEASE_CHANNEL="$INPUT_RELEASE_CHANNEL"
+            VERSION_NAME="$INPUT_VERSION_NAME"
+            VERSION_CODE="$INPUT_VERSION_CODE"
+            PUBLISH_TO_ITCH="$INPUT_PUBLISH_TO_ITCH"
+            PUBLISH_GITHUB_RELEASE="false"
+            RELEASE_NAME="Android ${VERSION_NAME} (${RELEASE_CHANNEL})"
+          else
+            RELEASE_CHANNEL="internal"
+            VERSION_NAME="0.1.0-main.${RUN_NUMBER}"
+            VERSION_CODE="$RUN_NUMBER"
+            PUBLISH_TO_ITCH="false"
+            PUBLISH_GITHUB_RELEASE="false"
+            RELEASE_NAME="Android internal ${VERSION_NAME}"
+          fi
+
+          case "$RELEASE_CHANNEL" in
+            preview) ITCH_CHANNEL="android-preview" ;;
+            internal) ITCH_CHANNEL="android-internal" ;;
+            production) ITCH_CHANNEL="android-release" ;;
+            *)
+              echo "Unsupported release channel: $RELEASE_CHANNEL"
+              exit 1
+              ;;
+          esac
+
+          echo "$VERSION_CODE" | grep -E '^[0-9]+$' >/dev/null
+          APK_NAME="rummikub-android-${VERSION_NAME}-${RELEASE_CHANNEL}.apk"
+
+          {
+            echo "release_channel=$RELEASE_CHANNEL"
+            echo "version_name=$VERSION_NAME"
+            echo "version_code=$VERSION_CODE"
+            echo "apk_name=$APK_NAME"
+            echo "itch_channel=$ITCH_CHANNEL"
+            echo "publish_to_itch=$PUBLISH_TO_ITCH"
+            echo "publish_github_release=$PUBLISH_GITHUB_RELEASE"
+            echo "release_name=$RELEASE_NAME"
+          } >> "$GITHUB_OUTPUT"
+
+  build-release-apk:
+    name: Build signed release APK
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    outputs:
+      apk_path: ${{ steps.stage.outputs.apk_path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Validate release secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          for secret_name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!secret_name}" ]; then
+              echo "Missing required secret: $secret_name"
+              exit 1
+            fi
+          done
+
+      - name: Decode Android keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > apps/android/app/release.keystore
+
+      - name: Assemble release APK
+        env:
+          ANDROID_KEYSTORE_PATH: apps/android/app/release.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_VERSION_NAME: ${{ needs.prepare-release.outputs.version_name }}
+          ANDROID_VERSION_CODE: ${{ needs.prepare-release.outputs.version_code }}
+        run: ./gradlew :apps:android:app:assembleRelease
+
+      - name: Stage release APK
+        id: stage
+        env:
+          APK_NAME: ${{ needs.prepare-release.outputs.apk_name }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          cp apps/android/app/build/outputs/apk/release/app-release.apk "dist/$APK_NAME"
+          echo "apk_path=dist/$APK_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-apk
+          retention-days: 14
+          path: ${{ steps.stage.outputs.apk_path }}
+
+  publish-github-release:
+    name: Publish GitHub release asset
+    needs: [prepare-release, build-release-apk]
+    if: needs.prepare-release.outputs.publish_github_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download staged APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-release-apk
+          path: dist
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.prepare-release.outputs.release_name }}
+          files: dist/*.apk
+          generate_release_notes: true
+          prerelease: false
+
+  publish-itch:
+    name: Publish APK to Itch.io
+    needs: [prepare-release, build-release-apk]
+    if: needs.prepare-release.outputs.publish_to_itch == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Itch configuration
+        env:
+          ITCH_IO_API_KEY: ${{ secrets.ITCH_IO_API_KEY }}
+          ITCH_IO_USER: ${{ vars.ITCH_IO_USER }}
+          ITCH_IO_GAME: ${{ vars.ITCH_IO_GAME }}
+        run: |
+          set -euo pipefail
+
+          for value_name in ITCH_IO_API_KEY ITCH_IO_USER ITCH_IO_GAME; do
+            if [ -z "${!value_name}" ]; then
+              echo "Missing required Itch configuration: $value_name"
+              exit 1
+            fi
+          done
+
+      - name: Download staged APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-release-apk
+          path: dist
+
+      - name: Install butler
+        run: |
+          set -euo pipefail
+          curl -L -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+          unzip -q butler.zip -d butler-bin
+          chmod +x butler-bin/butler
+
+      - name: Push APK to Itch.io
+        env:
+          BUTLER_API_KEY: ${{ secrets.ITCH_IO_API_KEY }}
+          ITCH_IO_USER: ${{ vars.ITCH_IO_USER }}
+          ITCH_IO_GAME: ${{ vars.ITCH_IO_GAME }}
+          ITCH_CHANNEL: ${{ needs.prepare-release.outputs.itch_channel }}
+        run: |
+          set -euo pipefail
+          ./butler-bin/butler push dist/*.apk "${ITCH_IO_USER}/${ITCH_IO_GAME}:${ITCH_CHANNEL}"
+
+  release-summary:
+    name: Release summary
+    needs:
+      - prepare-release
+      - build-release-apk
+      - publish-github-release
+      - publish-itch
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write release summary
+        env:
+          RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.release_channel }}
+          VERSION_NAME: ${{ needs.prepare-release.outputs.version_name }}
+          VERSION_CODE: ${{ needs.prepare-release.outputs.version_code }}
+          APK_NAME: ${{ needs.prepare-release.outputs.apk_name }}
+          ITCH_CHANNEL: ${{ needs.prepare-release.outputs.itch_channel }}
+          PUBLISH_TO_ITCH: ${{ needs.prepare-release.outputs.publish_to_itch }}
+          GITHUB_RELEASE_RESULT: ${{ needs.publish-github-release.result }}
+          ITCH_RESULT: ${{ needs.publish-itch.result }}
+        run: |
+          {
+            echo "# Android Release Summary"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Release channel | \`$RELEASE_CHANNEL\` |"
+            echo "| Version name | \`$VERSION_NAME\` |"
+            echo "| Version code | \`$VERSION_CODE\` |"
+            echo "| APK | \`$APK_NAME\` |"
+            echo "| Itch channel | \`$ITCH_CHANNEL\` |"
+            echo "| Artifact upload | \`done in build-release-apk\` |"
+            echo "| GitHub release job | \`${GITHUB_RELEASE_RESULT:-skipped}\` |"
+            echo "| Itch publish job | \`${ITCH_RESULT:-skipped}\` |"
+            echo
+            echo "The signed APK is available as the \`android-release-apk\` workflow artifact."
+            echo
+            echo "Tagged releases additionally attach the APK as a GitHub release asset."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -155,6 +155,29 @@ jobs:
     if: needs.prepare-release.outputs.trigger_render_deploy == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tagged backend release matches main before Render deploy
+        if: github.ref_type == 'tag'
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --depth=1
+
+          TAG_SHA="$(git rev-parse HEAD)"
+          MAIN_SHA="$(git rev-parse origin/main)"
+
+          if [ "$TAG_SHA" != "$MAIN_SHA" ]; then
+            echo "Tagged backend release does not match origin/main."
+            echo "Render deploy hooks normally deploy the configured branch, so this tag could drift from the Render deployment target."
+            echo "Tag SHA:  $TAG_SHA"
+            echo "Main SHA: $MAIN_SHA"
+            exit 1
+          fi
+
       - name: Trigger Render deploy
         env:
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -1,0 +1,217 @@
+name: Backend Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_channel:
+        description: "Release channel"
+        required: true
+        default: "internal"
+        type: choice
+        options:
+          - internal
+          - production
+      release_version:
+        description: "Optional product/release version label"
+        required: false
+      trigger_render_deploy:
+        description: "Trigger Render deployment"
+        required: true
+        default: true
+        type: boolean
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+    paths:
+      - "apps/backend/**"
+      - "apps/shared/**"
+      - "gradle/**"
+      - "gradlew"
+      - "gradlew.bat"
+      - "settings.gradle.kts"
+      - "build.gradle.kts"
+      - ".github/workflows/backend-release.yml"
+      - "docs/workflows.md"
+      - "docs/pr-monorepo-release-management.md"
+
+concurrency:
+  group: backend-release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BACKEND_BASE_URL: https://se2-group-codebase.onrender.com
+  HEALTH_URL: https://se2-group-codebase.onrender.com/actuator/health
+
+jobs:
+  prepare-release:
+    name: Prepare backend release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      release_channel: ${{ steps.meta.outputs.release_channel }}
+      release_version: ${{ steps.meta.outputs.release_version }}
+      trigger_render_deploy: ${{ steps.meta.outputs.trigger_render_deploy }}
+      deployment_reason: ${{ steps.meta.outputs.deployment_reason }}
+    steps:
+      - id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+          INPUT_RELEASE_CHANNEL: ${{ inputs.release_channel }}
+          INPUT_RELEASE_VERSION: ${{ inputs.release_version }}
+          INPUT_TRIGGER_RENDER_DEPLOY: ${{ inputs.trigger_render_deploy }}
+        run: |
+          set -euo pipefail
+
+          if [ "$REF_TYPE" = "tag" ]; then
+            RELEASE_CHANNEL="production"
+            RELEASE_VERSION="${REF_NAME#v}"
+            TRIGGER_RENDER_DEPLOY="true"
+            DEPLOYMENT_REASON="tagged product release"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RELEASE_CHANNEL="$INPUT_RELEASE_CHANNEL"
+            RELEASE_VERSION="${INPUT_RELEASE_VERSION:-0.1.0-manual.${RUN_NUMBER}}"
+            TRIGGER_RENDER_DEPLOY="$INPUT_TRIGGER_RENDER_DEPLOY"
+            DEPLOYMENT_REASON="manual backend release run"
+          else
+            RELEASE_CHANNEL="internal"
+            RELEASE_VERSION="0.1.0-main.${RUN_NUMBER}"
+            TRIGGER_RENDER_DEPLOY="true"
+            DEPLOYMENT_REASON="main branch deployment"
+          fi
+
+          {
+            echo "release_channel=$RELEASE_CHANNEL"
+            echo "release_version=$RELEASE_VERSION"
+            echo "trigger_render_deploy=$TRIGGER_RENDER_DEPLOY"
+            echo "deployment_reason=$DEPLOYMENT_REASON"
+          } >> "$GITHUB_OUTPUT"
+
+  build-backend:
+    name: Build backend release candidate
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    outputs:
+      jar_path: ${{ steps.stage.outputs.jar_path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Run backend tests
+        run: ./gradlew :apps:backend:test
+
+      - name: Build backend boot jar
+        run: ./gradlew :apps:backend:bootJar
+
+      - name: Stage backend jar artifact
+        id: stage
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          JAR_SOURCE="$(find apps/backend/build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*plain*.jar' | head -n 1)"
+
+          if [ -z "$JAR_SOURCE" ]; then
+            echo "No backend release jar found"
+            exit 1
+          fi
+
+          JAR_TARGET="dist/se2-backend-${RELEASE_VERSION}.jar"
+          cp "$JAR_SOURCE" "$JAR_TARGET"
+          echo "jar_path=$JAR_TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Upload backend release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-release-jar
+          retention-days: 14
+          path: ${{ steps.stage.outputs.jar_path }}
+
+  deploy-render:
+    name: Deploy backend to Render
+    needs: [prepare-release, build-backend]
+    if: needs.prepare-release.outputs.trigger_render_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Missing required secret: RENDER_DEPLOY_HOOK_URL"
+            exit 1
+          fi
+
+          curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"
+
+      - name: Wait for deployed backend health
+        run: |
+          set -euo pipefail
+
+          for i in {1..36}; do
+            if curl -fsS "$HEALTH_URL"; then
+              echo "Backend is healthy"
+              exit 0
+            fi
+
+            echo "Waiting for Render deployment to become healthy..."
+            sleep 10
+          done
+
+          echo "Backend did not become healthy in time"
+          exit 1
+
+  release-summary:
+    name: Backend release summary
+    needs:
+      - prepare-release
+      - build-backend
+      - deploy-render
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write backend release summary
+        env:
+          RELEASE_CHANNEL: ${{ needs.prepare-release.outputs.release_channel }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.release_version }}
+          DEPLOYMENT_REASON: ${{ needs.prepare-release.outputs.deployment_reason }}
+          RENDER_RESULT: ${{ needs.deploy-render.result }}
+        run: |
+          {
+            echo "# Backend Release Summary"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Release channel | \`$RELEASE_CHANNEL\` |"
+            echo "| Release version | \`$RELEASE_VERSION\` |"
+            echo "| Reason | $DEPLOYMENT_REASON |"
+            echo "| Backend artifact | \`backend-release-jar\` |"
+            echo "| Render deployment job | \`${RENDER_RESULT:-skipped}\` |"
+            echo "| Health endpoint | \`$HEALTH_URL\` |"
+            echo
+            echo "The backend release candidate jar is available as the \`backend-release-jar\` workflow artifact."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.declarativedsl.language.FunctionArgument
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -14,6 +12,10 @@ jacoco {
     toolVersion = "0.8.11"
 }
 
+fun env(name: String): String? = System.getenv(name)
+
+val ciVersionCode = env("ANDROID_VERSION_CODE")?.toIntOrNull()
+val ciVersionName = env("ANDROID_VERSION_NAME")
 
 android {
     namespace = "at.aau.serg.android"
@@ -23,10 +25,27 @@ android {
         applicationId = "at.aau.serg.android"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = ciVersionCode ?: 1
+        versionName = ciVersionName ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        create("ciRelease") {
+            env("ANDROID_KEYSTORE_PATH")?.let { path ->
+                storeFile = file(path)
+            }
+            env("ANDROID_KEYSTORE_PASSWORD")?.let { password ->
+                storePassword = password
+            }
+            env("ANDROID_KEY_ALIAS")?.let { alias ->
+                keyAlias = alias
+            }
+            env("ANDROID_KEY_PASSWORD")?.let { password ->
+                keyPassword = password
+            }
+        }
     }
 
     buildTypes {
@@ -40,6 +59,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+
+            if (env("ANDROID_KEYSTORE_PATH") != null) {
+                signingConfig = signingConfigs.getByName("ciRelease")
+            }
         }
     }
     testOptions {

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -329,7 +329,7 @@ and repository variables for:
 
 The detailed operator instructions live in:
 
-- [release-management.md](/Users/julianblaschke/Desktop/se2-group-codebase/docs/release-management.md)
+- [release-management.md](release-management.md)
 
 ---
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,12 +7,14 @@
 
 [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=se2-gruppenprojekt_se2-group-codebase_backend)
 
-This document explains the three GitHub Actions workflows used in the
+This document explains the main GitHub Actions workflows used in the
 repository:
 
 - backend
 - android frontend
 - shared
+- android release management
+- backend release management
 
 It first documents what they have in common, then describes each workflow on
 its own with its current implementation details.
@@ -152,7 +154,7 @@ not a good required-status surface.
 
 ## 3. Shared Differences
 
-Although the three workflows share the same overall shape, they differ in the
+Although the three validation workflows share the same overall shape, they differ in the
 build and Sonar execution details:
 
 - backend uses Gradle’s Sonar task directly
@@ -258,6 +260,146 @@ Source file:
 Workflow name:
 
 - `Frontend CI`
+
+This workflow remains the normal Android validation workflow:
+
+- unit tests
+- coverage generation
+- Sonar analysis
+
+It does **not** handle release distribution.
+
+---
+
+## 6. Android Release Workflow
+
+Source file:
+
+- `.github/workflows/android-release.yml`
+
+Workflow name:
+
+- `Android Release`
+
+This workflow is separate from normal Android CI because it deals with:
+
+- release signing
+- downloadable APK artifacts
+- GitHub release assets
+- Itch.io publication
+
+### 6.1 Trigger model
+
+The workflow supports:
+
+- manual runs through `workflow_dispatch`
+- pushes to `main`
+- pushes of tags matching `v*`
+
+The trigger model is intentionally broader than the validation workflow because
+release management is operational rather than purely test-oriented.
+
+### 6.2 Responsibilities
+
+The workflow:
+
+1. derives release metadata such as:
+   - release channel
+   - version name
+   - version code
+   - APK file name
+2. decodes the Android keystore from repository secrets
+3. builds a signed `assembleRelease` APK
+4. uploads the APK as the `android-release-apk` artifact
+5. attaches the APK to GitHub releases for tagged runs
+6. optionally pushes the APK to Itch.io using `butler`
+7. writes a workflow summary with the release metadata
+
+### 6.3 Secrets and variables
+
+The workflow depends on repository secrets for:
+
+- Android signing
+- Itch publishing
+
+and repository variables for:
+
+- `ITCH_IO_USER`
+- `ITCH_IO_GAME`
+
+The detailed operator instructions live in:
+
+- [release-management.md](/Users/julianblaschke/Desktop/se2-group-codebase/docs/release-management.md)
+
+---
+
+## 7. Backend Release Workflow
+
+Source file:
+
+- `.github/workflows/backend-release.yml`
+
+Workflow name:
+
+- `Backend Release`
+
+This workflow is the backend deployment counterpart to the Android release
+workflow.
+
+It is intentionally separate from:
+
+- `backend.yml`, which is validation CI
+- `android-release.yml`, which is APK distribution
+
+### 7.1 Trigger model
+
+The workflow supports:
+
+- manual runs through `workflow_dispatch`
+- pushes to `main`
+- pushes of tags matching `v*`
+
+That means the repository can support both:
+
+- continuous backend deployment on mainline changes
+- coordinated official product releases on tags
+
+### 7.2 Responsibilities
+
+The workflow:
+
+1. derives backend release metadata such as:
+   - release channel
+   - release version
+   - deployment reason
+2. runs backend tests
+3. builds the backend `bootJar`
+4. uploads the resulting jar as the `backend-release-jar` artifact
+5. triggers the configured Render deploy hook
+6. waits for the deployed backend to become healthy via `/actuator/health`
+7. writes a workflow summary
+
+### 7.3 Required secret
+
+The workflow depends on:
+
+```text
+RENDER_DEPLOY_HOOK_URL
+```
+
+### 7.4 Relationship to monorepo release management
+
+The backend release workflow should usually be read together with:
+
+- [android-release.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/android-release.yml)
+
+Those two workflows form the repository’s release-management layer:
+
+- backend workflow handles deployment
+- Android workflow handles APK distribution
+
+They stay operationally separate, but can be coordinated by the same
+product/release tag.
 
 ### 5.1 Change scope
 


### PR DESCRIPTION
# PR Description: Release Management

![Monorepo](https://img.shields.io/badge/Scope-Monorepo-0f172a)
![Backend](https://img.shields.io/badge/Surface-Backend-1d4ed8) ![Android](https://img.shields.io/badge/Surface-Android-15803d)
![Release Management](https://img.shields.io/badge/Domain-Release%20Management-7c3aed) ![Status](https://img.shields.io/badge/PR-Implementation%20Summary-9333ea)

## Summary

This PR introduces the first full release-management layer for the monorepo. (see #811 full docs)

It adds:

- a dedicated **Android release workflow** for signed APK generation
- a dedicated **backend release workflow** for Render deployment
- CI-driven Android versioning and signing support
- downloadable GitHub Actions artifacts for both release surfaces
- GitHub release asset support for tagged Android releases
- optional **Itch.io** APK publishing
- repository documentation for operator setup and the coordinated monorepo release model

The core design decision is to treat the repository as **one product with
multiple deliverables**:

- **Android app** -> signed APK distribution
- **Spring Boot backend** -> deployment to Render

These two deliverables are coordinated at the release/version level, but they
remain operationally separate.

### Linked Issues

- Closes #801 
- Closes #802 
- Closes #803 
- Closes #804 
- Closes #805 
- Closes #806 
- Closes #807 
- Closes #808 
- Closes #809 
- Closes #810 

---

## What this PR changes

### Android release management

The Android app now supports CI-driven release metadata and signing through:

- [build.gradle.kts](/Users/julianblaschke/Desktop/se2-group-codebase/apps/android/app/build.gradle.kts)

The new Android release workflow:

- [android-release.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/android-release.yml)

adds:

- `workflow_dispatch` support for manual APK releases
- `main` branch internal build support
- `v*` tag support for official APK releases
- signed `assembleRelease` builds
- deterministic APK naming
- artifact upload through `android-release-apk`
- GitHub release asset upload for tagged releases
- optional Itch.io publishing through `butler`

### Backend release management

The backend now has a separate release/deploy workflow:

- [backend-release.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/backend-release.yml)

This workflow:

- supports manual release runs
- supports `main` branch deployment
- supports `v*` tagged releases
- runs backend tests
- builds the backend `bootJar`
- uploads a backend release jar artifact
- triggers the Render deploy hook
- waits for `/actuator/health` before reporting success

### Documentation

This PR also adds the release-management documentation needed to operate the
new workflows:

- [release-management.md](/Users/julianblaschke/Desktop/se2-group-codebase/docs/release-management.md)
- [pr-monorepo-release-management.md](/Users/julianblaschke/Desktop/se2-group-codebase/docs/pr-monorepo-release-management.md)
- [workflows.md](/Users/julianblaschke/Desktop/se2-group-codebase/docs/workflows.md)

---

## Why this structure was chosen

This PR intentionally does **not** try to collapse Android and backend releases
into one combined artifact or one giant workflow.

That would be the wrong operational model for this repository because:

- the Android app is a downloadable user-facing binary
- the backend is a deployed server application
- signing, secrets, deployment targets, and rollback paths are different

Instead, the workflows are separated by deliverable but can still be aligned
through a shared product version tag such as:

```text
v1.2.0
```

That gives the team:

- clean release boundaries
- simpler debugging
- safer rollout behavior
- a coherent monorepo release story

---

## Release model after this PR

### Normal development flow

- `backend.yml` continues to handle backend validation CI
- `android.yml` continues to handle Android validation CI
- `shared.yml` continues to handle shared-module validation CI

### Internal / operational release flow

- backend can deploy from `main`
- Android preview/internal APKs can be generated manually

### Official product release flow

When the team creates a tag like:

```text
vX.Y.Z
```

the intended model is:

- backend release workflow deploys the tagged backend revision
- Android release workflow builds the matching tagged APK
- GitHub release notes become the shared product release record

---

## Secrets and configuration required

### Android release

Required secrets:

```text
ANDROID_KEYSTORE_BASE64
ANDROID_KEYSTORE_PASSWORD
ANDROID_KEY_ALIAS
ANDROID_KEY_PASSWORD
ITCH_IO_API_KEY
```

Required variables:

```text
ITCH_IO_USER
ITCH_IO_GAME
```

### Backend release

Required secret:

```text
RENDER_DEPLOY_HOOK_URL
```

---

## In scope

- Android APK release automation
- backend Render deployment workflow
- GitHub-hosted downloadable release artifacts
- optional Itch.io publication
- monorepo release documentation

## Out of scope

- Google Play Store publishing
- AAB release flow
- one combined backend+Android release artifact
- forced GitHub Packages registry use for APKs
- fully automated semantic version generation

---

## Validation performed

The implementation was validated locally for:

- workflow YAML correctness
- file hygiene via `git diff --check`

The workflows still require real repository secrets and live GitHub Actions
runs for full end-to-end verification.

---

## Suggested rollout

1. add the required GitHub secrets and variables
2. test the Android release workflow with a preview manual run
3. test the backend release workflow with an internal manual run
4. verify Render deployment and APK artifact output
5. test one shared tagged release flow

---

## Short PR close

This PR gives the repository a real release-management layer for both main
product surfaces. Android distribution and backend deployment are now handled
through explicit workflows, while the docs explain how to operate them and how
to coordinate them as one product release in the monorepo.
