### PR TITLE
feat(backend)(game): track per-player match metrics for result screen

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
@@ -17,6 +17,10 @@ import at.se2group.backend.persistence.TileEmbeddable
 import shared.models.game.domain.GamePlayerMetrics
 import shared.models.game.response.GamePlayerMetricsResponse
 
+/**
+ * Mapping extensions between persistence entities, domain models and API response models.
+ */
+
 fun GameEntity.toDomain(): ConfirmedGame =
     ConfirmedGame(
         gameId = gameId,

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
@@ -15,6 +15,7 @@ import at.se2group.backend.persistence.GameEntity
 import at.se2group.backend.persistence.GamePlayerEntity
 import at.se2group.backend.persistence.TileEmbeddable
 import shared.models.game.domain.GamePlayerMetrics
+import shared.models.game.response.GamePlayerMetricsResponse
 
 fun GameEntity.toDomain(): ConfirmedGame =
     ConfirmedGame(
@@ -150,7 +151,9 @@ fun ConfirmedGame.toResponse(): GameResponse =
         status = status.name,
         createdAt = createdAt.toString(),
         startedAt = startedAt?.toString(),
-        finishedAt = finishedAt?.toString()
+        finishedAt = finishedAt?.toString(),
+        totalTurnsCompleted = totalTurnsCompleted,
+        winnerUserId = winnerUserId
     )
 
 fun GamePlayer.toResponse(): GamePlayerResponse =
@@ -161,7 +164,8 @@ fun GamePlayer.toResponse(): GamePlayerResponse =
         rackTiles = rackTiles.map { it.toResponse() },
         hasCompletedInitialMeld = hasCompletedInitialMeld,
         score = score,
-        joinedAt = joinedAt.toString()
+        joinedAt = joinedAt.toString(),
+        metrics = metrics.toResponse()
     )
 
 fun BoardSet.toResponse(): BoardSetResponse =
@@ -186,3 +190,15 @@ fun Tile.toResponse(): TileResponse =
             isJoker = false
         )
     }
+
+fun GamePlayerMetrics.toResponse(): GamePlayerMetricsResponse =
+    GamePlayerMetricsResponse(
+        turnsCompleted = turnsCompleted,
+        tilesPlayed = tilesPlayed,
+        meldsCreated = meldsCreated,
+        pointsPlayed = pointsPlayed,
+        tilesRemainingAtEnd = tilesRemainingAtEnd,
+        penaltyPointsAtEnd = penaltyPointsAtEnd,
+        winner = winner,
+        finishPosition = finishPosition
+    )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/GameMapper.kt
@@ -14,6 +14,7 @@ import at.se2group.backend.persistence.BoardSetEntity
 import at.se2group.backend.persistence.GameEntity
 import at.se2group.backend.persistence.GamePlayerEntity
 import at.se2group.backend.persistence.TileEmbeddable
+import shared.models.game.domain.GamePlayerMetrics
 
 fun GameEntity.toDomain(): ConfirmedGame =
     ConfirmedGame(
@@ -26,7 +27,9 @@ fun GameEntity.toDomain(): ConfirmedGame =
         status = status,
         createdAt = createdAt,
         startedAt = startedAt,
-        finishedAt = finishedAt
+        finishedAt = finishedAt,
+        totalTurnsCompleted = totalTurnsCompleted,
+        winnerUserId = winnerUserId
     )
 
 fun ConfirmedGame.toEntity(): GameEntity {
@@ -38,7 +41,9 @@ fun ConfirmedGame.toEntity(): GameEntity {
         createdAt = createdAt,
         startedAt = startedAt,
         finishedAt = finishedAt,
-        drawPile = drawPile.map { it.toEmbeddable() }.toMutableList()
+        drawPile = drawPile.map { it.toEmbeddable() }.toMutableList(),
+        totalTurnsCompleted = totalTurnsCompleted,
+        winnerUserId = winnerUserId
     )
 
     gameEntity.players = players.map { it.toEntity(gameEntity) }.toMutableList()
@@ -55,7 +60,17 @@ fun GamePlayerEntity.toDomain(): GamePlayer =
         rackTiles = rackTiles.map { it.toDomain() },
         hasCompletedInitialMeld = hasCompletedInitialMeld,
         score = score,
-        joinedAt = joinedAt
+        joinedAt = joinedAt,
+        metrics = GamePlayerMetrics(
+            turnsCompleted = turnsCompleted,
+            tilesPlayed = tilesPlayed,
+            meldsCreated = meldsCreated,
+            pointsPlayed = pointsPlayed,
+            tilesRemainingAtEnd = tilesRemainingAtEnd,
+            penaltyPointsAtEnd = penaltyPointsAtEnd,
+            winner = winner,
+            finishPosition = finishPosition
+        )
     )
 
 fun GamePlayer.toEntity(game: GameEntity): GamePlayerEntity =
@@ -67,7 +82,15 @@ fun GamePlayer.toEntity(game: GameEntity): GamePlayerEntity =
         rackTiles = rackTiles.map { it.toEmbeddable() }.toMutableList(),
         hasCompletedInitialMeld = hasCompletedInitialMeld,
         score = score,
