### PR TITLE
feat(backend)(rules): enforce initial meld validation on end turn

### DIFF
--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
@@ -5,6 +5,7 @@ import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.GamePlayer
 import shared.models.game.domain.TurnDraft
 import shared.models.game.validation.ValidationResult
+import shared.models.game.validation.valid
 
 /**
  * Service responsible for validating the initial meld rule during the first
@@ -25,6 +26,9 @@ class FirstMoveValidationService {
         actingPlayer: GamePlayer,
         submittedDraft: TurnDraft
     ): ValidationResult {
+        if (actingPlayer.hasCompletedInitialMeld) {
+            return valid()
+        }
         throw UnsupportedOperationException("Not yet implemented")
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
@@ -1,0 +1,30 @@
+package at.se2group.backend.rules.service
+
+import org.springframework.stereotype.Service
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.TurnDraft
+import shared.models.game.validation.ValidationResult
+
+/**
+ * Service responsible for validating the initial meld rule during the first
+ * submitted turn of a player
+ *
+ * The initial meld rule requires that a player with who has not yet completed their initial meld
+ * must place tiles from their rack (worth at least 30 points) in a single submitted turn before the turn
+ * can be committed.
+ *
+ * Once the player has officially completed the initial meld, this validator skips
+ * all the checks on all subsequent turns for that player.
+ */
+
+@Service
+class FirstMoveValidationService {
+    fun validate(
+        confirmedGame: ConfirmedGame,
+        actingPlayer: GamePlayer,
+        submittedDraft: TurnDraft
+    ): ValidationResult {
+        throw UnsupportedOperationException("Not yet implemented")
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
@@ -3,6 +3,7 @@ package at.se2group.backend.rules.service
 import org.springframework.stereotype.Service
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.GamePlayer
+import shared.models.game.domain.NumberedTile
 import shared.models.game.domain.TurnDraft
 import shared.models.game.validation.ValidationResult
 import shared.models.game.validation.valid
@@ -29,6 +30,33 @@ class FirstMoveValidationService {
         if (actingPlayer.hasCompletedInitialMeld) {
             return valid()
         }
+        val score = calculateNewlyCommitedScore(confirmedGame, actingPlayer, submittedDraft)
+
         throw UnsupportedOperationException("Not yet implemented")
+    }
+
+    private fun calculateNewlyCommitedScore(
+        confirmedGame: ConfirmedGame,
+        actingPlayer: GamePlayer,
+        submittedDraft: TurnDraft
+    ): Int {
+        val confirmedBoardTileIds = confirmedGame.boardSets
+            .flatMap { it.tiles }
+            .map { it.tileId }
+            .toSet()
+        val confirmedRackTileIds = actingPlayer.rackTiles
+            .map { it.tileId }
+            .toSet()
+        val newlyCommitedScore = submittedDraft.boardSets
+            .flatMap { it.tiles }
+            .filter { it.tileId !in confirmedBoardTileIds }
+            .filter { it.tileId in confirmedRackTileIds }
+
+        return newlyCommitedScore.sumOf { tile ->
+            when (tile) {
+                is NumberedTile -> tile.number
+                else -> 0
+            }
+        }
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/FirstMoveValidationService.kt
@@ -7,6 +7,7 @@ import shared.models.game.domain.NumberedTile
 import shared.models.game.domain.TurnDraft
 import shared.models.game.validation.ValidationResult
 import shared.models.game.validation.valid
+import shared.models.game.validation.invalid
 
 /**
  * Service responsible for validating the initial meld rule during the first
@@ -22,6 +23,10 @@ import shared.models.game.validation.valid
 
 @Service
 class FirstMoveValidationService {
+
+    private companion object {
+        const val INITIAL_MELD_MINIMUM_SCORE = 30
+    }
     fun validate(
         confirmedGame: ConfirmedGame,
         actingPlayer: GamePlayer,
@@ -30,12 +35,19 @@ class FirstMoveValidationService {
         if (actingPlayer.hasCompletedInitialMeld) {
             return valid()
         }
-        val score = calculateNewlyCommitedScore(confirmedGame, actingPlayer, submittedDraft)
+        val score = calculateNewlyCommittedScore(confirmedGame, actingPlayer, submittedDraft)
 
-        throw UnsupportedOperationException("Not yet implemented")
+        return if (score >= INITIAL_MELD_MINIMUM_SCORE) {
+            valid()
+        } else {
+            invalid(
+                code = "INITIAL_MELD_TOO_LOW",
+                message = "Initial meld must score at least 30 points"
+            )
+        }
     }
 
-    private fun calculateNewlyCommitedScore(
+    private fun calculateNewlyCommittedScore(
         confirmedGame: ConfirmedGame,
         actingPlayer: GamePlayer,
         submittedDraft: TurnDraft
@@ -47,12 +59,12 @@ class FirstMoveValidationService {
         val confirmedRackTileIds = actingPlayer.rackTiles
             .map { it.tileId }
             .toSet()
-        val newlyCommitedScore = submittedDraft.boardSets
+        val newlyCommittedScore = submittedDraft.boardSets
             .flatMap { it.tiles }
             .filter { it.tileId !in confirmedBoardTileIds }
             .filter { it.tileId in confirmedRackTileIds }
 
-        return newlyCommitedScore.sumOf { tile ->
+        return newlyCommittedScore.sumOf { tile ->
             when (tile) {
                 is NumberedTile -> tile.number
                 else -> 0

--- a/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/rules/service/RummikubRuleService.kt
@@ -37,7 +37,8 @@ import shared.models.game.validation.invalid
 @Service
 class RummikubRuleService(
     private val tileConservationService: TileConservationService,
-    private val boardValidationService: BoardValidationService
+    private val boardValidationService: BoardValidationService,
+    private val firstMoveValidationService: FirstMoveValidationService
 ) {
 
     /**
@@ -67,6 +68,7 @@ class RummikubRuleService(
         actingPlayerUserId: String,
         submittedDraft: TurnDraft
     ): ValidationResult {
+        val actingPlayer = confirmedGame.players.first { it.userId == actingPlayerUserId }
         val violations = mutableListOf<RuleViolation>()
 
         violations += tileConservationService
@@ -76,6 +78,11 @@ class RummikubRuleService(
         violations += boardValidationService
             .validate(submittedDraft.boardSets)
             .violations
+
+        violations += firstMoveValidationService
+            .validate(confirmedGame, actingPlayer, submittedDraft)
+            .violations
+
 
         return if (violations.isEmpty()) valid() else invalid(violations)
     }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -61,6 +61,7 @@ class EndTurnService(
         }
 
         val resolvedGame = commitDraftToConfirmedGame(game, submittedDraft)
+            .applyInitialMeldCompletion(userId)
             .finishIfWinnerExists(userId)
 
         if (resolvedGame.status == GameStatus.FINISHED) {
@@ -131,6 +132,19 @@ class EndTurnService(
             .first { it.userId == actingPlayerUserId }
             .rackTiles
             .isEmpty()
+    }
+
+    private fun ConfirmedGame.applyInitialMeldCompletion(
+        actingPlayerUserId: String
+    ): ConfirmedGame {
+        val updatePlayers = players.map { player ->
+            if (player.userId == actingPlayerUserId && !player.hasCompletedInitialMeld) {
+                player.copy(hasCompletedInitialMeld = true)
+            } else {
+                player
+            }
+        }
+        return copy(players = updatePlayers)
     }
 
     private fun createNextDraft(game: ConfirmedGame): TurnDraft {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -364,6 +364,22 @@ class EndTurnServiceTest {
         assertTrue(actingPlayer.hasCompletedInitialMeld)
     }
 
+    @Test
+    fun `failed initial meld does not commit game state`() {
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(gameEntity()))
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(draftEntity())
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(invalid("INITIAL_MELD_TOO_LOW", "Initial meld must score at least 30 points"))
+
+        assertThrows<InvalidTurnSubmissionException> {
+            endTurnService.endTurn("game-1", "user-1", request())
+        }
+
+        verify(gameRepository, never()).save(any())
+        verify(gameBroadcastService, never()).broadcastGameUpdated(any())
+
+    }
+
     private fun request(
         rackTiles: List<TileRequest> = listOf(TileRequest("new-rack-tile", "BLACK", 9, false))
     ) = EndTurnRequest(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -220,7 +220,8 @@ class EndTurnServiceTest {
                         tile("tile-3", TileColor.RED, 5, false),
                         tile("new-rack-tile", TileColor.BLACK, 9, false)
                     ),
-                    user2Rack = mutableListOf(tile("user-2-rack"))
+                    user2Rack = mutableListOf(tile("user-2-rack")),
+                    hasCompletedInitialMeld = true
                 )
             )
         )

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -17,6 +17,7 @@ import at.se2group.backend.service.GameBroadcastService
 import at.se2group.backend.service.GameService
 import at.se2group.backend.service.InvalidTurnSubmissionException
 import at.se2group.backend.service.TileConservationService
+import at.se2group.backend.rules.service.FirstMoveValidationService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -196,7 +197,8 @@ class EndTurnServiceTest {
     fun `commits valid joker containing submitted draft`() {
         val realRuleService = RummikubRuleService(
             TileConservationService(),
-            BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService()))
+            BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService())),
+            FirstMoveValidationService()
         )
         val realEndTurnService = EndTurnService(
             gameRepository = gameRepository,
@@ -345,6 +347,21 @@ class EndTurnServiceTest {
         verify(gameBroadcastService).broadcastGameEnded("game-1", "user-1")
         verify(gameBroadcastService, never()).broadcastTurnChanged(any(), any())
         verify(gameBroadcastService, never()).broadcastDraftUpdated(any())
+    }
+
+    @Test
+    fun `marks player as having completed initial meld`() {
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(gameEntity()))
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(draftEntity())
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any())).thenReturn(valid())
+        whenever(gameRepository.save(any())).thenAnswer { it.arguments[0] }
+        whenever(turnDraftRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn("game-1", "user-1", request())
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+
+        assertTrue(actingPlayer.hasCompletedInitialMeld)
     }
 
     private fun request(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -380,6 +380,20 @@ class EndTurnServiceTest {
 
     }
 
+    @Test
+    fun `player with successful initial meld can submit low score turn`() {
+        val entity = gameEntity(hasCompletedInitialMeld = true)
+        whenever(gameRepository.findById("game-1")).thenReturn(Optional.of(entity))
+        whenever(turnDraftRepository.findByGameId("game-1")).thenReturn(draftEntity())
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any())).thenReturn(valid())
+        whenever(gameRepository.save(any())).thenAnswer { it.arguments[0] }
+        whenever(turnDraftRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn("game-1", "user-1", request())
+
+        assertTrue(result.players.first { it.userId == "user-1" }.hasCompletedInitialMeld)
+    }
+
     private fun request(
         rackTiles: List<TileRequest> = listOf(TileRequest("new-rack-tile", "BLACK", 9, false))
     ) = EndTurnRequest(
@@ -416,14 +430,16 @@ class EndTurnServiceTest {
         currentPlayerUserId: String = "user-1",
         status: GameStatus = GameStatus.ACTIVE,
         user1Rack: MutableList<TileEmbeddable> = mutableListOf(),
-        user2Rack: MutableList<TileEmbeddable> = mutableListOf()
+        user2Rack: MutableList<TileEmbeddable> = mutableListOf(),
+        hasCompletedInitialMeld: Boolean = false
     ): GameEntity {
         val game = GameEntity(
             gameId = "game-1",
             lobbyId = "lobby-1",
             currentPlayerUserId = currentPlayerUserId,
             status = status,
-            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+            createdAt = Instant.parse("2026-04-27T18:00:00Z"),
+
         )
 
         game.players = mutableListOf(
@@ -433,7 +449,8 @@ class EndTurnServiceTest {
                 displayName = "Alice",
                 turnOrder = 0,
                 rackTiles = user1Rack,
-                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
+                hasCompletedInitialMeld = hasCompletedInitialMeld
             ),
             GamePlayerEntity(
                 game = game,

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -109,5 +109,27 @@ class FirstMoveValidationServiceTest {
         assertTrue(result.isValid)
     }
 
+    @Test
+    fun `does not count existing board tiles toward initial meld score`() {
+        val existingBoardTile = tile("existing-1", TileColor.BLUE, 13)
+        val rackTile = tile("rack-1", TileColor.RED, 5)
+
+        val player = player().copy(rackTiles = listOf(rackTile))
+        val game = game(player).copy(
+            boardSets = listOf(BoardSet(boardSetId = "existing-1", tiles = listOf(existingBoardTile)))
+        )
+        val draft = draft(
+            boardSets = listOf(
+                BoardSet(boardSetId = "existing-1", tiles = listOf(existingBoardTile)),
+                BoardSet(boardSetId = "new-set", tiles = listOf(rackTile))
+            )
+        )
+        val result = service.validate(game, player, draft)
+
+        assertFalse(result.isValid)
+        assertEquals("INITIAL_MELD_TOO_LOW", result.violations.single().code)
+
+    }
+
 
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -34,6 +34,11 @@ class FirstMoveValidationServiceTest {
         rackTiles = emptyList()
     )
 
+    private fun tile(id: String, color: TileColor, number: Int) = NumberedTile(
+        tileId = id,
+        color = color,
+        number = number)
+
     @Test
     fun `returns valid when player already completed initial meld`() {
        val result = service.validate(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -2,7 +2,6 @@ package at.se2group.backend.rules.service
 
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -1,10 +1,13 @@
 package at.se2group.backend.rules.service
 
+
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import shared.models.game.domain.*
+import shared.models.game.domain.TileColor
 import java.time.Instant
 
 class FirstMoveValidationServiceTest {
@@ -49,4 +52,23 @@ class FirstMoveValidationServiceTest {
         assertTrue(result.isValid)
         assertTrue(result.violations.isEmpty())
     }
+
+    @Test
+    fun `returns invalid when newly committed score is lower than 30`() {
+        val rackTile = tile("tile-1", TileColor.RED, 5)
+        val player = player().copy(rackTiles = listOf(rackTile))
+        val game = game(player)
+        val draft = draft(
+            boardSets = listOf(
+                BoardSet(boardSetId = "set-1", tiles = listOf(rackTile)))
+        )
+
+        val result = service.validate(game, player, draft)
+
+        assertFalse(result.isValid)
+        assertEquals("INITIAL_MELD_TOO_LOW", result.violations.single().code)
+        assertEquals("Initial meld must score at least 30 points", result.violations.single().message)
+    }
+
+
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -70,5 +70,44 @@ class FirstMoveValidationServiceTest {
         assertEquals("Initial meld must score at least 30 points", result.violations.single().message)
     }
 
+    @Test
+    fun `returns valid when newly committed score is 30`(){
+        val tiles = listOf(
+            tile("tile-1", TileColor.RED, 10),
+            tile("tile-2", TileColor.RED, 10),
+            tile("tile-3", TileColor.RED, 10),
+        )
+        val player = player().copy(rackTiles = tiles)
+        val game = game(player)
+        val draft = draft(
+            boardSets = listOf(
+                BoardSet(boardSetId = "set-1", tiles = tiles)))
+
+        val result = service.validate(game, player, draft)
+
+        assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `returns valid when newly committed is higher than 30`() {
+        val tiles = listOf(
+            tile("tile-1", TileColor.RED, 13),
+            tile("tile-2", TileColor.RED, 13),
+            tile("tile-3", TileColor.RED, 13)
+
+        )
+        val player = player().copy(rackTiles = tiles)
+        val game = game(player)
+        val draft = draft(
+            boardSets = listOf(
+                BoardSet(boardSetId = "set-1", tiles = tiles)
+            )
+        )
+
+        val result = service.validate(game, player, draft)
+
+        assertTrue(result.isValid)
+    }
+
 
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -2,6 +2,7 @@ package at.se2group.backend.rules.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import shared.models.game.domain.*
 import java.time.Instant
@@ -34,10 +35,13 @@ class FirstMoveValidationServiceTest {
     )
 
     @Test
-    fun `validate throws not implemented yet`() {
-        val exception = assertThrows(UnsupportedOperationException::class.java) {
-            service.validate(game(player()), player(), draft())
-        }
-        assertEquals("Not implemented yet", exception.message)
+    fun `returns valid when player already completed initial meld`() {
+       val result = service.validate(
+           confirmedGame = game(player(hasCompletedInitialMeld = true)),
+           actingPlayer = player(hasCompletedInitialMeld = true),
+           submittedDraft = draft()
+       )
+        assertTrue(result.isValid)
+        assertTrue(result.violations.isEmpty())
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/FirstMoveValidationServiceTest.kt
@@ -1,0 +1,43 @@
+package at.se2group.backend.rules.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import shared.models.game.domain.*
+import java.time.Instant
+
+class FirstMoveValidationServiceTest {
+
+    private val service = FirstMoveValidationService()
+
+    private fun player(hasCompletedInitialMeld: Boolean = false) = GamePlayer(
+        userId = "user-1",
+        displayName = "Alice",
+        turnOrder = 1,
+        hasCompletedInitialMeld = hasCompletedInitialMeld,
+        joinedAt = Instant.now()
+    )
+
+    private fun game(player: GamePlayer) = ConfirmedGame(
+        gameId = "game-1",
+        lobbyId = "lobby-1",
+        players = listOf(player),
+        currentPlayerUserId = "user-1",
+        status = GameStatus.ACTIVE
+    )
+
+    private fun draft(boardSets: List<BoardSet> = emptyList()) = TurnDraft(
+        gameId = "game-1",
+        playerUserId = "user-1",
+        boardSets = boardSets,
+        rackTiles = emptyList()
+    )
+
+    @Test
+    fun `validate throws not implemented yet`() {
+        val exception = assertThrows(UnsupportedOperationException::class.java) {
+            service.validate(game(player()), player(), draft())
+        }
+        assertEquals("Not implemented yet", exception.message)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -29,12 +29,17 @@ class RummikubRuleServiceTest {
     @Mock
     lateinit var boardValidationService: BoardValidationService
 
+    @Mock
+    lateinit var firstMoveValidationService: FirstMoveValidationService
+
     private val ruleService by lazy {
-        RummikubRuleService(tileConservationService, boardValidationService)
+        RummikubRuleService(tileConservationService, boardValidationService, firstMoveValidationService)
     }
+
     private val realRuleService = RummikubRuleService(
         TileConservationService(),
-        BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService()))
+        BoardValidationService(SetValidationService(GroupValidationService(), RunValidationService())),
+        FirstMoveValidationService()
     )
 
     private val player = GamePlayer(
@@ -63,6 +68,7 @@ class RummikubRuleServiceTest {
     fun `returns valid when both tile conservation and board validation pass`() {
         whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
         whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
 
         val result = ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -78,6 +84,7 @@ class RummikubRuleServiceTest {
     fun `invokes tile conservation service`() {
         whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
         whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
 
         ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -92,6 +99,8 @@ class RummikubRuleServiceTest {
     fun `invokes board validation service`() {
         whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
         whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
+
 
         ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -107,6 +116,7 @@ class RummikubRuleServiceTest {
         whenever(tileConservationService.validate(any(), any(), any()))
             .thenReturn(invalid("TILE_CONSERVATION_VIOLATION", "tile mismatch"))
         whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
 
         val result = ruleService.validateSubmittedDraft(
             confirmedGame = confirmedGame,
@@ -127,6 +137,7 @@ class RummikubRuleServiceTest {
             message = "Run must have at least 3 tiles",
         )
         whenever(boardValidationService.validate(any())).thenReturn(ValidationResult(violations = listOf(boardViolation)))
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
 
 
         val result = ruleService.validateSubmittedDraft(
@@ -151,6 +162,7 @@ class RummikubRuleServiceTest {
         )
         whenever(boardValidationService.validate(any()))
             .thenReturn(ValidationResult(violations = listOf(boardViolation)))
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
 
 
         val result = ruleService.validateSubmittedDraft(
@@ -222,6 +234,43 @@ class RummikubRuleServiceTest {
             result.violations.map { it.code }
         )
         assertTrue(result.violations.all { it.boardSetId == "set-1" })
+    }
+
+    @Test
+    fun `invokes first move validation service`() {
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
+
+        ruleService.validateSubmittedDraft(confirmedGame, "user-1", submittedDraft)
+
+        verify(firstMoveValidationService).validate(confirmedGame, player, submittedDraft)
+    }
+
+    @Test
+    fun `returns invalid when initial meld score is too low`(){
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any()))
+            .thenReturn(invalid("INITIAL_MELD_SCORE_TOO_LOW", "Initial meld score must be at least 30 points"))
+
+        val result = ruleService.validateSubmittedDraft(confirmedGame, "user-1", submittedDraft)
+
+        assertFalse(result.isValid)
+        assertEquals("INITIAL_MELD_SCORE_TOO_LOW", result.violations.single().code)
+
+    }
+
+    @Test
+    fun `returns valid when initial meld score is at least 30`() {
+        whenever(tileConservationService.validate(any(), any(), any())).thenReturn(valid())
+        whenever(boardValidationService.validate(any())).thenReturn(valid())
+        whenever(firstMoveValidationService.validate(any(), any(), any())).thenReturn(valid())
+
+        val result = ruleService.validateSubmittedDraft(confirmedGame, "user-1", submittedDraft)
+
+        assertTrue(result.isValid)
+
     }
 
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/rules/service/RummikubRuleServiceTest.kt
@@ -186,7 +186,7 @@ class RummikubRuleServiceTest {
             NumberedTile("tile-3", TileColor.RED, 5)
         )
         val game = confirmedGame.copy(
-            players = listOf(player.copy(rackTiles = jokerRun))
+            players = listOf(player.copy(rackTiles = jokerRun, hasCompletedInitialMeld = true))
         )
         val draft = TurnDraft(
             gameId = "game-1",
@@ -213,7 +213,7 @@ class RummikubRuleServiceTest {
             JokerTile("tile-3", TileColor.RED)
         )
         val game = confirmedGame.copy(
-            players = listOf(player.copy(rackTiles = allJokers))
+            players = listOf(player.copy(rackTiles = allJokers, hasCompletedInitialMeld = true))
         )
         val draft = TurnDraft(
             gameId = "game-1",


### PR DESCRIPTION
# PR Summary: Initial Meld Rule in the Backend

![Backend](https://img.shields.io/badge/Scope-Backend-0f172a)
![Game Rules](https://img.shields.io/badge/Domain-Game%20Rules-1d4ed8)
![Initial Meld](https://img.shields.io/badge/Feature-Initial%20Meld-15803d)
![Status](https://img.shields.io/badge/PR%20Guide-Implementation%20Spec-7c3aed)

## Summary

Add backend enforcement for the initial meld rule during end-turn submission.

Introduce a dedicated first-move validator, integrate it into the top-level
Rummikub rule orchestration, reject first submitted turns below the 30-point
threshold, and mark the acting player as having completed their initial meld
after a successful first submission.

---

## Why

The current backend already validates tile conservation and board legality on end turn,
but it does not yet enforce the initial meld rule. This means a player can currently
commit their first turn with any number of points, which is not valid Rummikub.

This PR closes that gap.

---

## What is implemented

- `FirstMoveValidationService` — validates the initial meld threshold
- `RummikubRuleService` — wired to include first-move validation after board validation
- `EndTurnService` — marks `hasCompletedInitialMeld = true` after a successful first meld
- focused unit tests for `FirstMoveValidationService`
- updated tests for `RummikubRuleService` and `EndTurnService`

---

## Validation rules

- only applies to players whose `hasCompletedInitialMeld` is `false`
- newly committed rack tiles must sum to at least **30 points**
- tiles already on the confirmed board before the turn do not count
- joker tiles are scored as 0 points in this PR — joker scoring is a follow-up

---

## Validation order on end turn

1. tile conservation
2. board validation
3. initial meld validation

Reason: initial meld scoring only makes sense once the board is already legal.

---

## Score calculation

```kotlin
val confirmedBoardTileIds = confirmedGame.boardSets
    .flatMap { it.tiles }
    .map { it.tileId }
    .toSet()

val confirmedRackTileIds = actingPlayer.rackTiles
    .map { it.tileId }
    .toSet()

val newlyCommittedTiles = submittedDraft.boardSets
    .flatMap { it.tiles }
    .filter { it.tileId !in confirmedBoardTileIds }
    .filter { it.tileId in confirmedRackTileIds }

val score = newlyCommittedTiles.sumOf { tile ->
    when (tile) {
        is NumberedTile -> tile.number
        else -> 0
    }
}
```

---

## Error shape

```json
{
  "errorCode": "INVALID_TURN_SUBMISSION",
  "errorMessage": "Turn submission failed validation",
  "violations": [
    {
      "code": "INITIAL_MELD_TOO_LOW",
      "message": "Initial meld must score at least 30 points",
      "boardSetId": null,
      "tileIds": []
    }
  ]
}
```

---

## Example end-turn flow

### First successful initial meld

```text
Player hasCompletedInitialMeld = false
-> player submits legal draft
-> newly committed rack tiles sum to 34
-> validation passes
-> turn commits
-> player.hasCompletedInitialMeld becomes true
-> next turns skip first-move rule
```

### Failed first meld

```text
Player hasCompletedInitialMeld = false
-> player submits legal draft
-> newly committed rack tiles sum to 21
-> validation fails
-> end-turn is rejected
-> confirmed game does not change
-> hasCompletedInitialMeld stays false
```

### Later turn after initial meld is already completed

```text
Player hasCompletedInitialMeld = true
-> player submits legal draft with 12 points
-> initial-meld validator is skipped
-> normal validation decides outcome
```

---

## State transition in EndTurnService

```kotlin
val resolvedGame = commitDraftToConfirmedGame(game, submittedDraft)
    .applyInitialMeldCompletion(userId)
    .finishIfWinnerExists(userId)
```

```kotlin
private fun ConfirmedGame.applyInitialMeldCompletion(
    actingPlayerUserId: String
): ConfirmedGame {
    val updatedPlayers = players.map { player ->
        if (player.userId == actingPlayerUserId && !player.hasCompletedInitialMeld) {
            player.copy(hasCompletedInitialMeld = true)
        } else {
            player
        }
    }
    return copy(players = updatedPlayers)
}
```

---

## Out of scope

- advanced joker scoring resolution
- draft update restrictions based on initial meld
- websocket changes
- first-move rule variants such as rack-only restriction

---