-        joinedAt = joinedAt
+        joinedAt = joinedAt,
+        turnsCompleted = metrics.turnsCompleted,
+        tilesPlayed = metrics.tilesPlayed,
+        meldsCreated = metrics.meldsCreated,
+        pointsPlayed = metrics.pointsPlayed,
+        tilesRemainingAtEnd = metrics.tilesRemainingAtEnd,
+        penaltyPointsAtEnd = metrics.penaltyPointsAtEnd,
+        winner = metrics.winner,
+        finishPosition = metrics.finishPosition
     )
 
 fun BoardSetEntity.toDomain(): BoardSet =

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
@@ -41,6 +41,12 @@ class GameEntity(
     @Column(name = "finished_at")
     var finishedAt: Instant? = null,
 
+    @Column(name = "total_turns_completed", nullable = false)
+    var totalTurnsCompleted: Int = 0,
+
+    @Column(name = "winner_user_id")
+    var winnerUserId: String? = null,
+
     @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
     @OrderColumn(name = "player_order")
     var players: MutableList<GamePlayerEntity> = mutableListOf(),

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GameEntity.kt
@@ -15,6 +15,14 @@ import jakarta.persistence.OrderColumn
 import jakarta.persistence.Table
 import java.time.Instant
 
+/**
+ * JPA persistence model for a game.
+ *
+ * Stores the complete game state including players, board sets, draw pile,
+ * turn information and aggregated game metrics. The entity is mapped to the
+ * `games` table and acts as the root aggregate for all game-related data.
+ */
+
 @Entity
 @Table(name = "games")
 class GameEntity(
@@ -41,20 +49,39 @@ class GameEntity(
     @Column(name = "finished_at")
     var finishedAt: Instant? = null,
 
+    /**
+     * Total number of completed turns across the entire game.
+     */
     @Column(name = "total_turns_completed", nullable = false)
     var totalTurnsCompleted: Int = 0,
 
+    /**
+     * User id of the winning player once the game has finished.
+     */
     @Column(name = "winner_user_id")
     var winnerUserId: String? = null,
 
+    /**
+     * Players participating in the game.
+     *
+     * The persisted order corresponds to the players' turn order.
+     */
     @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
     @OrderColumn(name = "player_order")
     var players: MutableList<GamePlayerEntity> = mutableListOf(),
 
+    /**
+     * Current board sets in display order.
+     */
     @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL], orphanRemoval = true)
     @OrderColumn(name = "board_set_order")
     var boardSets: MutableList<BoardSetEntity> = mutableListOf(),
 
+    /**
+     * Remaining draw pile.
+     *
+     * Order is significant because tiles are drawn from the front of the pile.
+     */
     @ElementCollection
     @CollectionTable(name = "game_draw_pile_tiles", joinColumns = [JoinColumn(name = "game_id")])
     @OrderColumn(name = "draw_pile_order")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
@@ -14,6 +14,12 @@ import jakarta.persistence.OrderColumn
 import jakarta.persistence.Table
 import java.time.Instant
 
+/**
+ * JPA persistence model for a player participating in a game.
+ *
+ * Stores both the mutable game state of the player (rack, score, meld status)
+ * and the aggregated gameplay metrics used for post-game statistics.
+ */
 @Entity
 @Table(name= "game_players")
 class GamePlayerEntity(
@@ -43,30 +49,62 @@ class GamePlayerEntity(
     @Column(name = "joined_at", nullable = false)
     var joinedAt: Instant = Instant.now(),
 
+    /**
+     * Number of completed turns taken by this player.
+     */
     @Column(name = "turns_completed", nullable = false)
     var turnsCompleted: Int = 0,
 
+    /**
+     * Number of tiles played from the rack onto the board.
+     */
     @Column(name = "tiles_played", nullable = false)
     var tilesPlayed: Int = 0,
 
+    /**
+     * Number of newly created board sets.
+     *
+     * Modifying or extending existing board sets does not increase this metric.
+     */
     @Column(name = "melds_created", nullable = false)
     var meldsCreated: Int = 0,
 
+    /**
+     * Sum of tile values played from the rack.
+     *
+     * Joker handling follows the metric scoring rules rather than end-game penalty rules.
+     */
     @Column(name = "points_played", nullable = false)
     var pointsPlayed: Int = 0,
 
+    /**
+     * Number of tiles remaining in the player's rack when the game ended.
+     */
     @Column(name = "tiles_remaining_at_end")
     var tilesRemainingAtEnd: Int? = null,
 
+    /**
+     * End-game penalty score derived from the remaining rack tiles.
+     */
     @Column(name = "penalty_points_at_end")
     var penaltyPointsAtEnd: Int? = null,
 
     @Column(name = "winner", nullable = false)
     var winner: Boolean = false,
 
+    /**
+     * Final ranking position after game completion.
+     *
+     * A value of 1 indicates the winner.
+     */
     @Column(name = "finish_position")
     var finishPosition: Int? = null,
 
+    /**
+     * Tiles currently held by the player.
+     *
+     * The persisted order matches the rack order shown in the UI.
+     */
     @ElementCollection
     @CollectionTable(name = "game_player_rack_tiles", joinColumns = [JoinColumn(name = "game_player_id")])
     @OrderColumn(name = "rack_tile_order")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/GamePlayerEntity.kt
@@ -43,6 +43,30 @@ class GamePlayerEntity(
     @Column(name = "joined_at", nullable = false)
     var joinedAt: Instant = Instant.now(),
 
+    @Column(name = "turns_completed", nullable = false)
+    var turnsCompleted: Int = 0,
+
+    @Column(name = "tiles_played", nullable = false)
+    var tilesPlayed: Int = 0,
+
+    @Column(name = "melds_created", nullable = false)
+    var meldsCreated: Int = 0,
+
+    @Column(name = "points_played", nullable = false)
+    var pointsPlayed: Int = 0,
+
+    @Column(name = "tiles_remaining_at_end")
+    var tilesRemainingAtEnd: Int? = null,
+
+    @Column(name = "penalty_points_at_end")
+    var penaltyPointsAtEnd: Int? = null,
+
+    @Column(name = "winner", nullable = false)
+    var winner: Boolean = false,
+
+    @Column(name = "finish_position")
+    var finishPosition: Int? = null,
+
     @ElementCollection
     @CollectionTable(name = "game_player_rack_tiles", joinColumns = [JoinColumn(name = "game_player_id")])
     @OrderColumn(name = "rack_tile_order")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -21,7 +21,8 @@ class EndTurnService(
     private val gameService: GameService,
     private val rummikubRuleService: RummikubRuleService,
     private val gameBroadcastService: GameBroadcastService,
-    private val afterCommitExecutor: AfterCommitExecutor
+    private val afterCommitExecutor: AfterCommitExecutor,
+    private val gameMetricsService: GameMetricsService
 ) {
     private companion object {
         const val GAME_NOT_FOUND = "Game not found"
@@ -60,11 +61,24 @@ class EndTurnService(
             throw InvalidTurnSubmissionException(validation)
         }
 
-        val resolvedGame = commitDraftToConfirmedGame(game, submittedDraft)
-            .finishIfWinnerExists(userId)
+        val committedGame = commitDraftToConfirmedGame(game, submittedDraft)
 
-        if (resolvedGame.status == GameStatus.FINISHED) {
-            val savedGame = gameRepository.save(resolvedGame.toEntity()).toDomain()
+        val gameWithMetrics = gameMetricsService.applyCommittedTurnMetrics(
+            confirmedBeforeTurn = game,
+            committedGame = committedGame,
+            actingPlayerUserId = userId
+        )
+
+        val resolvedGame = gameWithMetrics.finishIfWinnerExists(userId)
+
+        val finalizedGame = if (resolvedGame.status == GameStatus.FINISHED) {
+            gameMetricsService.finalizeEndGameMetrics(resolvedGame)
+        } else {
+            resolvedGame
+        }
+
+        if (finalizedGame.status == GameStatus.FINISHED) {
+            val savedGame = gameRepository.save(finalizedGame.toEntity()).toDomain()
 
             turnDraftRepository.deleteById(gameId)
 
@@ -76,8 +90,8 @@ class EndTurnService(
             return savedGame
         }
 
-        val nextPlayerId = gameService.nextPlayerId(resolvedGame)
-        val advancedGame = resolvedGame.copy(currentPlayerUserId = nextPlayerId)
+        val nextPlayerId = gameService.nextPlayerId(finalizedGame)
+        val advancedGame = finalizedGame.copy(currentPlayerUserId = nextPlayerId)
         val savedGame = gameRepository.save(advancedGame.toEntity()).toDomain()
 
         val nextDraft = createNextDraft(savedGame)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -13,6 +13,14 @@ import shared.models.game.domain.TurnDraft
 import shared.models.game.request.EndTurnRequest
 import java.time.Instant
 
+/**
+ * Handles turn completion for active games.
+ *
+ * The service validates the submitted draft, applies the changes to the
+ * confirmed game state, updates gameplay metrics, determines whether the game
+ * has finished, advances the turn if necessary and broadcasts the resulting
+ * game state changes.
+ */
 @Service
 @Transactional(readOnly = true)
 class EndTurnService(
@@ -32,6 +40,12 @@ class EndTurnService(
         const val NOT_DRAFT_OWNER = "Draft belongs to a different user"
     }
 
+    /**
+     * Validates and commits the current player's draft.
+     *
+     * If the submitted turn is valid, gameplay metrics are updated and the game
+     * either advances to the next player or is finalized if a winner exists.
+     */
     @Transactional
     fun endTurn(
         gameId: String,
@@ -63,6 +77,8 @@ class EndTurnService(
 
         val committedGame = commitDraftToConfirmedGame(game, submittedDraft)
 
+        // Turn metrics are recorded before potential game finalization so the
+        // winning move is included in the aggregated statistics.
         val gameWithMetrics = gameMetricsService.applyCommittedTurnMetrics(
             confirmedBeforeTurn = game,
             committedGame = committedGame,
@@ -108,6 +124,12 @@ class EndTurnService(
         return savedGame
     }
 
+    /**
+     * Applies the submitted draft to the confirmed game state.
+     *
+     * The acting player's rack and the board configuration are taken from the
+     * validated draft.
+     */
     private fun commitDraftToConfirmedGame(
         confirmedGame: ConfirmedGame,
         draft: TurnDraft
@@ -126,6 +148,12 @@ class EndTurnService(
         )
     }
 
+    /**
+     * Marks the game as finished when the acting player has emptied their rack.
+     *
+     * Winner determination and end-game metric calculation are performed
+     * separately after the game has been marked as finished.
+     */
     private fun ConfirmedGame.finishIfWinnerExists(
         actingPlayerUserId: String,
         finishedAt: Instant = Instant.now()
@@ -147,6 +175,10 @@ class EndTurnService(
             .isEmpty()
     }
 
+    /**
+     * Creates a fresh draft for the next active player based on the current
+     * confirmed game state.
+     */
     private fun createNextDraft(game: ConfirmedGame): TurnDraft {
         val nextPlayer = game.players.first { it.userId == game.currentPlayerUserId }
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
@@ -1,0 +1,100 @@
+package at.se2group.backend.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.JokerTile
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.Tile
+import java.time.Instant
+
+@Service
+class GameMetricsService {
+    fun applyCommittedTurnMetrics(
+        confirmedBeforeTurn: ConfirmedGame,
+        committedGame: ConfirmedGame,
+        actingPlayerUserId: String
+    ): ConfirmedGame {
+        val beforePlayer = confirmedBeforeTurn.players.first { it.userId == actingPlayerUserId }
+        val afterPlayer = committedGame.players.first { it.userId == actingPlayerUserId }
+
+        val afterRackTileIds = afterPlayer.rackTiles.map { it.tileId }.toSet()
+        val playedTiles = beforePlayer.rackTiles.filter { it.tileId !in afterRackTileIds }
+
+        val previousBoardSetIds = confirmedBeforeTurn.boardSets.map { it.boardSetId }.toSet()
+        val meldsCreated = committedGame.boardSets.count { it.boardSetId !in previousBoardSetIds }
+
+        val updatedPlayers = committedGame.players.map { player ->
+            if (player.userId != actingPlayerUserId) {
+                player
+            } else {
+                player.copy(
+                    metrics = player.metrics.copy(
+                        turnsCompleted = player.metrics.turnsCompleted + 1,
+                        tilesPlayed = player.metrics.tilesPlayed + playedTiles.size,
+                        meldsCreated = player.metrics.meldsCreated + meldsCreated,
+                        pointsPlayed = player.metrics.pointsPlayed + playedTiles.sumOf { metricPointValue(it) }
+                    )
+                )
+            }
+        }
+
+        return committedGame.copy(
+            players = updatedPlayers,
+            totalTurnsCompleted = committedGame.totalTurnsCompleted + 1
+        )
+    }
+
+    fun finalizeEndGameMetrics(game: ConfirmedGame): ConfirmedGame {
+        val winnerUserId = game.winnerUserId ?: determineWinnerUserId(game)
+
+        val rankedPlayers = game.players
+            .sortedWith(
+                compareBy<GamePlayer> { if (it.userId == winnerUserId) 0 else 1 }
+                    .thenBy { it.rackTiles.sumOf(::tilePenaltyValue) }
+                    .thenBy { it.turnOrder }
+            )
+
+        val finishPositionsByUserId = rankedPlayers
+            .mapIndexed { index, player -> player.userId to index + 1 }
+            .toMap()
+
+        val updatedPlayers = game.players.map { player ->
+            val penalty = player.rackTiles.sumOf(::tilePenaltyValue)
+
+            player.copy(
+                metrics = player.metrics.copy(
+                    tilesRemainingAtEnd = player.rackTiles.size,
+                    penaltyPointsAtEnd = penalty,
+                    winner = player.userId == winnerUserId,
+                    finishPosition = finishPositionsByUserId[player.userId]
+                )
+            )
+        }
+
+        return game.copy(
+            players = updatedPlayers,
+            winnerUserId = winnerUserId,
+            finishedAt = game.finishedAt ?: Instant.now()
+        )
+    }
+
+    private fun determineWinnerUserId(game: ConfirmedGame): String {
+        return game.players
+            .firstOrNull { it.rackTiles.isEmpty() }
+            ?.userId
+            ?: game.currentPlayerUserId
+    }
+
+    private fun metricPointValue(tile: Tile): Int =
+        when (tile) {
+            is NumberedTile -> tile.number
+            is JokerTile -> 0
+        }
+
+    private fun tilePenaltyValue(tile: Tile): Int =
+        when (tile) {
+            is NumberedTile -> tile.number
+            is JokerTile -> 30
+        }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
@@ -80,10 +80,12 @@ class GameMetricsService {
     }
 
     private fun determineWinnerUserId(game: ConfirmedGame): String {
-        return game.players
-            .firstOrNull { it.rackTiles.isEmpty() }
-            ?.userId
-            ?: game.currentPlayerUserId
+        return requireNotNull(
+            game.winnerUserId
+                ?: game.players.firstOrNull { it.rackTiles.isEmpty() }?.userId
+        ) {
+            "Expected finished game to have either winnerUserId set or a player with an empty rack"
+        }
     }
 
     private fun metricPointValue(tile: Tile): Int =

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
@@ -88,12 +88,20 @@ class GameMetricsService {
         }
     }
 
+    /**
+     * Point value used for gameplay metrics (e.g. pointsPlayed).
+     * Jokers contribute 0 points because they do not have an intrinsic number value.
+     */
     private fun metricPointValue(tile: Tile): Int =
         when (tile) {
             is NumberedTile -> tile.number
             is JokerTile -> 0
         }
 
+    /**
+     * Penalty value used for end-game scoring.
+     * Jokers count as 30 penalty points according to the game rules.
+     */
     private fun tilePenaltyValue(tile: Tile): Int =
         when (tile) {
             is NumberedTile -> tile.number

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
@@ -22,6 +22,9 @@ class GameMetricsService {
         val playedTiles = beforePlayer.rackTiles.filter { it.tileId !in afterRackTileIds }
 
         val previousBoardSetIds = confirmedBeforeTurn.boardSets.map { it.boardSetId }.toSet()
+
+        // A meld is counted only when a new board set is introduced.
+        // Rearranging or extending existing board sets does not increase this metric.
         val meldsCreated = committedGame.boardSets.count { it.boardSetId !in previousBoardSetIds }
 
         val updatedPlayers = committedGame.players.map { player ->

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameMetricsService.kt
@@ -8,8 +8,24 @@ import shared.models.game.domain.NumberedTile
 import shared.models.game.domain.Tile
 import java.time.Instant
 
+/**
+ * Calculates and aggregates player and game metrics used for post-game
+ * statistics and result screens.
+ *
+ * Metrics are updated incrementally when a turn is committed and finalized
+ * once a game has ended.
+ */
 @Service
 class GameMetricsService {
+    /**
+     * Updates gameplay metrics for the player who committed a valid turn.
+     *
+     * Tracks:
+     * - completed turns
+     * - tiles played from the rack
+     * - newly created board sets
+     * - points contributed by played tiles
+     */
     fun applyCommittedTurnMetrics(
         confirmedBeforeTurn: ConfirmedGame,
         committedGame: ConfirmedGame,
@@ -19,6 +35,8 @@ class GameMetricsService {
         val afterPlayer = committedGame.players.first { it.userId == actingPlayerUserId }
 
         val afterRackTileIds = afterPlayer.rackTiles.map { it.tileId }.toSet()
+        // Tiles played during the turn are determined by comparing the acting
+        // player's rack before and after the committed draft.
         val playedTiles = beforePlayer.rackTiles.filter { it.tileId !in afterRackTileIds }
 
         val previousBoardSetIds = confirmedBeforeTurn.boardSets.map { it.boardSetId }.toSet()
@@ -48,9 +66,17 @@ class GameMetricsService {
         )
     }
 
+    /**
+     * Computes end-game metrics and final rankings.
+     *
+     * Determines the winner, calculates remaining rack penalties, assigns finish
+     * positions and populates result-screen statistics.
+     */
     fun finalizeEndGameMetrics(game: ConfirmedGame): ConfirmedGame {
         val winnerUserId = game.winnerUserId ?: determineWinnerUserId(game)
 
+        // Winner always ranks first. Remaining players are ranked by ascending
+        // penalty points with turn order used as a deterministic tie-breaker.
         val rankedPlayers = game.players
             .sortedWith(
                 compareBy<GamePlayer> { if (it.userId == winnerUserId) 0 else 1 }
@@ -82,6 +108,12 @@ class GameMetricsService {
         )
     }
 
+    /**
+     * Resolves the winner of a finished game.
+     *
+     * A finished game is expected to either explicitly store a winner or have a
+     * player with an empty rack from which the winner can be derived.
+     */
     private fun determineWinnerUserId(game: ConfirmedGame): String {
         return requireNotNull(
             game.winnerUserId

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.post
 import org.springframework.http.MediaType
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import shared.models.game.domain.GamePlayerMetrics
 import shared.models.game.validation.ValidationResult
 
 /**
@@ -75,7 +76,14 @@ class GameControllerTest {
                         NumberedTile("tile-1", TileColor.BLUE, 3)
                     ),
                     score = 10,
-                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+                    metrics = GamePlayerMetrics(
+                        turnsCompleted = 2,
+                        tilesPlayed = 5,
+                        meldsCreated = 1,
+                        pointsPlayed = 18,
+                        winner = false
+                    )
                 )
             ),
             drawPile = listOf(
@@ -83,7 +91,9 @@ class GameControllerTest {
             ),
             currentPlayerUserId = "user-1",
             status = GameStatus.ACTIVE,
-            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+            createdAt = Instant.parse("2026-04-27T18:00:00Z"),
+            totalTurnsCompleted = 4,
+            winnerUserId = null
         )
 
         `when`(gameService.getGame("game-1")).thenReturn(game)
@@ -108,6 +118,13 @@ class GameControllerTest {
                 jsonPath("$.board") { isArray() }
                 jsonPath("$.drawPile[0].tileId") { value("tile-2") }
                 jsonPath("$.drawPile[0].color") { value("RED") }
+                jsonPath("$.totalTurnsCompleted") { value(4) }
+                jsonPath("$.winnerUserId") { isEmpty() }
+                jsonPath("$.players[0].metrics.turnsCompleted") { value(2) }
+                jsonPath("$.players[0].metrics.tilesPlayed") { value(5) }
+                jsonPath("$.players[0].metrics.meldsCreated") { value(1) }
+                jsonPath("$.players[0].metrics.pointsPlayed") { value(18) }
+                jsonPath("$.players[0].metrics.winner") { value(false) }
             }
     }
 
@@ -203,6 +220,9 @@ class GameControllerTest {
                 jsonPath("$.gameId") { value("game-1") }
                 jsonPath("$.currentPlayerUserId") { value("user-1") }
                 jsonPath("$.status") { value("ACTIVE") }
+                jsonPath("$.totalTurnsCompleted") { value(0) }
+                jsonPath("$.winnerUserId") { isEmpty() }
+                jsonPath("$.players[0].metrics.turnsCompleted") { value(0) }
             }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameDtoTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameDtoTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
 import shared.models.game.response.BoardSetResponse
+import shared.models.game.response.GamePlayerMetricsResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
 import shared.models.game.response.TileResponse
@@ -75,7 +76,17 @@ class GameDtoTest {
             ),
             hasCompletedInitialMeld = true,
             score = 25,
-            joinedAt = joinedAt.toString()
+            joinedAt = joinedAt.toString(),
+            metrics = GamePlayerMetricsResponse(
+                turnsCompleted = 2,
+                tilesPlayed = 5,
+                meldsCreated = 1,
+                pointsPlayed = 21,
+                tilesRemainingAtEnd = null,
+                penaltyPointsAtEnd = null,
+                winner = false,
+                finishPosition = null
+            )
         )
 
         assertEquals("user-1", dto.userId)
@@ -85,6 +96,14 @@ class GameDtoTest {
         assertEquals(true, dto.hasCompletedInitialMeld)
         assertEquals(25, dto.score)
         assertEquals(joinedAt.toString(), dto.joinedAt)
+        assertEquals(2, dto.metrics.turnsCompleted)
+        assertEquals(5, dto.metrics.tilesPlayed)
+        assertEquals(1, dto.metrics.meldsCreated)
+        assertEquals(21, dto.metrics.pointsPlayed)
+        assertNull(dto.metrics.tilesRemainingAtEnd)
+        assertNull(dto.metrics.penaltyPointsAtEnd)
+        assertEquals(false, dto.metrics.winner)
+        assertNull(dto.metrics.finishPosition)
     }
 
     @Test
@@ -103,7 +122,17 @@ class GameDtoTest {
                     rackTiles = listOf(TileResponse("tile-8", "BLUE", 3, false)),
                     hasCompletedInitialMeld = false,
                     score = 10,
-                    joinedAt = Instant.parse("2026-04-27T17:55:00Z").toString()
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z").toString(),
+                    metrics = GamePlayerMetricsResponse(
+                        turnsCompleted = 1,
+                        tilesPlayed = 3,
+                        meldsCreated = 1,
+                        pointsPlayed = 18,
+                        tilesRemainingAtEnd = null,
+                        penaltyPointsAtEnd = null,
+                        winner = false,
+                        finishPosition = null
+                    )
                 )
             ),
             board = listOf(
@@ -129,7 +158,9 @@ class GameDtoTest {
             status = "ACTIVE",
             createdAt = createdAt.toString(),
             startedAt = startedAt.toString(),
-            finishedAt = null
+            finishedAt = null,
+            totalTurnsCompleted = 4,
+            winnerUserId = null
         )
 
         assertEquals("game-1", dto.gameId)
@@ -146,6 +177,10 @@ class GameDtoTest {
         assertNull(dto.finishedAt)
         assertNull(dto.turnDeadline)
         assertNull(dto.remainingTurnSeconds)
+        assertEquals(4, dto.totalTurnsCompleted)
+        assertNull(dto.winnerUserId)
+        assertEquals(1, dto.players[0].metrics.turnsCompleted)
+        assertEquals(3, dto.players[0].metrics.tilesPlayed)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameEventDtoTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/dto/GameEventDtoTest.kt
@@ -51,13 +51,17 @@ class GameEventDtoTest {
                 status = "ACTIVE",
                 createdAt = Instant.parse("2026-05-08T10:00:00Z").toString(),
                 startedAt = null,
-                finishedAt = null
+                finishedAt = null,
+                totalTurnsCompleted = 0,
+                winnerUserId = null
             )
         )
 
         assertEquals(GameUpdatedEvent.TYPE, event.type)
         assertEquals("game-1", event.gameId)
         assertEquals(42, event.game.drawPileCount)
+        assertEquals(0, event.game.totalTurnsCompleted)
+        assertEquals(null, event.game.winnerUserId)
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -14,6 +14,7 @@ import at.se2group.backend.rules.service.SetValidationService
 import at.se2group.backend.service.AfterCommitExecutor
 import at.se2group.backend.service.EndTurnService
 import at.se2group.backend.service.GameBroadcastService
+import at.se2group.backend.service.GameMetricsService
 import at.se2group.backend.service.GameService
 import at.se2group.backend.service.InvalidTurnSubmissionException
 import at.se2group.backend.service.TileConservationService
@@ -43,6 +44,7 @@ class EndTurnServiceTest {
     private val turnDraftRepository: TurnDraftRepository = mock()
     private val rummikubRuleService: RummikubRuleService = mock()
     private val gameBroadcastService: GameBroadcastService = mock()
+    private val gameMetricsService = GameMetricsService()
 
     private val gameService = GameService(gameRepository)
     private val afterCommitExecutor = AfterCommitExecutor()
@@ -53,7 +55,8 @@ class EndTurnServiceTest {
         gameService = gameService,
         rummikubRuleService = rummikubRuleService,
         gameBroadcastService = gameBroadcastService,
-        afterCommitExecutor = afterCommitExecutor
+        afterCommitExecutor = afterCommitExecutor,
+        gameMetricsService = gameMetricsService
     )
 
     @Test
@@ -185,6 +188,12 @@ class EndTurnServiceTest {
         val user1 = result.players.first { it.userId == "user-1" }
         assertEquals(listOf("new-rack-tile"), user1.rackTiles.map { it.tileId })
 
+        assertEquals(1, result.totalTurnsCompleted)
+        assertEquals(1, user1.metrics.turnsCompleted)
+        assertEquals(1, user1.metrics.tilesPlayed)
+        assertEquals(1, user1.metrics.meldsCreated)
+        assertEquals(5, user1.metrics.pointsPlayed)
+
         verify(gameRepository).save(any())
         verify(turnDraftRepository).save(any())
         verify(gameBroadcastService).broadcastGameUpdated(result)
@@ -204,7 +213,8 @@ class EndTurnServiceTest {
             gameService = gameService,
             rummikubRuleService = realRuleService,
             gameBroadcastService = gameBroadcastService,
-            afterCommitExecutor = afterCommitExecutor
+            afterCommitExecutor = afterCommitExecutor,
+            gameMetricsService = gameMetricsService
         )
 
         whenever(
@@ -296,6 +306,14 @@ class EndTurnServiceTest {
         assertEquals(GameStatus.FINISHED, result.status)
         assertTrue(result.finishedAt != null)
 
+        assertEquals("user-1", result.winnerUserId)
+
+        val winner = result.players.first { it.userId == "user-1" }
+        assertEquals(true, winner.metrics.winner)
+        assertEquals(1, winner.metrics.finishPosition)
+        assertEquals(0, winner.metrics.tilesRemainingAtEnd)
+        assertEquals(0, winner.metrics.penaltyPointsAtEnd)
+
         verify(turnDraftRepository).deleteById("game-1")
         verify(turnDraftRepository, never()).save(any())
         verify(gameBroadcastService).broadcastGameUpdated(result)
@@ -336,6 +354,12 @@ class EndTurnServiceTest {
         assertEquals("user-1", result.currentPlayerUserId)
         assertEquals(emptyList<String>(), result.players.first { it.userId == "user-1" }.rackTiles.map { it.tileId })
         assertEquals(listOf("user-2-rack"), result.players.first { it.userId == "user-2" }.rackTiles.map { it.tileId })
+
+        val loser = result.players.first { it.userId == "user-2" }
+        assertEquals(false, loser.metrics.winner)
+        assertEquals(2, loser.metrics.finishPosition)
+        assertEquals(1, loser.metrics.tilesRemainingAtEnd)
+        assertEquals(5, loser.metrics.penaltyPointsAtEnd)
 
         verify(gameRepository).save(any())
         verify(turnDraftRepository).deleteById("game-1")

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
@@ -1,0 +1,234 @@
+package at.se2group.backend.game.service
+
+import at.se2group.backend.service.GameMetricsService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import shared.models.game.domain.BoardSet
+import shared.models.game.domain.BoardSetType
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.JokerTile
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.Tile
+import shared.models.game.domain.TileColor
+
+class GameMetricsServiceTest {
+    private val service = GameMetricsService()
+
+    @Test
+    fun `applyCommittedTurnMetrics increments acting player turn metrics`() {
+        val tile1 = numbered("tile-1", 3)
+        val tile2 = numbered("tile-2", 4)
+        val remainingTile = numbered("tile-3", 9)
+
+        val before = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = listOf(tile1, tile2, remainingTile)),
+                player("user-2", 1, rackTiles = listOf(numbered("tile-4", 8)))
+            ),
+            boardSets = listOf(boardSet("set-old", listOf(numbered("tile-5", 10))))
+        )
+
+        val committed = before.copy(
+            players = listOf(
+                player("user-1", 0, rackTiles = listOf(remainingTile)),
+                player("user-2", 1, rackTiles = listOf(numbered("tile-4", 8)))
+            ),
+            boardSets = before.boardSets + boardSet("set-new", listOf(tile1, tile2, numbered("tile-6", 5)))
+        )
+
+        val result = service.applyCommittedTurnMetrics(
+            confirmedBeforeTurn = before,
+            committedGame = committed,
+            actingPlayerUserId = "user-1"
+        )
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+        val otherPlayer = result.players.first { it.userId == "user-2" }
+
+        assertEquals(1, result.totalTurnsCompleted)
+        assertEquals(1, actingPlayer.metrics.turnsCompleted)
+        assertEquals(2, actingPlayer.metrics.tilesPlayed)
+        assertEquals(1, actingPlayer.metrics.meldsCreated)
+        assertEquals(7, actingPlayer.metrics.pointsPlayed)
+
+        assertEquals(0, otherPlayer.metrics.turnsCompleted)
+        assertEquals(0, otherPlayer.metrics.tilesPlayed)
+        assertEquals(0, otherPlayer.metrics.meldsCreated)
+        assertEquals(0, otherPlayer.metrics.pointsPlayed)
+    }
+
+    @Test
+    fun `applyCommittedTurnMetrics does not count board rearrangement as tile placement`() {
+        val rackTile = numbered("rack-tile", 6)
+        val boardTile = numbered("board-tile", 7)
+
+        val before = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = listOf(rackTile)),
+                player("user-2", 1)
+            ),
+            boardSets = listOf(boardSet("set-1", listOf(boardTile, numbered("tile-2", 8), numbered("tile-3", 9))))
+        )
+
+        val committed = before.copy(
+            boardSets = listOf(boardSet("set-1", listOf(numbered("tile-2", 8), boardTile, numbered("tile-3", 9))))
+        )
+
+        val result = service.applyCommittedTurnMetrics(
+            confirmedBeforeTurn = before,
+            committedGame = committed,
+            actingPlayerUserId = "user-1"
+        )
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+
+        assertEquals(1, actingPlayer.metrics.turnsCompleted)
+        assertEquals(0, actingPlayer.metrics.tilesPlayed)
+        assertEquals(0, actingPlayer.metrics.pointsPlayed)
+        assertEquals(0, actingPlayer.metrics.meldsCreated)
+    }
+
+    @Test
+    fun `applyCommittedTurnMetrics counts joker as zero points played`() {
+        val joker = JokerTile("joker-1", TileColor.RED)
+        val numbered = numbered("tile-1", 12)
+
+        val before = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = listOf(joker, numbered)),
+                player("user-2", 1)
+            )
+        )
+
+        val committed = before.copy(
+            players = listOf(
+                player("user-1", 0, rackTiles = emptyList()),
+                player("user-2", 1)
+            ),
+            boardSets = listOf(boardSet("set-1", listOf(joker, numbered, numbered("tile-2", 13))))
+        )
+
+        val result = service.applyCommittedTurnMetrics(
+            confirmedBeforeTurn = before,
+            committedGame = committed,
+            actingPlayerUserId = "user-1"
+        )
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+
+        assertEquals(2, actingPlayer.metrics.tilesPlayed)
+        assertEquals(12, actingPlayer.metrics.pointsPlayed)
+    }
+
+    @Test
+    fun `finalizeEndGameMetrics marks empty rack player as winner`() {
+        val game = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = emptyList()),
+                player("user-2", 1, rackTiles = listOf(numbered("tile-1", 5), JokerTile("joker-1", TileColor.BLACK)))
+            ),
+            currentPlayerUserId = "user-1"
+        )
+
+        val result = service.finalizeEndGameMetrics(game)
+
+        val winner = result.players.first { it.userId == "user-1" }
+        val loser = result.players.first { it.userId == "user-2" }
+
+        assertEquals("user-1", result.winnerUserId)
+        assertTrue(winner.metrics.winner)
+        assertEquals(1, winner.metrics.finishPosition)
+        assertEquals(0, winner.metrics.tilesRemainingAtEnd)
+        assertEquals(0, winner.metrics.penaltyPointsAtEnd)
+
+        assertFalse(loser.metrics.winner)
+        assertEquals(2, loser.metrics.finishPosition)
+        assertEquals(2, loser.metrics.tilesRemainingAtEnd)
+        assertEquals(35, loser.metrics.penaltyPointsAtEnd)
+    }
+
+    @Test
+    fun `finalizeEndGameMetrics keeps existing winner user id`() {
+        val game = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = emptyList()),
+                player("user-2", 1, rackTiles = listOf(numbered("tile-1", 5)))
+            ),
+            currentPlayerUserId = "user-1",
+            winnerUserId = "user-2"
+        )
+
+        val result = service.finalizeEndGameMetrics(game)
+
+        assertEquals("user-2", result.winnerUserId)
+        assertFalse(result.players.first { it.userId == "user-1" }.metrics.winner)
+        assertTrue(result.players.first { it.userId == "user-2" }.metrics.winner)
+    }
+
+    @Test
+    fun `finalizeEndGameMetrics ranks non winners by lowest penalty then turn order`() {
+        val game = game(
+            players = listOf(
+                player("winner", 0, rackTiles = emptyList()),
+                player("user-2", 1, rackTiles = listOf(numbered("tile-1", 10))),
+                player("user-3", 2, rackTiles = listOf(numbered("tile-2", 3))),
+                player("user-4", 3, rackTiles = listOf(numbered("tile-3", 3)))
+            ),
+            currentPlayerUserId = "winner"
+        )
+
+        val result = service.finalizeEndGameMetrics(game)
+
+        assertEquals(1, result.players.first { it.userId == "winner" }.metrics.finishPosition)
+        assertEquals(4, result.players.first { it.userId == "user-2" }.metrics.finishPosition)
+        assertEquals(2, result.players.first { it.userId == "user-3" }.metrics.finishPosition)
+        assertEquals(3, result.players.first { it.userId == "user-4" }.metrics.finishPosition)
+    }
+
+    private fun game(
+        players: List<GamePlayer>,
+        boardSets: List<BoardSet> = emptyList(),
+        currentPlayerUserId: String = "user-1",
+        winnerUserId: String? = null
+    ) = ConfirmedGame(
+        gameId = "game-1",
+        lobbyId = "lobby-1",
+        players = players,
+        boardSets = boardSets,
+        currentPlayerUserId = currentPlayerUserId,
+        winnerUserId = winnerUserId
+    )
+
+    private fun player(
+        userId: String,
+        turnOrder: Int,
+        rackTiles: List<Tile> = emptyList()
+    ) = GamePlayer(
+        userId = userId,
+        displayName = userId,
+        turnOrder = turnOrder,
+        rackTiles = rackTiles
+    )
+
+    private fun boardSet(
+        boardSetId: String,
+        tiles: List<Tile>
+    ) = BoardSet(
+        boardSetId = boardSetId,
+        type = BoardSetType.RUN,
+        tiles = tiles
+    )
+
+    private fun numbered(
+        tileId: String,
+        number: Int
+    ) = NumberedTile(
+        tileId = tileId,
+        color = TileColor.BLUE,
+        number = number
+    )
+
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
@@ -188,6 +188,29 @@ class GameMetricsServiceTest {
         assertEquals(3, result.players.first { it.userId == "user-4" }.metrics.finishPosition)
     }
 
+    @Test
+    fun `finalizeEndGameMetrics counts joker as thirty penalty points`() {
+        val game = game(
+            players = listOf(
+                player("winner", 0, rackTiles = emptyList()),
+                player(
+                    "loser",
+                    1,
+                    rackTiles = listOf(JokerTile("joker-1", TileColor.BLACK))
+                )
+            ),
+            currentPlayerUserId = "winner"
+        )
+
+        val result = service.finalizeEndGameMetrics(game)
+
+        assertEquals(
+            30,
+            result.players.first { it.userId == "loser" }
+                .metrics.penaltyPointsAtEnd
+        )
+    }
+
     private fun game(
         players: List<GamePlayer>,
         boardSets: List<BoardSet> = emptyList(),

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameMetricsServiceTest.kt
@@ -211,6 +211,59 @@ class GameMetricsServiceTest {
         )
     }
 
+    @Test
+    fun `applyCommittedTurnMetrics does not count modified existing board sets as melds created`() {
+        val playedTile = numbered("tile-1", 5)
+
+        val before = game(
+            players = listOf(
+                player("user-1", 0, rackTiles = listOf(playedTile)),
+                player("user-2", 1)
+            ),
+            boardSets = listOf(
+                boardSet(
+                    "set-1",
+                    listOf(
+                        numbered("tile-2", 6),
+                        numbered("tile-3", 7),
+                        numbered("tile-4", 8)
+                    )
+                )
+            )
+        )
+
+        val committed = before.copy(
+            players = listOf(
+                player("user-1", 0, rackTiles = emptyList()),
+                player("user-2", 1)
+            ),
+            boardSets = listOf(
+                boardSet(
+                    "set-1",
+                    listOf(
+                        numbered("tile-2", 6),
+                        numbered("tile-3", 7),
+                        numbered("tile-4", 8),
+                        playedTile
+                    )
+                )
+            )
+        )
+
+        val result = service.applyCommittedTurnMetrics(
+            confirmedBeforeTurn = before,
+            committedGame = committed,
+            actingPlayerUserId = "user-1"
+        )
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+
+        assertEquals(1, actingPlayer.metrics.turnsCompleted)
+        assertEquals(1, actingPlayer.metrics.tilesPlayed)
+        assertEquals(5, actingPlayer.metrics.pointsPlayed)
+        assertEquals(0, actingPlayer.metrics.meldsCreated)
+    }
+
     private fun game(
         players: List<GamePlayer>,
         boardSets: List<BoardSet> = emptyList(),

--- a/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/mapper/GameMapperTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import shared.models.game.domain.GamePlayerMetrics
 import java.time.Instant
 
 class GameMapperTest {
@@ -38,7 +39,17 @@ class GameMapperTest {
                     ),
                     hasCompletedInitialMeld = true,
                     score = 25,
-                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+                    metrics = GamePlayerMetrics(
+                        turnsCompleted = 3,
+                        tilesPlayed = 8,
+                        meldsCreated = 2,
+                        pointsPlayed = 34,
+                        tilesRemainingAtEnd = 4,
+                        penaltyPointsAtEnd = 18,
+                        winner = true,
+                        finishPosition = 1
+                    )
                 ),
                 GamePlayer(
                     userId = "user-2",
@@ -71,7 +82,9 @@ class GameMapperTest {
             status = GameStatus.ACTIVE,
             createdAt = createdAt,
             startedAt = startedAt,
-            finishedAt = null
+            finishedAt = null,
+            totalTurnsCompleted = 7,
+            winnerUserId = "user-1"
         )
 
         val entity = game.toEntity()
@@ -82,12 +95,22 @@ class GameMapperTest {
         assertEquals(GameStatus.ACTIVE, entity.status)
         assertEquals(createdAt, entity.createdAt)
         assertEquals(startedAt, entity.startedAt)
+        assertEquals(7, entity.totalTurnsCompleted)
+        assertEquals("user-1", entity.winnerUserId)
 
         assertEquals(2, entity.players.size)
         assertEquals("user-1", entity.players[0].userId)
         assertEquals("Alice", entity.players[0].displayName)
         assertEquals(0, entity.players[0].turnOrder)
         assertEquals(2, entity.players[0].rackTiles.size)
+        assertEquals(3, entity.players[0].turnsCompleted)
+        assertEquals(8, entity.players[0].tilesPlayed)
+        assertEquals(2, entity.players[0].meldsCreated)
+        assertEquals(34, entity.players[0].pointsPlayed)
+        assertEquals(4, entity.players[0].tilesRemainingAtEnd)
+        assertEquals(18, entity.players[0].penaltyPointsAtEnd)
+        assertEquals(true, entity.players[0].winner)
+        assertEquals(1, entity.players[0].finishPosition)
         assertTrue(entity.players.all { it.game === entity })
 
         assertEquals(1, entity.boardSets.size)
@@ -115,6 +138,8 @@ class GameMapperTest {
             createdAt = Instant.parse("2026-04-27T18:00:00Z"),
             startedAt = Instant.parse("2026-04-27T18:05:00Z"),
             finishedAt = null,
+            totalTurnsCompleted = 9,
+            winnerUserId = "user-2",
             drawPile = mutableListOf(
                 embeddable("tile-9", TileColor.RED, 6, false),
                 embeddable("tile-10", TileColor.BLUE, null, true)
@@ -132,7 +157,15 @@ class GameMapperTest {
                 ),
                 hasCompletedInitialMeld = true,
                 score = 20,
-                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+                turnsCompleted = 4,
+                tilesPlayed = 10,
+                meldsCreated = 3,
+                pointsPlayed = 42,
+                tilesRemainingAtEnd = 1,
+                penaltyPointsAtEnd = 4,
+                winner = false,
+                finishPosition = 2
             ),
             GamePlayerEntity(
                 game = entity,
@@ -167,11 +200,21 @@ class GameMapperTest {
         assertEquals("lobby-1", game.lobbyId)
         assertEquals("user-2", game.currentPlayerUserId)
         assertEquals(GameStatus.ACTIVE, game.status)
+        assertEquals(9, game.totalTurnsCompleted)
+        assertEquals("user-2", game.winnerUserId)
 
         assertEquals(2, game.players.size)
         assertEquals("Alice", game.players[0].displayName)
         assertEquals(0, game.players[0].turnOrder)
         assertEquals(1, game.players[0].rackTiles.size)
+        assertEquals(4, game.players[0].metrics.turnsCompleted)
+        assertEquals(10, game.players[0].metrics.tilesPlayed)
+        assertEquals(3, game.players[0].metrics.meldsCreated)
+        assertEquals(42, game.players[0].metrics.pointsPlayed)
+        assertEquals(1, game.players[0].metrics.tilesRemainingAtEnd)
+        assertEquals(4, game.players[0].metrics.penaltyPointsAtEnd)
+        assertEquals(false, game.players[0].metrics.winner)
+        assertEquals(2, game.players[0].metrics.finishPosition)
 
         assertEquals(1, game.boardSets.size)
         assertEquals("set-1", game.boardSets[0].boardSetId)
@@ -255,7 +298,17 @@ class GameMapperTest {
                     ),
                     hasCompletedInitialMeld = true,
                     score = 25,
-                    joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                    joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+                    metrics = GamePlayerMetrics(
+                        turnsCompleted = 5,
+                        tilesPlayed = 12,
+                        meldsCreated = 4,
+                        pointsPlayed = 55,
+                        tilesRemainingAtEnd = 2,
+                        penaltyPointsAtEnd = 9,
+                        winner = true,
+                        finishPosition = 1
+                    )
                 )
             ),
             boardSets = listOf(
@@ -277,7 +330,9 @@ class GameMapperTest {
             status = GameStatus.ACTIVE,
             createdAt = createdAt,
             startedAt = startedAt,
-            finishedAt = null
+            finishedAt = null,
+            totalTurnsCompleted = 11,
+            winnerUserId = "user-1"
         )
 
         val response = game.toResponse()
@@ -293,6 +348,8 @@ class GameMapperTest {
         assertEquals(1, response.board.size)
         assertEquals(2, response.drawPile.size)
         assertEquals(2, response.drawPileCount)
+        assertEquals(11, response.totalTurnsCompleted)
+        assertEquals("user-1", response.winnerUserId)
         assertEquals(null, response.turnDeadline)
         assertEquals(null, response.remainingTurnSeconds)
 
@@ -300,6 +357,14 @@ class GameMapperTest {
         assertEquals("Alice", response.players[0].displayName)
         assertEquals(0, response.players[0].turnOrder)
         assertEquals(Instant.parse("2026-04-27T17:55:00Z").toString(), response.players[0].joinedAt)
+        assertEquals(5, response.players[0].metrics.turnsCompleted)
+        assertEquals(12, response.players[0].metrics.tilesPlayed)
+        assertEquals(4, response.players[0].metrics.meldsCreated)
+        assertEquals(55, response.players[0].metrics.pointsPlayed)
+        assertEquals(2, response.players[0].metrics.tilesRemainingAtEnd)
+        assertEquals(9, response.players[0].metrics.penaltyPointsAtEnd)
+        assertEquals(true, response.players[0].metrics.winner)
+        assertEquals(1, response.players[0].metrics.finishPosition)
         assertEquals(2, response.players[0].rackTiles.size)
         assertEquals("tile-22", response.players[0].rackTiles[0].tileId)
         assertEquals("BLUE", response.players[0].rackTiles[0].color)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/persistence/GameRepositoryTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/persistence/GameRepositoryTest.kt
@@ -27,6 +27,8 @@ class GameRepositoryTest {
             createdAt = Instant.parse("2026-04-27T18:00:00Z"),
             startedAt = Instant.parse("2026-04-27T18:05:00Z"),
             finishedAt = null,
+            totalTurnsCompleted = 6,
+            winnerUserId = "user-1",
             drawPile = mutableListOf(
                 embeddable("tile-1", TileColor.RED, 5, false),
                 embeddable("tile-2", TileColor.BLUE, null, true),
@@ -45,7 +47,15 @@ class GameRepositoryTest {
             ),
             hasCompletedInitialMeld = true,
             score = 25,
-            joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+            turnsCompleted = 3,
+            tilesPlayed = 8,
+            meldsCreated = 2,
+            pointsPlayed = 34,
+            tilesRemainingAtEnd = 0,
+            penaltyPointsAtEnd = 0,
+            winner = true,
+            finishPosition = 1
         )
 
         val player2 = GamePlayerEntity(
@@ -58,7 +68,15 @@ class GameRepositoryTest {
             ),
             hasCompletedInitialMeld = false,
             score = 10,
-            joinedAt = Instant.parse("2026-04-27T17:56:00Z")
+            joinedAt = Instant.parse("2026-04-27T17:56:00Z"),
+            turnsCompleted = 3,
+            tilesPlayed = 4,
+            meldsCreated = 1,
+            pointsPlayed = 19,
+            tilesRemainingAtEnd = 1,
+            penaltyPointsAtEnd = 13,
+            winner = false,
+            finishPosition = 2
         )
 
         val boardSet = BoardSetEntity(
@@ -86,6 +104,8 @@ class GameRepositoryTest {
         assertEquals("lobby-1", saved.lobbyId)
         assertEquals("user-1", saved.currentPlayerUserId)
         assertEquals(GameStatus.ACTIVE, saved.status)
+        assertEquals(6, saved.totalTurnsCompleted)
+        assertEquals("user-1", saved.winnerUserId)
         assertEquals(2, saved.players.size)
         assertEquals(1, saved.boardSets.size)
         assertEquals(3, saved.drawPile.size)
@@ -96,10 +116,26 @@ class GameRepositoryTest {
         assertEquals(2, saved.players[0].rackTiles.size)
         assertEquals(true, saved.players[0].hasCompletedInitialMeld)
         assertEquals(25, saved.players[0].score)
+        assertEquals(3, saved.players[0].turnsCompleted)
+        assertEquals(8, saved.players[0].tilesPlayed)
+        assertEquals(2, saved.players[0].meldsCreated)
+        assertEquals(34, saved.players[0].pointsPlayed)
+        assertEquals(0, saved.players[0].tilesRemainingAtEnd)
+        assertEquals(0, saved.players[0].penaltyPointsAtEnd)
+        assertEquals(true, saved.players[0].winner)
+        assertEquals(1, saved.players[0].finishPosition)
 
         assertEquals("user-2", saved.players[1].userId)
         assertEquals("Bob", saved.players[1].displayName)
         assertEquals(1, saved.players[1].rackTiles.size)
+        assertEquals(3, saved.players[1].turnsCompleted)
+        assertEquals(4, saved.players[1].tilesPlayed)
+        assertEquals(1, saved.players[1].meldsCreated)
+        assertEquals(19, saved.players[1].pointsPlayed)
+        assertEquals(1, saved.players[1].tilesRemainingAtEnd)
+        assertEquals(13, saved.players[1].penaltyPointsAtEnd)
+        assertEquals(false, saved.players[1].winner)
+        assertEquals(2, saved.players[1].finishPosition)
 
         assertEquals("set-1", saved.boardSets[0].boardSetId)
         assertEquals(BoardSetType.RUN, saved.boardSets[0].type)

--- a/apps/shared/src/main/kotlin/shared/models/game/domain/ConfirmedGame.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/domain/ConfirmedGame.kt
@@ -12,7 +12,9 @@ data class ConfirmedGame(
     val status: GameStatus = GameStatus.WAITING,
     val createdAt: Instant = Instant.now(),
     val startedAt: Instant? = null,
-    val finishedAt: Instant? = null
+    val finishedAt: Instant? = null,
+    val totalTurnsCompleted: Int = 0,
+    val winnerUserId: String? = null
 ) {
     init {
         require(gameId.isNotBlank()) { "gameId must not be blank" }

--- a/apps/shared/src/main/kotlin/shared/models/game/domain/GamePlayer.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/domain/GamePlayer.kt
@@ -9,7 +9,8 @@ data class GamePlayer(
     val rackTiles: List<Tile> = emptyList(),
     val hasCompletedInitialMeld: Boolean = false,
     val score: Int = 0,
-    val joinedAt: Instant = Instant.now()
+    val joinedAt: Instant = Instant.now(),
+    val metrics: GamePlayerMetrics = GamePlayerMetrics()
 ) {
     init {
         require(userId.isNotBlank()) { "userId must not be blank" }

--- a/apps/shared/src/main/kotlin/shared/models/game/domain/GamePlayerMetrics.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/domain/GamePlayerMetrics.kt
@@ -1,0 +1,12 @@
+package shared.models.game.domain
+
+data class GamePlayerMetrics(
+    val turnsCompleted: Int = 0,
+    val tilesPlayed: Int = 0,
+    val meldsCreated: Int = 0,
+    val pointsPlayed: Int = 0,
+    val tilesRemainingAtEnd: Int? = null,
+    val penaltyPointsAtEnd: Int? = null,
+    val winner: Boolean = false,
+    val finishPosition: Int? = null
+)

--- a/apps/shared/src/main/kotlin/shared/models/game/response/GamePlayerMetricsResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/response/GamePlayerMetricsResponse.kt
@@ -1,0 +1,12 @@
+package shared.models.game.response
+
+data class GamePlayerMetricsResponse(
+    val turnsCompleted: Int,
+    val tilesPlayed: Int,
+    val meldsCreated: Int,
+    val pointsPlayed: Int,
+    val tilesRemainingAtEnd: Int?,
+    val penaltyPointsAtEnd: Int?,
+    val winner: Boolean,
+    val finishPosition: Int?
+)

--- a/apps/shared/src/main/kotlin/shared/models/game/response/GamePlayerResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/response/GamePlayerResponse.kt
@@ -7,5 +7,6 @@ data class GamePlayerResponse(
     val rackTiles: List<TileResponse>,
     val hasCompletedInitialMeld: Boolean,
     val score: Int,
-    val joinedAt: String
+    val joinedAt: String,
+    val metrics: GamePlayerMetricsResponse
 )

--- a/apps/shared/src/main/kotlin/shared/models/game/response/GameResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/game/response/GameResponse.kt
@@ -14,5 +14,7 @@ data class GameResponse(
     val status: String,
     val createdAt: String,
     val startedAt: String?,
-    val finishedAt: String?
+    val finishedAt: String?,
+    val totalTurnsCompleted: Int,
+    val winnerUserId: String?
 )


### PR DESCRIPTION
# PR Summary: Per-Player Game Metrics for Result Screen - #707 

![Scope](https://img.shields.io/badge/Scope-Backend-111827) ![Domain](https://img.shields.io/badge/Domain-Game%20Metrics-1f2937) ![Feature](https://img.shields.io/badge/Feature-Per--Player%20Match%20Stats-374151)
![API](https://img.shields.io/badge/Affects-Game%20Response-4b5563) ![Persistence](https://img.shields.io/badge/Affects-Persistence-334155) ![Status](https://img.shields.io/badge/PR%20Description-Summary-0f172a)
![Linked Documentation](https://img.shields.io/badge/Linked%20Documentation-Discussion%20707-3f3f46)


- Closes #844 
- Closes #845 
- Closes #846 
- Closes #847 
- Closes #848 
- Closes #849 
- Closes #850 
- Closes #851 
- Closes #852  
- Closes #853 
- Related to #321 
- Related to #322 
- Closes #325 
- Closes #323 
- Closes #324 
- Related to #326 

## Summary

This PR adds persistent per-player match metrics on the backend so the result
screen can show more than only the final score. The backend becomes the source
of truth for statistics that should survive reconnects, app restarts, and late
websocket delivery instead of being reconstructed loosely on the client.

The main metrics in scope are:

- turns completed
- tiles played
- melds created
- points played
- tiles remaining at end
- penalty points at end
- winner state
- finish position

At match level, the PR may also add a small number of aggregate fields where
they clearly belong, such as:

- total turns completed
- winner user id
- finished timestamp

## Why this change exists

Right now the backend stores enough state to play the game, but not enough to
render a strong result screen. The Android side can show the confirmed board,
player racks, scores, and game status, but it does not receive stable backend
statistics for match performance.

Without backend-owned metrics:

- clients would need to infer numbers from incomplete history
- reconnects could lose locally derived aggregates
- different clients could derive different result values
- the result screen would stay limited to crude score-only output

This PR fixes that by updating metrics only when a turn is successfully
committed.

## Core implementation idea

The recommended flow is:

1. validate the submitted turn against confirmed game state
2. commit the submitted draft into confirmed game state
3. compute metric deltas from the committed turn
4. update only the acting player’s metrics
5. finalize end-of-match fields only when the match is actually finished

The most important metric computations are:

### Tiles played

Compute tiles played from the acting player’s rack delta:

```kotlin
val beforePlayer = confirmedBeforeTurn.players.first { it.userId == actingPlayerUserId }
val afterPlayer = committedGame.players.first { it.userId == actingPlayerUserId }

val playedTileIds = beforePlayer.rackTiles.map { it.tileId }.toSet() -
    afterPlayer.rackTiles.map { it.tileId }.toSet()
```

### Points played

Sum the values of the tiles that actually left the acting player’s rack:

```kotlin
val pointsPlayed = beforePlayer.rackTiles
    .filter { it.tileId in playedTileIds }
    .sumOf { metricPointValue(it) }
```

### Melds created

Count new board sets by comparing committed board-set IDs against the confirmed
board before the turn:

```kotlin
val previousBoardSetIds = confirmedBeforeTurn.boardSets.map { it.boardSetId }.toSet()
val newBoardSets = committedGame.boardSets.filter { it.boardSetId !in previousBoardSetIds }
val meldsCreated = newBoardSets.size
```

## Architecture direction

The cleanest boundary is a dedicated metrics service instead of burying this
logic directly in `EndTurnService`.

Recommended shape:

```kotlin
class GameMetricsService {
    fun applyCommittedTurnMetrics(
        confirmedBeforeTurn: ConfirmedGame,
        committedGame: ConfirmedGame,
        actingPlayerUserId: String
    ): ConfirmedGame

    fun finalizeEndGameMetrics(
        game: ConfirmedGame
    ): ConfirmedGame
}
```

This keeps:

- `EndTurnService` focused on orchestration
- metric logic isolated and unit-testable
- future result-screen extensions easier to add

## Important lifecycle note

In this project, winner detection and true match completion are not the same
thing. A player can be recorded as the winner while the remaining players keep
playing. That means:

- winner state can exist before the match is fully finished
- `tilesRemainingAtEnd`, `penaltyPointsAtEnd`, `finishPosition`, and
  `finishedAt` should be treated as true end-of-match fields

## Expected API impact

The frontend result screen will need these metrics in the game response, so the
PR should extend the response model instead of keeping this data backend-only.

Typical additions are:

- metrics on each player response
- optional `winnerUserId` on the game response

## Testing scope

The main test surface should include:

- metric accumulation on successful end-turn
- no metric updates on invalid turn submission
- rack-delta tile counting
- meld creation counting
- points-played accumulation
- end-of-match finalization
- response and persistence mapping

## Outcome

After this PR:

- the backend owns the result-screen statistics
- metrics survive reconnects and reloads
- the final game response contains stable player-level match data
- the Android result screen can consume backend truth instead of guessing
