### PR TITLE
feat(backend)(security)(jwt,auth,session): replace `X-User-Id` with `JWT` bearer authentication

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,8 +59,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Run frontend tests
-        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport
+      - name: Run frontend debug tests
+        run: ./gradlew clean :apps:android:app:testDebugUnitTest
+
+      - name: Run frontend release coverage task
+        run: ./gradlew :apps:android:app:testReleaseUnitTest :apps:android:app:jacocoTestReport
 
       - name: Run frontend Sonar analysis
         uses: SonarSource/sonarqube-scan-action@v6

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,15 +76,25 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
-          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
-          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken // empty')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken // empty')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
             fi
           done
+
+          if [ -n "$SCAN_HOST_ACCESS_TOKEN" ] && [ -n "$SCAN_GUEST_ACCESS_TOKEN" ]; then
+            SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+            SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+            SCAN_JOIN_USER_ID_LINE=""
+          else
+            SCAN_HOST_AUTH_HEADER="X-User-Id:$SCAN_HOST_USER_ID"
+            SCAN_GUEST_AUTH_HEADER="X-User-Id:$SCAN_GUEST_USER_ID"
+            SCAN_JOIN_USER_ID_LINE='            "userId": "scan-join-user",'
+          fi
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"
@@ -93,6 +103,9 @@ jobs:
             echo "SCAN_GUEST_USER_ID=$SCAN_GUEST_USER_ID"
             echo "SCAN_HOST_ACCESS_TOKEN=$SCAN_HOST_ACCESS_TOKEN"
             echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
+            echo "SCAN_HOST_AUTH_HEADER=$SCAN_HOST_AUTH_HEADER"
+            echo "SCAN_GUEST_AUTH_HEADER=$SCAN_GUEST_AUTH_HEADER"
+            echo "SCAN_JOIN_USER_ID_LINE=$SCAN_JOIN_USER_ID_LINE"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -102,6 +115,9 @@ jobs:
             -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
             -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
             -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
+            -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+            -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+            -e "s|__SCAN_JOIN_USER_ID_LINE__|$SCAN_JOIN_USER_ID_LINE|g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -115,7 +131,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_ACCESS_TOKEN:-}" ] && [ -n "${SCAN_GUEST_ACCESS_TOKEN:-}" ]; then
+          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_AUTH_HEADER:-}" ] && [ -n "${SCAN_GUEST_AUTH_HEADER:-}" ]; then
             sed \
               -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
               -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
@@ -123,6 +139,9 @@ jobs:
               -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
               -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
               -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
+              -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+              -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+              -e "s|__SCAN_JOIN_USER_ID_LINE__|${SCAN_JOIN_USER_ID_LINE:-}|g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,25 +76,19 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
-          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken // empty')"
-          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken // empty')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
             fi
           done
 
-          if [ -n "$SCAN_HOST_ACCESS_TOKEN" ] && [ -n "$SCAN_GUEST_ACCESS_TOKEN" ]; then
-            SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
-            SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
-            SCAN_JOIN_USER_ID_LINE=""
-          else
-            SCAN_HOST_AUTH_HEADER="X-User-Id:$SCAN_HOST_USER_ID"
-            SCAN_GUEST_AUTH_HEADER="X-User-Id:$SCAN_GUEST_USER_ID"
-            SCAN_JOIN_USER_ID_LINE='            "userId": "scan-join-user",'
-          fi
+          SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+          SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+          SCAN_JOIN_USER_ID_LINE=""
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,8 +76,10 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
@@ -89,6 +91,8 @@ jobs:
             echo "SCAN_GAME_ID=$SCAN_GAME_ID"
             echo "SCAN_HOST_USER_ID=$SCAN_HOST_USER_ID"
             echo "SCAN_GUEST_USER_ID=$SCAN_GUEST_USER_ID"
+            echo "SCAN_HOST_ACCESS_TOKEN=$SCAN_HOST_ACCESS_TOKEN"
+            echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -96,6 +100,8 @@ jobs:
             -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
             -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
             -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+            -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
+            -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -109,12 +115,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ]; then
+          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_ACCESS_TOKEN:-}" ] && [ -n "${SCAN_GUEST_ACCESS_TOKEN:-}" ]; then
             sed \
               -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
               -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
               -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
               -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+              -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
+              -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -88,7 +88,6 @@ jobs:
 
           SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
           SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
-          SCAN_JOIN_USER_ID_LINE=""
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"
@@ -99,7 +98,6 @@ jobs:
             echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
             echo "SCAN_HOST_AUTH_HEADER=$SCAN_HOST_AUTH_HEADER"
             echo "SCAN_GUEST_AUTH_HEADER=$SCAN_GUEST_AUTH_HEADER"
-            echo "SCAN_JOIN_USER_ID_LINE=$SCAN_JOIN_USER_ID_LINE"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -111,7 +109,6 @@ jobs:
             -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
             -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
             -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
-            -e "s|__SCAN_JOIN_USER_ID_LINE__|$SCAN_JOIN_USER_ID_LINE|g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -135,7 +132,6 @@ jobs:
               -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
               -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
               -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
-              -e "s|__SCAN_JOIN_USER_ID_LINE__|${SCAN_JOIN_USER_ID_LINE:-}|g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -72,6 +72,8 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -80,7 +82,6 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies
         method: POST
         headers:
-          - "X-User-Id:scan-ephemeral-user"
           - "Content-Type:application/json"
         data: |
           {
@@ -100,7 +101,6 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
-            "userId": "scan-join-user",
             "displayName": "Scan Join User"
           }
         responseCode: 404
@@ -111,7 +111,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
         method: PATCH
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -127,12 +127,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/ready
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/unready
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -141,7 +141,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/leave
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -150,7 +150,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: DELETE
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 204
 
   - type: requestor
@@ -159,7 +159,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -168,7 +168,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -177,7 +177,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: DELETE
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -185,6 +185,8 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -193,7 +195,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draft
         method: PUT
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -221,7 +223,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -230,7 +232,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/end-turn
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -263,11 +265,13 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -291,12 +295,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -101,7 +101,6 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
-__SCAN_JOIN_USER_ID_LINE__
             "displayName": "Scan Join User"
           }
         responseCode: 404

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -73,7 +73,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -101,6 +101,7 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
+__SCAN_JOIN_USER_ID_LINE__
             "displayName": "Scan Join User"
           }
         responseCode: 404
@@ -111,7 +112,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
         method: PATCH
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -127,12 +128,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/ready
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/unready
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -141,7 +142,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/leave
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -150,7 +151,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: DELETE
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 204
 
   - type: requestor
@@ -159,7 +160,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -168,7 +169,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -177,7 +178,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: DELETE
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -186,7 +187,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -195,7 +196,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draft
         method: PUT
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -223,7 +224,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -232,7 +233,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/end-turn
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -266,12 +267,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -295,12 +296,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {

--- a/apps/android/app/src/test/java/at/aau/serg/android/core/network/game/GameWebSocketServiceTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/core/network/game/GameWebSocketServiceTest.kt
@@ -93,7 +93,9 @@ class GameWebSocketServiceTest {
                 "status": "ACTIVE",
                 "createdAt": "2026-01-01T00:00:00Z",
                 "startedAt": null,
-                "finishedAt": null
+                "finishedAt": null,
+                "totalTurnsCompleted": 0,
+                "winnerUserId": null
               }
             }
         """.trimIndent()

--- a/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/GameNetworkMapperTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/GameNetworkMapperTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import shared.models.game.domain.*
+import shared.models.game.response.GamePlayerMetricsResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
 import shared.models.game.response.TileResponse
@@ -15,6 +16,16 @@ import java.time.Instant
 
 class GameNetworkMapperTest {
     private val fakeDate: String = "2025-01-01T10:00:00Z"
+    private val emptyMetrics = GamePlayerMetricsResponse(
+        turnsCompleted = 0,
+        tilesPlayed = 0,
+        meldsCreated = 0,
+        pointsPlayed = 0,
+        tilesRemainingAtEnd = null,
+        penaltyPointsAtEnd = null,
+        winner = false,
+        finishPosition = null
+    )
 
     @Test
     fun numberedTile_to_tileRequest() {
@@ -104,7 +115,8 @@ class GameNetworkMapperTest {
             rackTiles = listOf(TileResponse("t1", "RED", 5, false)),
             hasCompletedInitialMeld = true,
             score = 100,
-            joinedAt = now
+            joinedAt = now,
+            metrics = emptyMetrics
         )
 
         val domain = response.toDomain()
@@ -129,7 +141,8 @@ class GameNetworkMapperTest {
                     rackTiles = emptyList(),
                     hasCompletedInitialMeld = false,
                     score = 0,
-                    joinedAt = fakeDate
+                    joinedAt = fakeDate,
+                    metrics = emptyMetrics
                 )
             ),
             drawPile = emptyList(),
@@ -148,7 +161,9 @@ class GameNetworkMapperTest {
             drawPileCount = 0,
             currentTurnPlayerId = "u1",
             turnDeadline = fakeDate,
-            remainingTurnSeconds = 0
+            remainingTurnSeconds = 0,
+            totalTurnsCompleted = 0,
+            winnerUserId = null
         )
 
         val domain = response.toDomain()
@@ -174,7 +189,8 @@ class GameNetworkMapperTest {
                     rackTiles = emptyList(),
                     hasCompletedInitialMeld = false,
                     score = 0,
-                    joinedAt = fakeDate
+                    joinedAt = fakeDate,
+                    metrics = emptyMetrics
                 )
             ),
             drawPile = emptyList(),
@@ -187,7 +203,9 @@ class GameNetworkMapperTest {
             drawPileCount = 0,
             currentTurnPlayerId = "u1",
             turnDeadline = "null",
-            remainingTurnSeconds = 0
+            remainingTurnSeconds = 0,
+            totalTurnsCompleted = 0,
+            winnerUserId = null
         )
 
         val domain = response.toDomain()

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -46,6 +46,7 @@ import shared.models.game.event.GameUpdatedEvent
 import shared.models.game.event.TurnChangedEvent
 import shared.models.game.event.TurnTimedOutEvent
 import shared.models.game.response.BoardSetResponse
+import shared.models.game.response.GamePlayerMetricsResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
 import shared.models.game.response.TileResponse
@@ -89,6 +90,17 @@ class GameViewModelTest {
         ),
     )
 
+    private val emptyMetrics = GamePlayerMetricsResponse(
+        turnsCompleted = 0,
+        tilesPlayed = 0,
+        meldsCreated = 0,
+        pointsPlayed = 0,
+        tilesRemainingAtEnd = null,
+        penaltyPointsAtEnd = null,
+        winner = false,
+        finishPosition = null
+    )
+
     private val fakeGameResponse: GameResponse = GameResponse(
         gameId = "FakeGame1",
         lobbyId = "FakeLobby1",
@@ -100,7 +112,8 @@ class GameViewModelTest {
                 rackTiles = emptyList(),
                 hasCompletedInitialMeld = false,
                 score = 0,
-                joinedAt = "2026-05-08T10:00:00Z"
+                joinedAt = "2026-05-08T10:00:00Z",
+                metrics = emptyMetrics
             )
         ),
         board = emptyList(),
@@ -113,7 +126,9 @@ class GameViewModelTest {
         status = GameStatus.WAITING.toString(),
         createdAt = "2026-05-08T10:00:00Z",
         startedAt = "2026-05-08T10:00:00Z",
-        finishedAt = "2026-05-08T10:00:00Z"
+        finishedAt = "2026-05-08T10:00:00Z",
+        totalTurnsCompleted = 0,
+        winnerUserId = null
     )
 
     fun setTestGameState() {

--- a/apps/backend/build.gradle.kts
+++ b/apps/backend/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(projects.apps.shared)
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.actuator)
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation(libs.jackson.module.kotlin)
     implementation(libs.kotlin.reflect)
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.5")
@@ -35,9 +36,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.h2database:h2")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("com.auth0:java-jwt:4.4.0")
 
 
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.withType<Test> {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/BackendApplication.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/BackendApplication.kt
@@ -1,9 +1,11 @@
 package at.se2group.backend
 
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class BackendApplication
 
 fun main(args: Array<String>) {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/GameController.kt
@@ -6,18 +6,19 @@ import at.se2group.backend.service.GameService
 import at.se2group.backend.service.TurnDraftService
 import at.se2group.backend.service.DrawTileService
 import at.se2group.backend.service.EndTurnService
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.PostMapping
 import shared.models.game.request.UpdateDraftRequest
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import shared.models.game.response.TurnDraftResponse
 import shared.models.game.request.EndTurnRequest
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 
 @RestController
 @RequestMapping("/api/games")
@@ -28,42 +29,50 @@ class GameController(
     private val endTurnService: EndTurnService
 ) {
     @GetMapping("/{gameId}")
-    fun getGame(@PathVariable gameId: String): GameResponse {
-        return gameService.getGame(gameId).toResponse()
+    @SecurityRequirement(name = "bearerAuth")
+    fun getGame(
+        @PathVariable gameId: String,
+        authentication: Authentication
+    ): GameResponse {
+        return gameService.getGameForUser(gameId, authentication.name).toResponse()
     }
 
     @PutMapping("/{gameId}/draft")
+    @SecurityRequirement(name = "bearerAuth")
     fun updateDraft(
         @PathVariable gameId: String,
-        @RequestHeader("X-User-Id") userId: String,
+        authentication: Authentication,
         @Valid @RequestBody request: UpdateDraftRequest
     ): TurnDraftResponse {
 
-        return turnDraftService.updateDraft(gameId, userId, request).toResponse()
+        return turnDraftService.updateDraft(gameId, authentication.name, request).toResponse()
     }
 
     @PostMapping("/{gameId}/draw")
+    @SecurityRequirement(name = "bearerAuth")
     fun drawTile(
         @PathVariable gameId: String,
-        @RequestHeader("X-User-Id") userId: String
+        authentication: Authentication
     ): GameResponse {
-        return drawTileService.drawTile(gameId, userId).toResponse()
+        return drawTileService.drawTile(gameId, authentication.name).toResponse()
     }
 
     @PostMapping("/{gameId}/end-turn")
+    @SecurityRequirement(name = "bearerAuth")
     fun endTurn(
         @PathVariable gameId: String,
-        @RequestHeader("X-User-Id") userId: String,
+        authentication: Authentication,
         @Valid @RequestBody request: EndTurnRequest
     ): GameResponse {
-        return endTurnService.endTurn(gameId, userId, request).toResponse()
+        return endTurnService.endTurn(gameId, authentication.name, request).toResponse()
     }
 
     @PostMapping("/{gameId}/reset-draft")
+    @SecurityRequirement(name = "bearerAuth")
     fun resetDraft(
         @PathVariable gameId: String,
-        @RequestHeader("X-User-Id") userId: String
+        authentication: Authentication
     ): TurnDraftResponse {
-        return turnDraftService.resetDraft(gameId,userId).toResponse()
+        return turnDraftService.resetDraft(gameId,authentication.name).toResponse()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/LobbyController.kt
@@ -1,8 +1,11 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.dto.AuthenticatedLobbyResponse
 import at.se2group.backend.dto.LobbyListItemResponse
 import at.se2group.backend.mapper.toListItemResponse
 import at.se2group.backend.service.LobbyService
+import at.se2group.backend.service.LobbyAuthenticationService
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,18 +15,19 @@ import at.se2group.backend.dto.LobbyResponse
 import at.se2group.backend.mapper.toResponse
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.PathVariable
 import at.se2group.backend.dto.JoinLobbyRequest
 import at.se2group.backend.dto.UpdateLobbySettingsRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 
 @RestController
 @RequestMapping("/api/lobbies")
 class LobbyController(
-    private val lobbyService: LobbyService
+    private val lobbyService: LobbyService,
+    private val lobbyAuthenticationService: LobbyAuthenticationService
 ) {
 
     @GetMapping
@@ -34,48 +38,53 @@ class LobbyController(
 
     @PostMapping
     fun createLobby(
-        @RequestHeader("X-User-Id") userId: String,
        @Valid @RequestBody request: CreateLobbyRequest
-    ): LobbyResponse {
-        return lobbyService.createLobby(userId, request)
-            .toResponse()
+    ): AuthenticatedLobbyResponse {
+        return lobbyAuthenticationService.createAuthenticatedLobby(request)
     }
 
     @GetMapping("/{lobbyId}")
-    fun getLobby(@PathVariable lobbyId: String): LobbyResponse {
-        return lobbyService.getLobby(lobbyId).toResponse()
+    @SecurityRequirement(name = "bearerAuth")
+    fun getLobby(
+        @PathVariable lobbyId: String,
+        authentication: Authentication
+    ): LobbyResponse {
+        return lobbyService.getLobbyForUser(lobbyId, authentication.name).toResponse()
     }
     @PostMapping("/{lobbyId}/join")
     fun joinLobby(
         @PathVariable lobbyId: String,
         @Valid @RequestBody request: JoinLobbyRequest
-    ): LobbyResponse {
-        return lobbyService.joinLobby(lobbyId, request).toResponse()
+    ): AuthenticatedLobbyResponse {
+        return lobbyAuthenticationService.joinAuthenticatedLobby(lobbyId, request)
     }
 
     @PatchMapping("/{lobbyId}/settings")
+    @SecurityRequirement(name = "bearerAuth")
     fun updateLobbySettings(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String,
+        authentication: Authentication,
         @Valid @RequestBody request: UpdateLobbySettingsRequest
     ): LobbyResponse {
-        return lobbyService.updateLobbySettings(lobbyId, userId, request).toResponse()
+        return lobbyService.updateLobbySettings(lobbyId, authentication.name, request).toResponse()
     }
 
     @PostMapping("/{lobbyId}/start")
+    @SecurityRequirement(name = "bearerAuth")
     fun startLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String
+        authentication: Authentication
     ): LobbyResponse {
-        return lobbyService.startLobby(lobbyId, userId).toResponse()
+        return lobbyService.startLobby(lobbyId, authentication.name).toResponse()
     }
 
     @PostMapping("/{lobbyId}/leave")
+    @SecurityRequirement(name = "bearerAuth")
     fun leaveLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String,
+        authentication: Authentication,
         ): ResponseEntity<Any> {
-        val updatedLobby = lobbyService.leaveLobby(lobbyId, userId)
+        val updatedLobby = lobbyService.leaveLobby(lobbyId, authentication.name)
 
         return if (updatedLobby == null) {
             ResponseEntity.noContent().build()
@@ -85,27 +94,30 @@ class LobbyController(
     }
 
     @PostMapping("/{lobbyId}/ready")
+    @SecurityRequirement(name = "bearerAuth")
     fun readyLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String,
+        authentication: Authentication,
     ): LobbyResponse {
-        return lobbyService.readyLobby(lobbyId, userId).toResponse()
+        return lobbyService.readyLobby(lobbyId, authentication.name).toResponse()
     }
 
     @PostMapping("/{lobbyId}/unready")
+    @SecurityRequirement(name = "bearerAuth")
     fun unreadyLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String
+        authentication: Authentication
      ): LobbyResponse {
-        return lobbyService.unreadyLobby(lobbyId, userId).toResponse()
+        return lobbyService.unreadyLobby(lobbyId, authentication.name).toResponse()
     }
 
     @DeleteMapping("/{lobbyId}")
+    @SecurityRequirement(name = "bearerAuth")
     fun deleteLobby(
         @PathVariable lobbyId: String,
-        @RequestHeader("X-User-Id") userId: String
+        authentication: Authentication
     ): ResponseEntity<Unit> {
-        lobbyService.deleteLobby(lobbyId, userId)
+        lobbyService.deleteLobby(lobbyId, authentication.name)
         return ResponseEntity.noContent().build()
     }
 }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
@@ -1,5 +1,6 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.security.JwtService
 import at.se2group.backend.service.SecurityScanFixtureService
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.beans.factory.annotation.Value
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 )
 class SecurityScanFixtureController(
     private val securityScanFixtureService: SecurityScanFixtureService,
+    private val jwtService: JwtService,
     @Value("\${app.scan-fixture.secret:}") private val expectedSecret: String
 ) {
 
@@ -37,7 +39,9 @@ class SecurityScanFixtureController(
             hostUserId = state.hostUserId,
             guestUserId = state.guestUserId,
             gameId = state.gameId,
-            draftOwnerUserId = state.draftOwnerUserId
+            draftOwnerUserId = state.draftOwnerUserId,
+            hostAccessToken = jwtService.issueAccessToken(state.hostUserId),
+            guestAccessToken = jwtService.issueAccessToken(state.guestUserId)
         )
     }
 }
@@ -47,5 +51,7 @@ data class SecurityScanFixtureResponse(
     val hostUserId: String,
     val guestUserId: String,
     val gameId: String,
-    val draftOwnerUserId: String
+    val draftOwnerUserId: String,
+    val hostAccessToken: String,
+    val guestAccessToken: String
 )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/AuthenticatedLobbyResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/AuthenticatedLobbyResponse.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.dto
+
+data class AuthenticatedLobbyResponse(
+    val accessToken: String,
+    val lobby: LobbyResponse
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/JoinLobbyRequest.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/JoinLobbyRequest.kt
@@ -3,10 +3,6 @@ package at.se2group.backend.dto
 import jakarta.validation.constraints.NotBlank
 
 data class JoinLobbyRequest(
-
-    @field:NotBlank(message = "userId must not be blank")
-    val userId: String,
-
     @field:NotBlank(message = "displayName must not be blank")
     val displayName: String
 )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/InvalidBearerTokenAuthenticationException.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/InvalidBearerTokenAuthenticationException.kt
@@ -1,0 +1,6 @@
+package at.se2group.backend.security
+
+import org.springframework.security.core.AuthenticationException
+
+class InvalidBearerTokenAuthenticationException :
+    AuthenticationException("Missing or invalid bearer token")

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt
@@ -6,10 +6,8 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.AuthenticationEntryPoint
-import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-@Component
 class JwtAuthenticationFilter(
     private val jwtService: JwtService,
     private val authenticationEntryPoint: AuthenticationEntryPoint
@@ -27,7 +25,11 @@ class JwtAuthenticationFilter(
             return
         }
 
-        if (!authorization.startsWith("Bearer ")) {
+        val parts = authorization.trim().split(Regex("\\s+"), limit = 2)
+        val scheme = parts.firstOrNull()
+        val token = parts.getOrNull(1)?.trim()
+
+        if (!scheme.equals("Bearer", ignoreCase = true) || token.isNullOrBlank()) {
             authenticationEntryPoint.commence(
                 request,
                 response,
@@ -35,8 +37,6 @@ class JwtAuthenticationFilter(
             )
             return
         }
-
-        val token = authorization.removePrefix("Bearer ").trim()
 
         try {
             val userId = jwtService.extractUserId(token)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,55 @@
+package at.se2group.backend.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtService: JwtService,
+    private val authenticationEntryPoint: AuthenticationEntryPoint
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val authorization = request.getHeader("Authorization")
+
+        if (authorization.isNullOrBlank()) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        if (!authorization.startsWith("Bearer ")) {
+            authenticationEntryPoint.commence(
+                request,
+                response,
+                InvalidBearerTokenAuthenticationException()
+            )
+            return
+        }
+
+        val token = authorization.removePrefix("Bearer ").trim()
+
+        try {
+            val userId = jwtService.extractUserId(token)
+            val authentication = UsernamePasswordAuthenticationToken.authenticated(
+                userId,
+                null,
+                emptyList()
+            )
+            SecurityContextHolder.getContext().authentication = authentication
+            filterChain.doFilter(request, response)
+        } catch (ex: InvalidBearerTokenAuthenticationException) {
+            SecurityContextHolder.clearContext()
+            authenticationEntryPoint.commence(request, response, ex)
+        }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtProperties.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtProperties.kt
@@ -1,0 +1,10 @@
+package at.se2group.backend.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app.auth.jwt")
+data class JwtProperties(
+    val issuer: String,
+    val secret: String,
+    val accessTokenTtlSeconds: Long
+)

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/JwtService.kt
@@ -1,0 +1,37 @@
+package at.se2group.backend.security
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.Date
+
+@Service
+class JwtService(
+    private val jwtProperties: JwtProperties
+) {
+    private val algorithm = Algorithm.HMAC256(jwtProperties.secret)
+    private val verifier = JWT.require(algorithm)
+        .withIssuer(jwtProperties.issuer)
+        .build()
+
+    fun issueAccessToken(userId: String): String {
+        val now = Instant.now()
+        val expiresAt = now.plusSeconds(jwtProperties.accessTokenTtlSeconds)
+        return JWT.create()
+            .withIssuer(jwtProperties.issuer)
+            .withSubject(userId)
+            .withIssuedAt(Date.from(now))
+            .withExpiresAt(Date.from(expiresAt))
+            .sign(algorithm)
+    }
+
+    fun extractUserId(token: String): String {
+        return try {
+            verifier.verify(token).subject
+                ?: throw InvalidBearerTokenAuthenticationException()
+        } catch (_: Exception) {
+            throw InvalidBearerTokenAuthenticationException()
+        }
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/OpenApiSecurityConfiguration.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/OpenApiSecurityConfiguration.kt
@@ -1,0 +1,23 @@
+package at.se2group.backend.security
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiSecurityConfiguration {
+    @Bean
+    fun backendOpenApi(): OpenAPI {
+        return OpenAPI().components(
+            Components().addSecuritySchemes(
+                "bearerAuth",
+                SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+            )
+        )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/RestAccessDeniedHandler.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/RestAccessDeniedHandler.kt
@@ -1,0 +1,32 @@
+package at.se2group.backend.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import shared.models.api.ApiErrorResponse
+
+@Component
+class RestAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        response.status = HttpServletResponse.SC_FORBIDDEN
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.write(
+            objectMapper.writeValueAsString(
+                ApiErrorResponse(
+                    errorCode = "FORBIDDEN",
+                    errorMessage = "Access denied"
+                )
+            )
+        )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/RestAuthenticationEntryPoint.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/RestAuthenticationEntryPoint.kt
@@ -1,0 +1,32 @@
+package at.se2group.backend.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import shared.models.api.ApiErrorResponse
+
+@Component
+class RestAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.write(
+            objectMapper.writeValueAsString(
+                ApiErrorResponse(
+                    errorCode = "UNAUTHORIZED",
+                    errorMessage = "Missing or invalid bearer token"
+                )
+            )
+        )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt
@@ -1,0 +1,46 @@
+package at.se2group.backend.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val restAuthenticationEntryPoint: RestAuthenticationEntryPoint,
+    private val restAccessDeniedHandler: RestAccessDeniedHandler
+) {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .logout { it.disable() }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .exceptionHandling {
+                it.authenticationEntryPoint(restAuthenticationEntryPoint)
+                it.accessDeniedHandler(restAccessDeniedHandler)
+            }
+            .authorizeHttpRequests {
+                it.requestMatchers("/", "/robots.txt", "/sitemap.xml").permitAll()
+                it.requestMatchers("/actuator/health").permitAll()
+                it.requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                it.requestMatchers("/internal/security/**").permitAll()
+                it.requestMatchers(HttpMethod.GET, "/api/leaderboard").permitAll()
+                it.requestMatchers(HttpMethod.GET, "/api/lobbies").permitAll()
+                it.requestMatchers(HttpMethod.POST, "/api/lobbies").permitAll()
+                it.requestMatchers(HttpMethod.POST, "/api/lobbies/*/join").permitAll()
+                it.anyRequest().authenticated()
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+
+        return http.build()
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt
@@ -10,12 +10,23 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 class SecurityConfig(
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val jwtService: JwtService,
     private val restAuthenticationEntryPoint: RestAuthenticationEntryPoint,
     private val restAccessDeniedHandler: RestAccessDeniedHandler
 ) {
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun jwtAuthenticationFilter(): JwtAuthenticationFilter {
+        return JwtAuthenticationFilter(
+            jwtService = jwtService,
+            authenticationEntryPoint = restAuthenticationEntryPoint
+        )
+    }
+
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        jwtAuthenticationFilter: JwtAuthenticationFilter
+    ): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .httpBasic { it.disable() }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameService.kt
@@ -69,6 +69,14 @@ class GameService(
             .toDomain()
     }
 
+    fun getGameForUser(gameId: String, userId: String): ConfirmedGame {
+        val game = getGame(gameId)
+        if (game.players.none { it.userId == userId }) {
+            throw SecurityException("Only game participants can access this game")
+        }
+        return game
+    }
+
     fun nextPlayerId(game: ConfirmedGame): String{
         val sorted = game.players.sortedBy { it.turnOrder }
         val currentIndex = sorted.indexOfFirst { it.userId == game.currentPlayerUserId }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyAuthenticationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyAuthenticationService.kt
@@ -1,0 +1,33 @@
+package at.se2group.backend.service
+
+import at.se2group.backend.dto.AuthenticatedLobbyResponse
+import at.se2group.backend.dto.CreateLobbyRequest
+import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.mapper.toResponse
+import at.se2group.backend.security.JwtService
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class LobbyAuthenticationService(
+    private val lobbyService: LobbyService,
+    private val jwtService: JwtService
+) {
+    fun createAuthenticatedLobby(request: CreateLobbyRequest): AuthenticatedLobbyResponse {
+        val userId = UUID.randomUUID().toString()
+        val lobby = lobbyService.createLobby(userId, request)
+        return AuthenticatedLobbyResponse(
+            accessToken = jwtService.issueAccessToken(userId),
+            lobby = lobby.toResponse()
+        )
+    }
+
+    fun joinAuthenticatedLobby(lobbyId: String, request: JoinLobbyRequest): AuthenticatedLobbyResponse {
+        val userId = UUID.randomUUID().toString()
+        val lobby = lobbyService.joinLobby(lobbyId, userId, request)
+        return AuthenticatedLobbyResponse(
+            accessToken = jwtService.issueAccessToken(userId),
+            lobby = lobby.toResponse()
+        )
+    }
+}

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -143,6 +143,14 @@ class LobbyService(
         return requireLobbyEntity(lobbyId).toDomain()
     }
 
+    fun getLobbyForUser(lobbyId: String, userId: String): Lobby {
+        val lobby = getLobby(lobbyId)
+        if (lobby.players.none { it.userId == userId }) {
+            throw SecurityException("Only lobby participants can access this lobby")
+        }
+        return lobby
+    }
+
     /**
      * Adds a new player to an existing open lobby.
      *
@@ -157,7 +165,7 @@ class LobbyService(
      * player is already part of the lobby.
      */
     @Transactional
-    fun joinLobby(lobbyId: String, request: JoinLobbyRequest): Lobby {
+    fun joinLobby(lobbyId: String, userId: String, request: JoinLobbyRequest): Lobby {
         val lobbyEntity = requireLobbyEntity(lobbyId)
         val lobby = lobbyEntity.toDomain()
 
@@ -165,11 +173,11 @@ class LobbyService(
 
         check(lobby.players.size < lobby.settings.maxPlayers) { "Lobby is full" }
 
-        check(!(lobby.players.any { it.userId == request.userId })) { "Player already in lobby" }
+        check(!(lobby.players.any { it.userId == userId })) { "Player already in lobby" }
 
         val updatedLobby = lobby.copy(
             players = lobby.players + LobbyPlayer(
-                userId = request.userId,
+                userId = userId,
                 displayName = request.displayName,
                 isReady = false
             )

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -6,6 +6,11 @@ server:
   port: 8080
 
 app:
+  auth:
+    jwt:
+      issuer: ${APP_AUTH_JWT_ISSUER:se2-group-backend}
+      secret: ${APP_AUTH_JWT_SECRET:change-me-in-production-change-me-in-production}
+      access-token-ttl-seconds: ${APP_AUTH_JWT_ACCESS_TOKEN_TTL_SECONDS:86400}
   scan-fixture:
     enabled: ${APP_SCAN_FIXTURE_ENABLED:false}
     secret: ${APP_SCAN_FIXTURE_SECRET:}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt
@@ -1,50 +1,48 @@
 package at.se2group.backend.api
 
-import shared.models.game.domain.ConfirmedGame
-import shared.models.game.domain.GamePlayer
-import shared.models.game.domain.GameStatus
-import shared.models.game.domain.NumberedTile
-import shared.models.game.domain.TileColor
-import at.se2group.backend.service.GameService
-import at.se2group.backend.service.TurnDraftService
+import at.se2group.backend.security.JwtAuthenticationFilter
+import at.se2group.backend.security.InvalidBearerTokenAuthenticationException
+import at.se2group.backend.security.JwtService
+import at.se2group.backend.security.RestAccessDeniedHandler
+import at.se2group.backend.security.RestAuthenticationEntryPoint
+import at.se2group.backend.security.SecurityConfig
 import at.se2group.backend.service.DrawTileService
 import at.se2group.backend.service.EndTurnService
+import at.se2group.backend.service.GameService
 import at.se2group.backend.service.InvalidTurnSubmissionException
+import at.se2group.backend.service.TurnDraftService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
-import java.time.Instant
-import shared.models.game.domain.TurnDraft
-import org.springframework.test.web.servlet.put
 import org.springframework.test.web.servlet.post
-import org.springframework.http.MediaType
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
+import org.springframework.test.web.servlet.put
+import shared.models.game.domain.ConfirmedGame
+import shared.models.game.domain.GamePlayer
 import shared.models.game.domain.GamePlayerMetrics
+import shared.models.game.domain.GameStatus
+import shared.models.game.domain.NumberedTile
+import shared.models.game.domain.TileColor
+import shared.models.game.domain.TurnDraft
 import shared.models.game.validation.ValidationResult
+import java.time.Instant
 
-/**
- * Web-layer tests for [GameController].
- *
- * This class exercises the controller through Spring MVC with mocked game
- * services so that transport behavior can be verified independently from game
- * rules or persistence. For the error-handling PR, the important responsibility
- * here is proving that game endpoints surface the shared REST contract when:
- *
- * - request-entry failures happen before service code is reached
- * - service-layer exceptions are propagated into the global advice
- * - structured invalid-turn conflicts stay distinct from generic conflicts
- *
- * The tests in this class therefore serve as the game-specific confirmation
- * that the global error-handling policy is actually visible at the public API.
- */
 @WebMvcTest(GameController::class)
-@Import(GlobalExceptionHandler::class)
+@Import(
+    GlobalExceptionHandler::class,
+    SecurityConfig::class,
+    RestAuthenticationEntryPoint::class,
+    RestAccessDeniedHandler::class,
+    JwtAuthenticationFilter::class
+)
 class GameControllerTest {
 
     @Autowired
@@ -62,6 +60,9 @@ class GameControllerTest {
     @MockitoBean
     lateinit var endTurnService: EndTurnService
 
+    @MockitoBean
+    lateinit var jwtService: JwtService
+
     @Test
     fun `getGame returns game response`() {
         val game = ConfirmedGame(
@@ -72,9 +73,7 @@ class GameControllerTest {
                     userId = "user-1",
                     displayName = "Alice",
                     turnOrder = 0,
-                    rackTiles = listOf(
-                        NumberedTile("tile-1", TileColor.BLUE, 3)
-                    ),
+                    rackTiles = listOf(NumberedTile("tile-1", TileColor.BLUE, 3)),
                     score = 10,
                     joinedAt = Instant.parse("2026-04-27T17:55:00Z"),
                     metrics = GamePlayerMetrics(
@@ -86,9 +85,7 @@ class GameControllerTest {
                     )
                 )
             ),
-            drawPile = listOf(
-                NumberedTile("tile-2", TileColor.RED, 7)
-            ),
+            drawPile = listOf(NumberedTile("tile-2", TileColor.RED, 7)),
             currentPlayerUserId = "user-1",
             status = GameStatus.ACTIVE,
             createdAt = Instant.parse("2026-04-27T18:00:00Z"),
@@ -96,99 +93,75 @@ class GameControllerTest {
             winnerUserId = null
         )
 
-        `when`(gameService.getGame("game-1")).thenReturn(game)
+        `when`(gameService.getGameForUser("game-1", "user-1")).thenReturn(game)
 
-        mockMvc.get("/api/games/game-1")
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.gameId") { value("game-1") }
-                jsonPath("$.lobbyId") { value("lobby-1") }
-                jsonPath("$.currentPlayerUserId") { value("user-1") }
-                jsonPath("$.currentTurnPlayerId") { value("user-1") }
-                jsonPath("$.status") { value("ACTIVE") }
-                jsonPath("$.drawPileCount") { value(1) }
-                jsonPath("$.turnDeadline") { isEmpty() }
-                jsonPath("$.remainingTurnSeconds") { isEmpty() }
-                jsonPath("$.players[0].userId") { value("user-1") }
-                jsonPath("$.players[0].displayName") { value("Alice") }
-                jsonPath("$.players[0].rackTiles[0].tileId") { value("tile-1") }
-                jsonPath("$.players[0].rackTiles[0].color") { value("BLUE") }
-                jsonPath("$.players[0].rackTiles[0].number") { value(3) }
-                jsonPath("$.players[0].rackTiles[0].isJoker") { value(false) }
-                jsonPath("$.board") { isArray() }
-                jsonPath("$.drawPile[0].tileId") { value("tile-2") }
-                jsonPath("$.drawPile[0].color") { value("RED") }
-                jsonPath("$.totalTurnsCompleted") { value(4) }
-                jsonPath("$.winnerUserId") { isEmpty() }
-                jsonPath("$.players[0].metrics.turnsCompleted") { value(2) }
-                jsonPath("$.players[0].metrics.tilesPlayed") { value(5) }
-                jsonPath("$.players[0].metrics.meldsCreated") { value(1) }
-                jsonPath("$.players[0].metrics.pointsPlayed") { value(18) }
-                jsonPath("$.players[0].metrics.winner") { value(false) }
-            }
+        mockMvc.get("/api/games/game-1") {
+            with(user("user-1"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.gameId") { value("game-1") }
+            jsonPath("$.lobbyId") { value("lobby-1") }
+            jsonPath("$.currentPlayerUserId") { value("user-1") }
+            jsonPath("$.currentTurnPlayerId") { value("user-1") }
+            jsonPath("$.status") { value("ACTIVE") }
+            jsonPath("$.drawPileCount") { value(1) }
+            jsonPath("$.players[0].metrics.turnsCompleted") { value(2) }
+            jsonPath("$.players[0].metrics.tilesPlayed") { value(5) }
+            jsonPath("$.players[0].metrics.meldsCreated") { value(1) }
+            jsonPath("$.players[0].metrics.pointsPlayed") { value(18) }
+            jsonPath("$.players[0].metrics.winner") { value(false) }
+            jsonPath("$.totalTurnsCompleted") { value(4) }
+            jsonPath("$.winnerUserId") { isEmpty() }
+        }
     }
 
     @Test
     fun `getGame returns 404 when game does not exist`() {
-        `when`(gameService.getGame("missing-game"))
+        `when`(gameService.getGameForUser("missing-game", "user-1"))
             .thenThrow(NoSuchElementException("Game not found"))
 
-        mockMvc.get("/api/games/missing-game")
-            .andExpect {
-                status { isNotFound() }
-                jsonPath("$.errorCode") { value("NOT_FOUND") }
-                jsonPath("$.errorMessage") { value("Game not found") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
+        mockMvc.get("/api/games/missing-game") {
+            with(user("user-1"))
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.errorCode") { value("NOT_FOUND") }
+            jsonPath("$.errorMessage") { value("Game not found") }
+        }
     }
 
     @Test
     fun `updateDraft returns ok`() {
-        val requestJson = """
-        {
-            "boardSets": [
-                {
-                    "boardSetId": "set-1",
-                    "type": "UNRESOLVED",
-                    "tiles": [{ "tileId": "tile-3", "color": "BLUE", "number": 3, "isJoker": false }]
-                }
-            ],
-            "rackTiles": [
-                { "tileId": "tile-4", "color": "RED", "number": 5, "isJoker": false }
-            ]
-        }
-    """.trimIndent()
-
         val draft = TurnDraft(
             gameId = "game-1",
             playerUserId = "mock-user",
             version = 3
         )
 
-        `when`(
-            turnDraftService.updateDraft(
-                eq("game-1"),
-                eq("mock-user"),
-                any()
-            )
-        ).thenReturn(draft)
+        `when`(turnDraftService.updateDraft(eq("game-1"), eq("mock-user"), any())).thenReturn(draft)
 
         mockMvc.put("/api/games/game-1/draft") {
-            header("X-User-Id", "mock-user")
+            with(user("mock-user"))
             contentType = MediaType.APPLICATION_JSON
-            content = requestJson
+            content = """
+                {
+                  "boardSets": [
+                    {
+                      "boardSetId": "set-1",
+                      "type": "UNRESOLVED",
+                      "tiles": [{ "tileId": "tile-3", "color": "BLUE", "number": 3, "isJoker": false }]
+                    }
+                  ],
+                  "rackTiles": [
+                    { "tileId": "tile-4", "color": "RED", "number": 5, "isJoker": false }
+                  ]
+                }
+            """.trimIndent()
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.playerUserId") { value("mock-user") }
+            jsonPath("$.version") { value(3) }
         }
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.gameId") { value("game-1") }
-                jsonPath("$.playerUserId") { value("mock-user") }
-                jsonPath("$.draftBoard") { isArray() }
-                jsonPath("$.draftHand") { isArray() }
-                jsonPath("$.version") { value(3) }
-            }
     }
-
-
 
     private fun confirmedGame() = ConfirmedGame(
         gameId = "game-1",
@@ -208,22 +181,15 @@ class GameControllerTest {
 
     @Test
     fun `drawTile returns 200 with game response`() {
-        val game = confirmedGame()
-        `when`(drawTileService.drawTile("game-1", "user-1"))
-            .thenReturn(game)
+        `when`(drawTileService.drawTile("game-1", "user-1")).thenReturn(confirmedGame())
 
         mockMvc.post("/api/games/game-1/draw") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.gameId") { value("game-1") }
+            jsonPath("$.currentPlayerUserId") { value("user-1") }
         }
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.gameId") { value("game-1") }
-                jsonPath("$.currentPlayerUserId") { value("user-1") }
-                jsonPath("$.status") { value("ACTIVE") }
-                jsonPath("$.totalTurnsCompleted") { value(0) }
-                jsonPath("$.winnerUserId") { isEmpty() }
-                jsonPath("$.players[0].metrics.turnsCompleted") { value(0) }
-            }
     }
 
     @Test
@@ -232,14 +198,12 @@ class GameControllerTest {
             .thenThrow(NoSuchElementException("Game not found"))
 
         mockMvc.post("/api/games/missing-game/draw") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.errorCode") { value("NOT_FOUND") }
+            jsonPath("$.errorMessage") { value("Game not found") }
         }
-            .andExpect{
-                status { isNotFound() }
-                jsonPath("$.errorCode") { value("NOT_FOUND") }
-                jsonPath("$.errorMessage") { value("Game not found") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
     }
 
     @Test
@@ -248,70 +212,55 @@ class GameControllerTest {
             .thenThrow(IllegalStateException("Game is not active"))
 
         mockMvc.post("/api/games/game-1/draw") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.errorCode") { value("CONFLICT") }
+            jsonPath("$.errorMessage") { value("Game is not active") }
         }
+    }
 
-            .andExpect{
-                status { isConflict() }
-                jsonPath("$.errorCode") { value("CONFLICT") }
-                jsonPath("$.errorMessage") { value("Game is not active") }
-                jsonPath("$.violations.length()") { value(0) }
+    @Test
+    fun `drawTile returns 401 when bearer authentication is missing`() {
+        mockMvc.post("/api/games/game-1/draw")
+            .andExpect {
+                status { isUnauthorized() }
+                jsonPath("$.errorCode") { value("UNAUTHORIZED") }
+                jsonPath("$.errorMessage") { value("Missing or invalid bearer token") }
             }
     }
 
     @Test
-    fun `drawTile returns 400 when required user header is missing`() {
-        mockMvc.post("/api/games/game-1/draw")
-            .andExpect {
-                status { isBadRequest() }
-                jsonPath("$.errorCode") { value("BAD_REQUEST") }
-                jsonPath("$.errorMessage") { value("Missing required header: X-User-Id") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
+    fun `drawTile returns 401 when bearer token is invalid`() {
+        `when`(jwtService.extractUserId("invalid-token"))
+            .thenThrow(InvalidBearerTokenAuthenticationException())
+
+        mockMvc.post("/api/games/game-1/draw") {
+            header("Authorization", "Bearer invalid-token")
+        }.andExpect {
+            status { isUnauthorized() }
+            jsonPath("$.errorCode") { value("UNAUTHORIZED") }
+            jsonPath("$.errorMessage") { value("Missing or invalid bearer token") }
+        }
     }
 
     @Test
     fun `endTurn returns 200 with game response`() {
-        val requestJson = """
-            {
-                "boardSets": [
-                    {
-                        "boardSetId": "set-1",
-                        "type": "RUN",
-                        "tiles": [
-                            { "tileId": "tile-1", "color": "RED", "number": 3, "isJoker": false },
-                            { "tileId": "tile-2", "color": "RED", "number": 4, "isJoker": false },
-                            { "tileId": "tile-3", "color": "RED", "number": 5, "isJoker": false }
-                        ]
-                    }
-                ],
-                "rackTiles": [
-                    { "tileId": "tile-4", "color": "BLACK", "number": 9, "isJoker": false }
-                ]
-            }
-        """.trimIndent()
-
-        val game = confirmedGame()
-
-        `when`(
-            endTurnService.endTurn(
-                eq("game-1"),
-                eq("user-1"),
-                any()
-            )
-        ).thenReturn(game)
+        `when`(endTurnService.endTurn(eq("game-1"), eq("user-1"), any())).thenReturn(confirmedGame())
 
         mockMvc.post("/api/games/game-1/end-turn") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
             contentType = MediaType.APPLICATION_JSON
-            content = requestJson
+            content = """
+                {
+                  "boardSets": [],
+                  "rackTiles": []
+                }
+            """.trimIndent()
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.gameId") { value("game-1") }
         }
-            .andExpect {
-                status { isOk() }
-                jsonPath("$.gameId") { value("game-1") }
-                jsonPath("$.currentPlayerUserId") { value("user-1") }
-                jsonPath("$.status") { value("ACTIVE") }
-            }
     }
 
     @Test
@@ -320,21 +269,13 @@ class GameControllerTest {
             .thenThrow(NoSuchElementException("Game not found"))
 
         mockMvc.post("/api/games/missing-game/end-turn") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
             contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                    "boardSets": [],
-                    "rackTiles": []
-                }
-            """.trimIndent()
+            content = """{"boardSets":[],"rackTiles":[]}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.errorCode") { value("NOT_FOUND") }
         }
-            .andExpect {
-                status { isNotFound() }
-                jsonPath("$.errorCode") { value("NOT_FOUND") }
-                jsonPath("$.errorMessage") { value("Game not found") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
     }
 
     @Test
@@ -343,21 +284,13 @@ class GameControllerTest {
             .thenThrow(IllegalStateException("Game is not active"))
 
         mockMvc.post("/api/games/game-1/end-turn") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
             contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                    "boardSets": [],
-                    "rackTiles": []
-                }
-            """.trimIndent()
+            content = """{"boardSets":[],"rackTiles":[]}"""
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.errorCode") { value("CONFLICT") }
         }
-            .andExpect {
-                status { isConflict() }
-                jsonPath("$.errorCode") { value("CONFLICT") }
-                jsonPath("$.errorMessage") { value("Game is not active") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
     }
 
     @Test
@@ -366,60 +299,50 @@ class GameControllerTest {
             .thenThrow(InvalidTurnSubmissionException(ValidationResult()))
 
         mockMvc.post("/api/games/game-1/end-turn") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
             contentType = MediaType.APPLICATION_JSON
-            content = """
-                {
-                    "boardSets": [],
-                    "rackTiles": []
-                }
-            """.trimIndent()
+            content = """{"boardSets":[],"rackTiles":[]}"""
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.errorCode") { value("INVALID_TURN_SUBMISSION") }
         }
-            .andExpect {
-                status { isConflict() }
-                jsonPath("$.errorCode") { value("INVALID_TURN_SUBMISSION") }
-                jsonPath("$.errorMessage") { value("Submitted draft is invalid") }
-            }
     }
 
     @Test
     fun `updateDraft returns 400 for malformed json body`() {
         mockMvc.put("/api/games/game-1/draft") {
-            header("X-User-Id", "mock-user")
+            with(user("mock-user"))
             contentType = MediaType.APPLICATION_JSON
             content = """
                 {
-                    "boardSets": [
-                        {
-                            "boardSetId": "set-1",
-                            "type": "NOT_A_REAL_TYPE",
-                            "tiles": []
-                        }
-                    ],
-                    "rackTiles": []
+                  "boardSets": [
+                    {
+                      "boardSetId": "set-1",
+                      "type": "NOT_A_REAL_TYPE",
+                      "tiles": []
+                    }
+                  ],
+                  "rackTiles": []
                 }
             """.trimIndent()
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.errorCode") { value("BAD_REQUEST") }
+            jsonPath("$.errorMessage") { value("Malformed JSON request body") }
         }
-            .andExpect {
-                status { isBadRequest() }
-                jsonPath("$.errorCode") { value("BAD_REQUEST") }
-                jsonPath("$.errorMessage") { value("Malformed JSON request body") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
     }
 
     @Test
     fun `getGame returns 500 for unexpected backend exception`() {
-        `when`(gameService.getGame("game-1"))
+        `when`(gameService.getGameForUser("game-1", "user-1"))
             .thenThrow(RuntimeException("boom"))
 
-        mockMvc.get("/api/games/game-1")
-            .andExpect {
-                status { isInternalServerError() }
-                jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
-                jsonPath("$.errorMessage") { value("An unexpected error occurred") }
-                jsonPath("$.violations.length()") { value(0) }
-            }
+        mockMvc.get("/api/games/game-1") {
+            with(user("user-1"))
+        }.andExpect {
+            status { isInternalServerError() }
+            jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
+        }
     }
 
     @Test
@@ -428,16 +351,15 @@ class GameControllerTest {
             gameId = "game-1",
             playerUserId = "user-1",
             boardSets = emptyList(),
-            rackTiles = listOf(NumberedTile("rack-1", TileColor.RED,5)),
+            rackTiles = listOf(NumberedTile("rack-1", TileColor.RED, 5)),
             version = 4
         )
         `when`(turnDraftService.resetDraft("game-1", "user-1")).thenReturn(draft)
 
         mockMvc.post("/api/games/game-1/reset-draft") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
         }.andExpect {
             status { isOk() }
-            jsonPath("$.gameId") { value("game-1") }
             jsonPath("$.playerUserId") { value("user-1") }
             jsonPath("$.version") { value("4") }
         }
@@ -449,10 +371,9 @@ class GameControllerTest {
             .thenThrow(NoSuchElementException("Game not found"))
 
         mockMvc.post("/api/games/missing/reset-draft") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
         }.andExpect {
             status { isNotFound() }
-            jsonPath("$.errorCode") { value("NOT_FOUND") }
             jsonPath("$.errorMessage") { value("Game not found") }
         }
     }
@@ -463,10 +384,9 @@ class GameControllerTest {
             .thenThrow(NoSuchElementException("Draft not found"))
 
         mockMvc.post("/api/games/game-1/reset-draft") {
-            header("X-User-Id", "user-1")
+            with(user("user-1"))
         }.andExpect {
             status { isNotFound() }
-            jsonPath("$.errorCode") { value("NOT_FOUND") }
             jsonPath("$.errorMessage") { value("Draft not found") }
         }
     }
@@ -477,10 +397,9 @@ class GameControllerTest {
             .thenThrow(IllegalStateException("User is not the current active player"))
 
         mockMvc.post("/api/games/game-1/reset-draft") {
-            header("X-User-Id", "user-2")
+            with(user("user-2"))
         }.andExpect {
             status { isConflict() }
-            jsonPath("$.errorCode") { value("CONFLICT") }
             jsonPath("$.errorMessage") { value("User is not the current active player") }
         }
     }
@@ -491,22 +410,20 @@ class GameControllerTest {
             .thenThrow(IllegalStateException("Draft belongs to a different user"))
 
         mockMvc.post("/api/games/game-1/reset-draft") {
-            header("X-User-Id", "user-2")
+            with(user("user-2"))
         }.andExpect {
             status { isConflict() }
-            jsonPath("$.errorCode") { value("CONFLICT") }
             jsonPath("$.errorMessage") { value("Draft belongs to a different user") }
         }
     }
 
     @Test
-    fun `resetDraft returns 400 when X-User-Id header is missing`() {
+    fun `resetDraft returns 401 when bearer authentication is missing`() {
         mockMvc.post("/api/games/game-1/reset-draft")
             .andExpect {
-                status { isBadRequest() }
-        }
-
+                status { isUnauthorized() }
+                jsonPath("$.errorCode") { value("UNAUTHORIZED") }
+                jsonPath("$.errorMessage") { value("Missing or invalid bearer token") }
+            }
     }
-
-
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/GlobalExceptionHandlerMvcTest.kt
@@ -1,12 +1,16 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.security.JwtService
+import at.se2group.backend.security.RestAuthenticationEntryPoint
 import at.se2group.backend.dto.CreateLobbyRequest
 import jakarta.validation.Valid
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -36,11 +40,15 @@ import org.springframework.web.bind.annotation.RestController
  * layer uses the same REST error contract as the application exception layer.
  */
 @WebMvcTest(ExceptionProbeController::class)
-@Import(GlobalExceptionHandler::class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler::class, RestAuthenticationEntryPoint::class)
 class GlobalExceptionHandlerMvcTest {
 
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var jwtService: JwtService
 
     @Test
     fun `returns 400 for path variable type mismatch`() {
@@ -61,14 +69,6 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.errorCode") { value("BAD_REQUEST") }
                 jsonPath("$.errorMessage") { value("Missing required header: X-Probe-User") }
                 jsonPath("$.violations.length()") { value(0) }
-                header { string("X-Content-Type-Options", "nosniff") }
-                header { string("Cross-Origin-Resource-Policy", "same-origin") }
-                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
-                header { string("Cross-Origin-Opener-Policy", "same-origin") }
-                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
-                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
-                header { string("Pragma", "no-cache") }
-                header { string("Expires", "0") }
             }
     }
 
@@ -115,14 +115,6 @@ class GlobalExceptionHandlerMvcTest {
                 jsonPath("$.errorCode") { value("INTERNAL_SERVER_ERROR") }
                 jsonPath("$.errorMessage") { value("An unexpected error occurred") }
                 jsonPath("$.violations.length()") { value(0) }
-                header { string("X-Content-Type-Options", "nosniff") }
-                header { string("Cross-Origin-Resource-Policy", "same-origin") }
-                header { string("Cross-Origin-Embedder-Policy", "require-corp") }
-                header { string("Cross-Origin-Opener-Policy", "same-origin") }
-                header { string("Strict-Transport-Security", "max-age=31536000; includeSubDomains") }
-                header { string("Cache-Control", "no-cache, no-store, must-revalidate, private") }
-                header { string("Pragma", "no-cache") }
-                header { string("Expires", "0") }
             }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt
@@ -2,36 +2,30 @@ package at.se2group.backend.api
 
 import at.se2group.backend.dto.CreateLobbyRequest
 import at.se2group.backend.dto.JoinLobbyRequest
-import at.se2group.backend.service.LobbyService
+import at.se2group.backend.dto.UpdateLobbySettingsRequest
+import at.se2group.backend.mapper.toResponse
+import at.se2group.backend.security.JwtService
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.post
-import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
 import shared.models.lobby.domain.Lobby
+import shared.models.lobby.domain.LobbyPlayer
 import shared.models.lobby.domain.LobbySettings
 import shared.models.lobby.domain.LobbyStatus
-import shared.models.lobby.domain.LobbyPlayer
-import org.springframework.test.web.servlet.patch
 
-/**
- * MVC tests for [LobbyController].
- *
- * This class uses the real Spring Boot test slice for lobby endpoints and a
- * mocked [LobbyService] so that request validation, controller wiring, and
- * exception mapping can be verified together. For the error-handling PR, its
- * main value is proving that lobby DTO bean validation is normalized into the
- * shared `ApiErrorResponse` contract instead of leaking Spring's default error
- * payload shape.
- */
 @SpringBootTest
 @AutoConfigureMockMvc
 class LobbyControllerTest {
@@ -43,130 +37,107 @@ class LobbyControllerTest {
     lateinit var objectMapper: ObjectMapper
 
     @MockitoBean
-    lateinit var lobbyService: LobbyService
+    lateinit var lobbyService: at.se2group.backend.service.LobbyService
+
+    @MockitoBean
+    lateinit var lobbyAuthenticationService: at.se2group.backend.service.LobbyAuthenticationService
+
+    @MockitoBean
+    lateinit var jwtService: JwtService
+
+    private fun lobby(): Lobby = Lobby(
+        lobbyId = "123",
+        hostUserId = "user1",
+        players = listOf(LobbyPlayer("user1", "Stefan", false)),
+        status = LobbyStatus.OPEN,
+        settings = LobbySettings(4, false, true)
+    )
 
     @Test
-    fun `createLobby should return 200 for valid request`() {
-
-        val request = CreateLobbyRequest(
-            displayName = "Stefan",
-            maxPlayers = 4
-        )
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = listOf(
-                LobbyPlayer(
-                    userId = "user1",
-                    displayName = "Stefan",
-                    isReady = false
+    fun `createLobby should return authenticated response for valid request`() {
+        val request = CreateLobbyRequest(displayName = "Stefan", maxPlayers = 4)
+        `when`(lobbyAuthenticationService.createAuthenticatedLobby(any()))
+            .thenReturn(
+                at.se2group.backend.dto.AuthenticatedLobbyResponse(
+                    accessToken = "token-1",
+                    lobby = lobby().toResponse()
                 )
-            ),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
             )
-        )
-
-        `when`(lobbyService.createLobby(any(), any()))
-            .thenReturn(lobby)
 
         mockMvc.post("/api/lobbies") {
             contentType = MediaType.APPLICATION_JSON
-            header("X-User-Id", "user1")
             content = objectMapper.writeValueAsString(request)
         }.andExpect {
             status { isOk() }
+            jsonPath("$.accessToken") { value("token-1") }
+            jsonPath("$.lobby.lobbyId") { value("123") }
         }
     }
 
     @Test
     fun `createLobby should return 400 for invalid request`() {
-
-        val invalidJson = """
-            {
-              "displayName": "",
-              "maxPlayers": 4
-            }
-        """.trimIndent()
-
         mockMvc.post("/api/lobbies") {
             contentType = MediaType.APPLICATION_JSON
-            header("X-User-Id", "user1")
-            content = invalidJson
+            content = """{"displayName":"","maxPlayers":4}"""
         }.andExpect {
             status { isBadRequest() }
             jsonPath("$.errorCode") { value("BAD_REQUEST") }
             jsonPath("$.errorMessage") { value("Request validation failed") }
-            jsonPath("$.violations.length()") { value(0) }
         }
     }
 
     @Test
-    fun `joinLobby should return 200 for valid request`() {
-
-        val request = JoinLobbyRequest(
-            userId = "user2",
-            displayName = "Max"
-        )
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = listOf(
-                LobbyPlayer("user1", "Stefan", false),
-                LobbyPlayer("user2", "Max", false)
-            ),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
+    fun `joinLobby should return authenticated response for valid request`() {
+        `when`(lobbyAuthenticationService.joinAuthenticatedLobby(any(), any()))
+            .thenReturn(
+                at.se2group.backend.dto.AuthenticatedLobbyResponse(
+                    accessToken = "token-2",
+                    lobby = lobby().copy(
+                        players = listOf(
+                            LobbyPlayer("user1", "Stefan", false),
+                            LobbyPlayer("user2", "Max", false)
+                        )
+                    ).toResponse()
+                )
             )
-        )
-
-        `when`(lobbyService.joinLobby(any(), any()))
-            .thenReturn(lobby)
 
         mockMvc.post("/api/lobbies/123/join") {
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(request)
+            content = objectMapper.writeValueAsString(JoinLobbyRequest(displayName = "Max"))
         }.andExpect {
             status { isOk() }
+            jsonPath("$.accessToken") { value("token-2") }
+            jsonPath("$.lobby.players.length()") { value(2) }
         }
     }
 
     @Test
-    fun `getLobby should return 200`() {
+    fun `getLobby should return 200 for participant`() {
+        `when`(lobbyService.getLobbyForUser("123", "user1")).thenReturn(lobby())
 
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = emptyList(),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(4, false, true)
-        )
+        mockMvc.get("/api/lobbies/123") {
+            with(user("user1"))
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.lobbyId") { value("123") }
+        }
+    }
 
-        `when`(lobbyService.getLobby(any()))
-            .thenReturn(lobby)
-
+    @Test
+    fun `getLobby should return 401 when auth is missing`() {
         mockMvc.get("/api/lobbies/123")
             .andExpect {
-                status { isOk() }
+                status { isUnauthorized() }
+                jsonPath("$.errorCode") { value("UNAUTHORIZED") }
             }
     }
 
     @Test
     fun `deleteLobby should return 204`() {
-
-        doNothing().`when`(lobbyService)
-            .deleteLobby(any(), any())
+        doNothing().`when`(lobbyService).deleteLobby(any(), any())
 
         mockMvc.delete("/api/lobbies/123") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isNoContent() }
         }
@@ -174,24 +145,10 @@ class LobbyControllerTest {
 
     @Test
     fun `readyLobby should return 200`() {
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = emptyList(),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
-            )
-        )
-
-        `when`(lobbyService.readyLobby(any(), any()))
-            .thenReturn(lobby)
+        `when`(lobbyService.readyLobby(any(), any())).thenReturn(lobby())
 
         mockMvc.post("/api/lobbies/123/ready") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isOk() }
         }
@@ -199,24 +156,10 @@ class LobbyControllerTest {
 
     @Test
     fun `unreadyLobby should return 200`() {
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = emptyList(),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(
-                maxPlayers = 4,
-                isPrivate = false,
-                allowGuests = true
-            )
-        )
-
-        `when`(lobbyService.unreadyLobby(any(), any()))
-            .thenReturn(lobby)
+        `when`(lobbyService.unreadyLobby(any(), any())).thenReturn(lobby())
 
         mockMvc.post("/api/lobbies/123/unready") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isOk() }
         }
@@ -224,20 +167,10 @@ class LobbyControllerTest {
 
     @Test
     fun `startLobby should return 200`() {
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = emptyList(),
-            status = LobbyStatus.IN_GAME,
-            settings = LobbySettings(4, false, true)
-        )
-
-        `when`(lobbyService.startLobby(any(), any()))
-            .thenReturn(lobby)
+        `when`(lobbyService.startLobby(any(), any())).thenReturn(lobby().copy(status = LobbyStatus.IN_GAME))
 
         mockMvc.post("/api/lobbies/123/start") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isOk() }
         }
@@ -245,30 +178,15 @@ class LobbyControllerTest {
 
     @Test
     fun `updateLobbySettings should return 200`() {
-
-        val requestJson = """
-        {
-          "maxPlayers": 4,
-          "isPrivate": false,
-          "allowGuests": true
-        }
-    """.trimIndent()
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user1",
-            players = emptyList(),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(4, false, true)
-        )
-
         `when`(lobbyService.updateLobbySettings(any(), any(), any()))
-            .thenReturn(lobby)
+            .thenReturn(lobby())
 
         mockMvc.patch("/api/lobbies/123/settings") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
             contentType = MediaType.APPLICATION_JSON
-            content = requestJson
+            content = objectMapper.writeValueAsString(
+                UpdateLobbySettingsRequest(maxPlayers = 4, isPrivate = false, allowGuests = true)
+            )
         }.andExpect {
             status { isOk() }
         }
@@ -276,20 +194,10 @@ class LobbyControllerTest {
 
     @Test
     fun `leaveLobby should return 200 when lobby remains`() {
-
-        val lobby = Lobby(
-            lobbyId = "123",
-            hostUserId = "user2",
-            players = emptyList(),
-            status = LobbyStatus.OPEN,
-            settings = LobbySettings(4, false, true)
-        )
-
-        `when`(lobbyService.leaveLobby(any(), any()))
-            .thenReturn(lobby)
+        `when`(lobbyService.leaveLobby(any(), any())).thenReturn(lobby())
 
         mockMvc.post("/api/lobbies/123/leave") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isOk() }
         }
@@ -297,12 +205,10 @@ class LobbyControllerTest {
 
     @Test
     fun `leaveLobby should return 204 when lobby deleted`() {
-
-        `when`(lobbyService.leaveLobby(any(), any()))
-            .thenReturn(null)
+        `when`(lobbyService.leaveLobby(any(), any())).thenReturn(null)
 
         mockMvc.post("/api/lobbies/123/leave") {
-            header("X-User-Id", "user1")
+            with(user("user1"))
         }.andExpect {
             status { isNoContent() }
         }
@@ -310,19 +216,7 @@ class LobbyControllerTest {
 
     @Test
     fun `listLobbies should return 200`() {
-
-        val lobbies = listOf(
-            Lobby(
-                lobbyId = "123",
-                hostUserId = "user1",
-                players = emptyList(),
-                status = LobbyStatus.OPEN,
-                settings = LobbySettings(4, false, true)
-            )
-        )
-
-        `when`(lobbyService.listOpenLobbies())
-            .thenReturn(lobbies)
+        `when`(lobbyService.listOpenLobbies()).thenReturn(listOf(lobby()))
 
         mockMvc.get("/api/lobbies")
             .andExpect {
@@ -331,32 +225,13 @@ class LobbyControllerTest {
     }
 
     @Test
-    fun `should return 400 when illegal argument`() {
-        `when`(lobbyService.getLobby(any())).thenThrow(IllegalArgumentException())
+    fun `protected lobby access should surface service errors`() {
+        `when`(lobbyService.getLobbyForUser(any(), any())).thenThrow(SecurityException())
 
-        mockMvc.get("/api/lobbies/123")
-            .andExpect {
-                status { isBadRequest() }
-            }
-    }
-
-    @Test
-    fun `should return 403 when security exception`() {
-        `when`(lobbyService.getLobby(any())).thenThrow(SecurityException())
-
-        mockMvc.get("/api/lobbies/123")
-            .andExpect {
-                status { isForbidden() }
-            }
-    }
-
-    @Test
-    fun `should return 404 when not found`() {
-        `when`(lobbyService.getLobby(any())).thenThrow(NoSuchElementException())
-
-        mockMvc.get("/api/lobbies/123")
-            .andExpect {
-                status { isNotFound() }
-            }
+        mockMvc.get("/api/lobbies/123") {
+            with(user("user1"))
+        }.andExpect {
+            status { isForbidden() }
+        }
     }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt
@@ -48,6 +48,9 @@ class OpenApiDocsTest {
                 jsonPath("$['paths']['/api/lobbies/{lobbyId}']") { exists() }
                 jsonPath("$['paths']['/api/lobbies/{lobbyId}/settings']") { exists() }
                 jsonPath("$['paths']['/api/lobbies/{lobbyId}/join']") { exists() }
+                jsonPath("$['components']['securitySchemes']['bearerAuth']['type']") { value("http") }
+                jsonPath("$['components']['securitySchemes']['bearerAuth']['scheme']") { value("bearer") }
+                jsonPath("$['components']['securitySchemes']['bearerAuth']['bearerFormat']") { value("JWT") }
                 jsonPath("$['paths']['/internal/security/scan-fixture']") { doesNotExist() }
                 header { string("Content-Type", org.hamcrest.Matchers.containsString("application/json")) }
                 header { string("X-Content-Type-Options", "nosniff") }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/RootControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/RootControllerTest.kt
@@ -1,8 +1,15 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.security.JwtAuthenticationFilter
+import at.se2group.backend.security.JwtService
+import at.se2group.backend.security.RestAccessDeniedHandler
+import at.se2group.backend.security.RestAuthenticationEntryPoint
+import at.se2group.backend.security.SecurityConfig
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -26,10 +33,19 @@ import org.springframework.test.web.servlet.get
  * - the exact response shape remains stable for external callers
  */
 @WebMvcTest(RootController::class)
+@Import(
+    SecurityConfig::class,
+    RestAuthenticationEntryPoint::class,
+    RestAccessDeniedHandler::class,
+    JwtAuthenticationFilter::class
+)
 class RootControllerTest {
 
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var jwtService: JwtService
 
     @Test
     fun `root returns running service metadata`() {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
@@ -70,6 +70,8 @@ class SecurityScanFixtureControllerTest {
                 jsonPath("$.guestUserId") { value(SecurityScanFixtureService.SCAN_GUEST_USER_ID) }
                 jsonPath("$.gameId") { value(SecurityScanFixtureService.SCAN_GAME_ID) }
                 jsonPath("$.draftOwnerUserId") { value(SecurityScanFixtureService.SCAN_HOST_USER_ID) }
+                jsonPath("$.hostAccessToken") { isNotEmpty() }
+                jsonPath("$.guestAccessToken") { isNotEmpty() }
             }
 
         assertTrue(lobbyRepository.findById(SecurityScanFixtureService.SCAN_OPEN_LOBBY_ID).isPresent)

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SiteMetadataControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SiteMetadataControllerTest.kt
@@ -1,9 +1,16 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.security.JwtAuthenticationFilter
+import at.se2group.backend.security.JwtService
+import at.se2group.backend.security.RestAccessDeniedHandler
+import at.se2group.backend.security.RestAuthenticationEntryPoint
+import at.se2group.backend.security.SecurityConfig
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -27,10 +34,19 @@ import org.springframework.test.web.servlet.get
  * - the sitemap keeps pointing at the intended backend health location
  */
 @WebMvcTest(SiteMetadataController::class)
+@Import(
+    SecurityConfig::class,
+    RestAuthenticationEntryPoint::class,
+    RestAccessDeniedHandler::class,
+    JwtAuthenticationFilter::class
+)
 class SiteMetadataControllerTest {
 
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var jwtService: JwtService
 
     @Test
     fun `robots txt returns plain text crawl policy`() {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceGetTest.kt
@@ -81,4 +81,36 @@ class GameServiceGetTest {
         assertEquals("Game not found", exception.message)
         verify(gameRepository).findById("missing-game")
     }
+
+    @Test
+    fun `getGameForUser rejects non participant access`() {
+        val entity = GameEntity(
+            gameId = "game-1",
+            lobbyId = "lobby-1",
+            currentPlayerUserId = "user-1",
+            status = GameStatus.ACTIVE,
+            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+        )
+
+        entity.players = mutableListOf(
+            GamePlayerEntity(
+                game = entity,
+                userId = "user-1",
+                displayName = "Alice",
+                turnOrder = 0,
+                rackTiles = mutableListOf(),
+                hasCompletedInitialMeld = false,
+                score = 0,
+                joinedAt = Instant.parse("2026-04-27T17:55:00Z")
+            )
+        )
+
+        `when`(gameRepository.findById("game-1")).thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<SecurityException> {
+            gameService.getGameForUser("game-1", "outsider")
+        }
+
+        assertEquals("Only game participants can access this game", exception.message)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyAuthenticationServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyAuthenticationServiceTest.kt
@@ -1,0 +1,93 @@
+package at.se2group.backend.lobby.service
+
+import at.se2group.backend.dto.CreateLobbyRequest
+import at.se2group.backend.dto.JoinLobbyRequest
+import at.se2group.backend.security.JwtService
+import at.se2group.backend.service.LobbyAuthenticationService
+import at.se2group.backend.service.LobbyService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import shared.models.lobby.domain.Lobby
+import shared.models.lobby.domain.LobbyPlayer
+import shared.models.lobby.domain.LobbySettings
+import shared.models.lobby.domain.LobbyStatus
+
+@ExtendWith(MockitoExtension::class)
+class LobbyAuthenticationServiceTest {
+
+    @Mock
+    lateinit var lobbyService: LobbyService
+
+    @Mock
+    lateinit var jwtService: JwtService
+
+    private fun lobby(userId: String, displayName: String) = Lobby(
+        lobbyId = "123456",
+        hostUserId = userId,
+        players = listOf(LobbyPlayer(userId, displayName, false)),
+        status = LobbyStatus.OPEN,
+        settings = LobbySettings(maxPlayers = 4, isPrivate = false, allowGuests = true)
+    )
+
+    @Test
+    fun `createAuthenticatedLobby issues token for generated user and returns lobby response`() {
+        val request = CreateLobbyRequest(displayName = "Alice", maxPlayers = 4)
+
+        `when`(lobbyService.createLobby(org.mockito.kotlin.any(), org.mockito.kotlin.eq(request)))
+            .thenAnswer { invocation ->
+                val generatedUserId = invocation.arguments[0] as String
+                lobby(generatedUserId, "Alice")
+            }
+        `when`(jwtService.issueAccessToken(org.mockito.kotlin.any()))
+            .thenAnswer { invocation -> "token:${invocation.arguments[0] as String}" }
+
+        val service = LobbyAuthenticationService(lobbyService, jwtService)
+        val response = service.createAuthenticatedLobby(request)
+        val generatedUserId = response.lobby.hostUserId
+
+        assertTrue(generatedUserId.isNotBlank())
+        assertEquals("token:$generatedUserId", response.accessToken)
+        assertEquals(generatedUserId, response.lobby.hostUserId)
+        assertEquals(generatedUserId, response.lobby.players.first().userId)
+        assertEquals("Alice", response.lobby.players.first().displayName)
+        assertFalse(response.lobby.players.first().isReady)
+    }
+
+    @Test
+    fun `joinAuthenticatedLobby issues token for generated user and returns joined lobby response`() {
+        val request = JoinLobbyRequest(displayName = "Bob")
+
+        `when`(lobbyService.joinLobby(org.mockito.kotlin.eq("123456"), org.mockito.kotlin.any(), org.mockito.kotlin.eq(request)))
+            .thenAnswer { invocation ->
+                val generatedUserId = invocation.arguments[1] as String
+                Lobby(
+                    lobbyId = "123456",
+                    hostUserId = "host-1",
+                    players = listOf(
+                        LobbyPlayer("host-1", "Alice", false),
+                        LobbyPlayer(generatedUserId, "Bob", false)
+                    ),
+                    status = LobbyStatus.OPEN,
+                    settings = LobbySettings(maxPlayers = 4, isPrivate = false, allowGuests = true)
+                )
+            }
+        `when`(jwtService.issueAccessToken(org.mockito.kotlin.any()))
+            .thenAnswer { invocation -> "token:${invocation.arguments[0] as String}" }
+
+        val service = LobbyAuthenticationService(lobbyService, jwtService)
+        val response = service.joinAuthenticatedLobby("123456", request)
+        val generatedUserId = response.lobby.players.last().userId
+
+        assertTrue(generatedUserId.isNotBlank())
+        assertTrue(response.lobby.players.any { it.userId == generatedUserId })
+        assertEquals("token:$generatedUserId", response.accessToken)
+        assertEquals("host-1", response.lobby.hostUserId)
+        assertEquals("Bob", response.lobby.players.last().displayName)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt
@@ -100,4 +100,32 @@ class LobbyServiceGetTest {
         verify(lobbyRepository).findById("missing-lobby")
         verifyNoInteractions(lobbyBroadcastService)
     }
+
+    @Test
+    fun `getLobbyForUser rejects non participant access`() {
+        val entity = LobbyEntity(
+            lobbyId = "lobby-1",
+            hostUserId = "host-1",
+            status = LobbyStatus.OPEN,
+            maxPlayers = 4,
+            isPrivate = false,
+            allowGuests = true,
+            players = mutableListOf(
+                LobbyPlayerEmbeddable(
+                    userId = "host-1",
+                    displayName = "Alice",
+                    isReady = false,
+                )
+            )
+        )
+
+        Mockito.`when`(lobbyRepository.findById("lobby-1"))
+            .thenReturn(Optional.of(entity))
+
+        val exception = assertThrows<SecurityException> {
+            lobbyService.getLobbyForUser("lobby-1", "outsider")
+        }
+
+        assertEquals("Only lobby participants can access this lobby", exception.message)
+    }
 }

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt
@@ -75,10 +75,7 @@ class LobbyServiceJoinTest {
             )
         )
 
-        val request = JoinLobbyRequest(
-            userId = "player-2",
-            displayName = "Bob"
-        )
+        val request = JoinLobbyRequest(displayName = "Bob")
 
         `when`(lobbyRepository.findById("lobby-1"))
             .thenReturn(Optional.of(entity))
@@ -90,7 +87,7 @@ class LobbyServiceJoinTest {
                 runDeferredAction(it)
             }
 
-        val result = lobbyService.joinLobby("lobby-1", request)
+        val result = lobbyService.joinLobby("lobby-1", "player-2", request)
 
         assertEquals("lobby-1", result.lobbyId)
         assertEquals("host-1", result.hostUserId)
@@ -156,16 +153,13 @@ class LobbyServiceJoinTest {
             )
         )
 
-        val request = JoinLobbyRequest(
-            userId = "player-3",
-            displayName = "Charlie"
-        )
+        val request = JoinLobbyRequest(displayName = "Charlie")
 
         `when`(lobbyRepository.findById("lobby-1"))
             .thenReturn(Optional.of(entity))
 
         val exception = assertThrows<IllegalStateException> {
-            lobbyService.joinLobby("lobby-1", request)
+            lobbyService.joinLobby("lobby-1", "player-3", request)
         }
 
         assertEquals("Lobby is not open", exception.message)
@@ -198,16 +192,13 @@ class LobbyServiceJoinTest {
             )
         )
 
-        val request = JoinLobbyRequest(
-            userId = "player-3",
-            displayName = "Charlie"
-        )
+        val request = JoinLobbyRequest(displayName = "Charlie")
 
         `when`(lobbyRepository.findById("lobby-1"))
             .thenReturn(Optional.of(entity))
 
         val exception = assertThrows<IllegalStateException> {
-            lobbyService.joinLobby("lobby-1", request)
+            lobbyService.joinLobby("lobby-1", "player-3", request)
         }
 
         assertEquals("Lobby is full", exception.message)
@@ -240,16 +231,13 @@ class LobbyServiceJoinTest {
             )
         )
 
-        val request = JoinLobbyRequest(
-            userId = "player-2",
-            displayName = "Bob"
-        )
+        val request = JoinLobbyRequest(displayName = "Bob")
 
         `when`(lobbyRepository.findById("lobby-1"))
             .thenReturn(Optional.of(entity))
 
         val exception = assertThrows<IllegalStateException> {
-            lobbyService.joinLobby("lobby-1", request)
+            lobbyService.joinLobby("lobby-1", "player-2", request)
         }
 
         assertEquals("Player already in lobby", exception.message)
@@ -277,17 +265,14 @@ class LobbyServiceJoinTest {
             )
         )
 
-        val request = JoinLobbyRequest(
-            userId = "player-2",
-            displayName = "Bob"
-        )
+        val request = JoinLobbyRequest(displayName = "Bob")
 
         `when`(lobbyRepository.findById("lobby-1"))
             .thenReturn(Optional.of(entity))
         `when`(lobbyRepository.save(any(LobbyEntity::class.java)))
             .thenAnswer { it.arguments[0] as LobbyEntity }
 
-        lobbyService.joinLobby("lobby-1", request)
+        lobbyService.joinLobby("lobby-1", "player-2", request)
 
         val captor = ArgumentCaptor.forClass(LobbyEntity::class.java)
         verify(lobbyRepository).save(captor.capture())

--- a/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtAuthenticationFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtAuthenticationFilterTest.kt
@@ -88,6 +88,43 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
+    fun `filter authenticates request when bearer scheme casing varies`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "bEaReR valid-token")
+        }
+        val response = MockHttpServletResponse()
+
+        `when`(jwtService.extractUserId("valid-token")).thenReturn("user-123")
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(jwtService).extractUserId("valid-token")
+        verify(filterChain).doFilter(request, response)
+        verifyNoInteractions(authenticationEntryPoint)
+        assertEquals("user-123", SecurityContextHolder.getContext().authentication?.name)
+    }
+
+    @Test
+    fun `filter rejects bearer scheme without token`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer")
+        }
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(authenticationEntryPoint).commence(
+            same(request),
+            same(response),
+            any()
+        )
+        verify(filterChain, never()).doFilter(request, response)
+        verifyNoInteractions(jwtService)
+    }
+
+    @Test
     fun `filter clears security context and returns 401 when bearer token is invalid`() {
         val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
         val request = MockHttpServletRequest().apply {

--- a/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtAuthenticationFilterTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,114 @@
+package at.se2group.backend.security
+
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.same
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.AuthenticationEntryPoint
+
+@ExtendWith(MockitoExtension::class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    lateinit var jwtService: JwtService
+
+    @Mock
+    lateinit var authenticationEntryPoint: AuthenticationEntryPoint
+
+    @Mock
+    lateinit var filterChain: FilterChain
+
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `filter passes through when authorization header is missing`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(filterChain).doFilter(request, response)
+        verifyNoInteractions(jwtService, authenticationEntryPoint)
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+
+    @Test
+    fun `filter rejects authorization header without bearer prefix`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Token abc")
+        }
+        val response = MockHttpServletResponse()
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(authenticationEntryPoint).commence(
+            same(request),
+            same(response),
+            any()
+        )
+        verify(filterChain, never()).doFilter(request, response)
+        verifyNoInteractions(jwtService)
+    }
+
+    @Test
+    fun `filter authenticates request when bearer token is valid`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer valid-token")
+        }
+        val response = MockHttpServletResponse()
+
+        `when`(jwtService.extractUserId("valid-token")).thenReturn("user-123")
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(jwtService).extractUserId("valid-token")
+        verify(filterChain).doFilter(request, response)
+        verifyNoInteractions(authenticationEntryPoint)
+        assertEquals("user-123", SecurityContextHolder.getContext().authentication?.name)
+    }
+
+    @Test
+    fun `filter clears security context and returns 401 when bearer token is invalid`() {
+        val filter = JwtAuthenticationFilter(jwtService, authenticationEntryPoint)
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer broken-token")
+        }
+        val response = MockHttpServletResponse()
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken.authenticated("stale-user", null, emptyList())
+
+        `when`(jwtService.extractUserId("broken-token"))
+            .thenThrow(InvalidBearerTokenAuthenticationException())
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(jwtService).extractUserId("broken-token")
+        verify(authenticationEntryPoint).commence(
+            same(request),
+            same(response),
+            any()
+        )
+        verify(filterChain, never()).doFilter(request, response)
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/security/JwtServiceTest.kt
@@ -1,0 +1,29 @@
+package at.se2group.backend.security
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class JwtServiceTest {
+
+    private val jwtService = JwtService(
+        JwtProperties(
+            issuer = "test-backend",
+            secret = "test-secret-test-secret-test-secret",
+            accessTokenTtlSeconds = 3600
+        )
+    )
+
+    @Test
+    fun `issueAccessToken and extractUserId round trip user identity`() {
+        val token = jwtService.issueAccessToken("user-123")
+        assertEquals("user-123", jwtService.extractUserId(token))
+    }
+
+    @Test
+    fun `extractUserId rejects invalid token`() {
+        assertThrows<InvalidBearerTokenAuthenticationException> {
+            jwtService.extractUserId("not-a-valid-token")
+        }
+    }
+}

--- a/apps/backend/src/test/kotlin/at/se2group/backend/security/RestAccessDeniedHandlerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/security/RestAccessDeniedHandlerTest.kt
@@ -1,0 +1,31 @@
+package at.se2group.backend.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import shared.models.api.ApiErrorResponse
+
+class RestAccessDeniedHandlerTest {
+
+    private val objectMapper = ObjectMapper()
+    private val handler = RestAccessDeniedHandler(objectMapper)
+
+    @Test
+    fun `handle writes forbidden json response`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+
+        handler.handle(request, response, AccessDeniedException("nope"))
+
+        assertEquals(403, response.status)
+        assertEquals("application/json", response.contentType)
+
+        val body = objectMapper.readTree(response.contentAsString)
+        assertEquals("FORBIDDEN", body["errorCode"].asText())
+        assertEquals("Access denied", body["errorMessage"].asText())
+        assertEquals(0, body["violations"].size())
+    }
+}

--- a/apps/backend/src/test/resources/application.yml
+++ b/apps/backend/src/test/resources/application.yml
@@ -1,3 +1,8 @@
 app:
+  auth:
+    jwt:
+      issuer: test-backend
+      secret: test-secret-test-secret-test-secret
+      access-token-ttl-seconds: 3600
   scan-fixture:
     enabled: false

--- a/docs/zap-af-workflow-guide.md
+++ b/docs/zap-af-workflow-guide.md
@@ -1,0 +1,639 @@
+# OWASP ZAP AF Workflow Guide
+
+![Scope](https://img.shields.io/badge/Scope-Backend%20Security-475569)
+![Workflow](https://img.shields.io/badge/Workflow-ZAP%20Automation%20Framework-64748b)
+![Auth](https://img.shields.io/badge/Auth-JWT%20Bearer-6b7280)
+![Fixtures](https://img.shields.io/badge/Fixtures-Deterministic%20Scan%20State-78716c)
+![Runtime](https://img.shields.io/badge/Runtime-Render%20Deployed%20Backend-52525b)
+![CI](https://img.shields.io/badge/CI-GitHub%20Actions-4b5563)
+
+## Purpose
+
+This document explains, from start to finish, how the OWASP ZAP Automation
+Framework workflow works in this repository.
+
+It covers:
+
+- what the workflow is scanning
+- how the backend scan fixtures are created
+- how JWT authentication fits into the scan
+- which GitHub and Render settings are required
+- how the generated AF plan is built
+- how to debug failures when the workflow breaks
+
+This guide is specifically about:
+
+- [.github/workflows/backend-security-af.yml](../.github/workflows/backend-security-af.yml)
+- [.github/zap/backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)
+- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)
+- [SecurityScanFixtureService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt)
+
+---
+
+## High-level overview
+
+The ZAP AF workflow does **not** scan the backend blindly.
+
+Instead, it uses a prepared backend fixture so that it can make meaningful,
+repeatable requests against:
+
+- a real open lobby
+- a real active game
+- a real draft
+- real users with valid authentication
+
+The flow looks like this:
+
+1. GitHub Actions waits until the deployed backend is reachable on Render.
+2. The workflow calls an internal backend endpoint:
+   - `POST /internal/security/scan-fixture`
+3. The backend recreates deterministic scan data:
+   - prepared lobby
+   - prepared active game
+   - prepared host user
+   - prepared guest user
+4. The backend returns:
+   - fixture ids
+   - JWT access tokens for the prepared users
+5. The workflow injects those values into the generated ZAP AF plan.
+6. ZAP executes the plan against the deployed backend.
+7. Reports and endpoint coverage artifacts are generated and uploaded.
+
+That means the scan is not just "pinging endpoints". It is exercising real API
+flows using the same JWT auth model that real clients use.
+
+---
+
+## Which workflow runs this
+
+The workflow file is:
+
+- [.github/workflows/backend-security-af.yml](../.github/workflows/backend-security-af.yml)
+
+It runs on:
+
+- manual `workflow_dispatch`
+- backend-related pull requests
+- pushes to `main`
+- a weekly schedule
+
+Its target is the deployed Render backend:
+
+```yaml
+env:
+  BACKEND_BASE_URL: https://se2-group-codebase.onrender.com
+  HEALTH_URL: https://se2-group-codebase.onrender.com/actuator/health
+```
+
+So the scan always tests the deployed backend, not a temporary local server
+inside GitHub Actions.
+
+---
+
+## Why scan fixtures exist
+
+Many protected endpoints cannot be scanned meaningfully without state.
+
+Examples:
+
+- `GET /api/lobbies/{id}`
+- `PATCH /api/lobbies/{id}/settings`
+- `POST /api/games/{id}/draw`
+- `POST /api/games/{id}/end-turn`
+
+Those need:
+
+- a real lobby id
+- a real game id
+- a real player who belongs to that lobby/game
+- valid authorization
+
+Without fixtures, the AF plan would mostly hit:
+
+- `401 Unauthorized`
+- `404 Not Found`
+- or invalid-state conflicts
+
+That would not prove that the positive paths still work.
+
+So the backend creates deterministic scan fixtures before ZAP runs.
+
+---
+
+## The internal fixture endpoint
+
+The workflow bootstraps everything through:
+
+```http
+POST /internal/security/scan-fixture
+X-Scan-Secret: <secret>
+```
+
+This endpoint is implemented in:
+
+- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)
+
+It is intentionally:
+
+- hidden from OpenAPI
+- protected by a dedicated scan secret
+- enabled only when scan fixtures are explicitly turned on
+
+Core behavior:
+
+```kotlin
+@PostMapping("/scan-fixture")
+fun createScanFixture(
+    @RequestHeader("X-Scan-Secret", required = false) providedSecret: String?
+): SecurityScanFixtureResponse
+```
+
+If the secret is missing or wrong, the endpoint rejects the request.
+
+If the secret is valid, it calls:
+
+```kotlin
+val state = securityScanFixtureService.recreateFixture()
+```
+
+and returns a response containing both ids and JWTs.
+
+---
+
+## What the fixture response looks like
+
+The workflow expects a JSON response with this shape:
+
+```json
+{
+  "lobbyId": "scan-open-lobby",
+  "hostUserId": "scan-host-user",
+  "guestUserId": "scan-guest-user",
+  "gameId": "scan-game-1",
+  "draftOwnerUserId": "scan-host-user",
+  "hostAccessToken": "<jwt>",
+  "guestAccessToken": "<jwt>"
+}
+```
+
+Meaning of each field:
+
+- `lobbyId`
+  - the prepared open lobby used for positive lobby-state requests
+- `hostUserId`
+  - the prepared host player identity
+- `guestUserId`
+  - the prepared guest player identity
+- `gameId`
+  - the prepared active game used for positive game-state requests
+- `draftOwnerUserId`
+  - the user who currently owns the prepared draft
+- `hostAccessToken`
+  - valid backend-issued JWT for `hostUserId`
+- `guestAccessToken`
+  - valid backend-issued JWT for `guestUserId`
+
+These token fields are critical after the JWT auth refactor. The AF workflow is
+now JWT-only and expects those fields to exist.
+
+---
+
+## How the backend creates those JWTs
+
+The fixture controller does not invent tokens manually. It uses the same
+backend JWT service that the rest of the application uses.
+
+Relevant code pattern:
+
+```kotlin
+hostAccessToken = jwtService.issueAccessToken(state.hostUserId)
+guestAccessToken = jwtService.issueAccessToken(state.guestUserId)
+```
+
+This matters because the scan should authenticate exactly like normal backend
+clients do:
+
+- same JWT issuer
+- same signature
+- same expiry logic
+- same subject claim (`sub`)
+
+So the ZAP scan is not using fake auth. It is using real backend-issued bearer
+tokens.
+
+---
+
+## Where the fixture state itself comes from
+
+The fixture ids are created by:
+
+- [SecurityScanFixtureService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt)
+
+That service recreates deterministic backend state for the scan.
+
+Important point:
+
+- the workflow does **not** create the fixture itself
+- the backend service creates it
+- the workflow only requests it and consumes the returned ids/tokens
+
+This is why names like `scan-open-lobby` and `scan-game-1` show up in reports.
+
+The service seeds known state so the AF plan can rely on it repeatedly.
+
+---
+
+## Why Render must run the updated backend code
+
+The AF workflow runs against:
+
+```text
+https://se2-group-codebase.onrender.com
+```
+
+So even if your branch contains the correct code locally, the workflow still
+depends on what Render is currently serving.
+
+This is the most important operational point in the whole setup:
+
+> The deployed backend on Render must already include the updated
+> `SecurityScanFixtureController` implementation that returns
+> `hostAccessToken` and `guestAccessToken`.
+
+If Render is still on an older backend version, the fixture endpoint may return
+only ids and no JWT token fields.
+
+Then this workflow step will fail:
+
+```bash
+SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+```
+
+and the guard will stop the scan:
+
+```bash
+if [ -z "$value" ] || [ "$value" = "null" ]; then
+  echo "Scan fixture endpoint returned incomplete data"
+  exit 1
+fi
+```
+
+So when the AF workflow says:
+
+```text
+Scan fixture endpoint returned incomplete data
+```
+
+the first thing to check is whether Render is running the updated backend code.
+
+---
+
+## Required configuration in GitHub and Render
+
+## GitHub Actions
+
+In the repository settings:
+
+`Settings -> Secrets and variables -> Actions`
+
+you need the repository secret:
+
+```text
+ZAP_SCAN_FIXTURE_SECRET
+```
+
+This is the secret that GitHub sends in the request header:
+
+```http
+X-Scan-Secret: <secret>
+```
+
+## Render backend
+
+In the backend service environment variables, you need:
+
+```text
+APP_SCAN_FIXTURE_ENABLED=true
+APP_SCAN_FIXTURE_SECRET=<same value as ZAP_SCAN_FIXTURE_SECRET>
+```
+
+These do two things:
+
+- enable the internal fixture endpoint
+- make sure the endpoint only responds when the correct secret is provided
+
+The values must match between:
+
+- GitHub secret: `ZAP_SCAN_FIXTURE_SECRET`
+- Render env var: `APP_SCAN_FIXTURE_SECRET`
+
+If they do not match, the fixture request will fail with `403 Forbidden`.
+
+---
+
+## How the workflow uses the fixture response
+
+After the fixture response comes back, the workflow extracts values with `jq`:
+
+```bash
+SCAN_LOBBY_ID="$(echo "$FIXTURE_JSON" | jq -r '.lobbyId')"
+SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
+SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
+SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
+SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+```
+
+Then it constructs reusable auth headers:
+
+```bash
+SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+```
+
+Then it substitutes placeholders in the AF plan:
+
+```bash
+sed \
+  -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
+  -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
+  -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+  -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+  .github/zap/backend-automation-plan.yaml \
+  > .github/zap/backend-automation-plan.generated.yaml
+```
+
+So ZAP never runs against the placeholder template directly. It runs against the
+generated concrete plan.
+
+---
+
+## The AF plan template
+
+The template is:
+
+- [.github/zap/backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)
+
+This file contains:
+
+- public requests
+- positive lobby-state requests
+- positive game-state requests
+- negative-path requests
+- report generation steps
+
+Examples of protected requests now using JWT placeholders:
+
+```yaml
+- url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
+  method: GET
+  headers:
+    - "__SCAN_HOST_AUTH_HEADER__"
+  responseCode: 200
+```
+
+```yaml
+- url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
+  method: POST
+  headers:
+    - "__SCAN_HOST_AUTH_HEADER__"
+  responseCode: 200
+```
+
+This is the JWT-specific alignment. Before the auth refactor, these protected
+requests used `X-User-Id`. Now they use backend-issued bearer tokens.
+
+---
+
+## Public vs protected requests
+
+Not every request in the AF plan should carry a JWT.
+
+### Public requests stay public
+
+Examples:
+
+- `GET /`
+- `GET /robots.txt`
+- `GET /sitemap.xml`
+- `GET /actuator/health`
+- `GET /api/leaderboard`
+- `GET /api/lobbies`
+- invalid `POST /api/lobbies`
+- missing `POST /api/lobbies/{id}/join`
+
+These do not need bearer auth.
+
+### Protected requests must use JWT
+
+Examples:
+
+- `GET /api/lobbies/{id}`
+- `PATCH /api/lobbies/{id}/settings`
+- `POST /api/lobbies/{id}/ready`
+- `POST /api/lobbies/{id}/leave`
+- `DELETE /api/lobbies/{id}`
+- `GET /api/games/{id}`
+- `PUT /api/games/{id}/draft`
+- `POST /api/games/{id}/draw`
+- `POST /api/games/{id}/end-turn`
+
+These must use valid bearer tokens or they should fail with `401`.
+
+---
+
+## Why some negative-path requests still expect `404`
+
+Some protected requests intentionally target missing resources, for example:
+
+- missing lobby id
+- missing game id
+
+These still send a valid JWT.
+
+Why:
+
+- without auth, they would fail too early with `401`
+- with auth, they correctly reach the controller/service layer
+- then the backend can return the intended `404`
+
+So the scan is checking both:
+
+- authentication boundary
+- correct missing-resource behavior behind that boundary
+
+---
+
+## Reports and artifacts
+
+After ZAP runs, the workflow generates:
+
+- `zap-af-report.md`
+- `zap-af-report.html`
+- `zap-af-report.json`
+- `zap-af-endpoint-coverage.md`
+- `.github/zap/backend-automation-plan.generated.yaml`
+
+These artifacts are the fastest way to confirm whether the scan executed the
+expected JWT-authenticated request path after a deployment.
+
+The most useful files for debugging are:
+
+## 1. `backend-automation-plan.generated.yaml`
+
+This tells you what ZAP actually ran after placeholder substitution.
+
+Use this to answer:
+
+- did the workflow inject the real lobby/game ids?
+- did it inject `Authorization: Bearer ...` headers?
+- did the join request body match the current DTO shape?
+
+## 2. `zap-af-endpoint-coverage.md`
+
+This summarizes:
+
+- which endpoints were exercised
+- expected status codes
+- response profile
+
+## 3. `zap-af-report.md`
+
+This is the human-readable ZAP alert report.
+
+## 4. `zap-af-report.json`
+
+This is the machine-readable version for deeper inspection.
+
+---
+
+## How to verify that JWT mode is really being used
+
+A clean AF report with zero alerts does **not** by itself prove that the scan
+used JWT auth correctly.
+
+The definitive check is the generated plan artifact:
+
+look at:
+
+```text
+.github/zap/backend-automation-plan.generated.yaml
+```
+
+If protected requests contain:
+
+```yaml
+Authorization:Bearer <token>
+```
+
+then the scan is truly running in JWT mode.
+
+That is the file you should inspect whenever you want to confirm that the scan
+is aligned with the current auth contract.
+
+---
+
+## Typical failure modes
+
+## 1. `Scan fixture endpoint returned incomplete data`
+
+Most likely causes:
+
+- Render is running an older backend version
+- the deployed fixture controller does not yet return token fields
+- the backend code on Render is behind your branch
+
+Fix:
+
+- deploy the updated backend to Render
+- rerun the workflow
+
+## 2. `403 Forbidden` on `/internal/security/scan-fixture`
+
+Most likely causes:
+
+- `ZAP_SCAN_FIXTURE_SECRET` missing in GitHub
+- `APP_SCAN_FIXTURE_SECRET` missing in Render
+- values do not match
+
+Fix:
+
+- set both secrets
+- ensure they are identical
+
+## 3. `404` or `401` where a positive protected endpoint should return `200`
+
+Most likely causes:
+
+- fixture ids are wrong
+- generated plan did not substitute properly
+- fixture tokens are missing or invalid
+- Render backend and local workflow contract are out of sync
+
+Fix:
+
+- inspect `backend-automation-plan.generated.yaml`
+- inspect fixture endpoint response shape
+
+## 4. Health check never becomes reachable
+
+Most likely causes:
+
+- Render service asleep or unhealthy
+- backend deployment broken
+
+Fix:
+
+- check Render deploy logs
+- verify `/actuator/health` manually
+
+---
+
+## Manual verification with curl
+
+If you want to verify the fixture endpoint manually, call it directly:
+
+```bash
+curl -fsS \
+  -X POST "https://se2-group-codebase.onrender.com/internal/security/scan-fixture" \
+  -H "X-Scan-Secret: <your-secret>"
+```
+
+Expected result:
+
+```json
+{
+  "lobbyId": "scan-open-lobby",
+  "hostUserId": "scan-host-user",
+  "guestUserId": "scan-guest-user",
+  "gameId": "scan-game-1",
+  "draftOwnerUserId": "scan-host-user",
+  "hostAccessToken": "<jwt>",
+  "guestAccessToken": "<jwt>"
+}
+```
+
+If the token fields are missing, the deployed backend is not on the required
+version yet.
+
+---
+
+## Final mental model
+
+The AF workflow is best understood like this:
+
+- GitHub Actions does not create scan state itself
+- the backend creates scan state
+- the backend also mints JWTs for the scan users
+- the workflow injects those values into a generated AF plan
+- ZAP runs that concrete plan against the deployed Render backend
+
+So the scan is only correct when all three pieces match:
+
+1. backend fixture code
+2. workflow extraction/substitution logic
+3. AF request plan
+
+If those stay aligned, the ZAP AF scan continues to test the real backend
+security model even after major authentication changes.


### PR DESCRIPTION
# Replace `X-User-Id` with JWT Bearer Authentication

![Scope](https://img.shields.io/badge/Scope-Backend-475569) ![Domain](https://img.shields.io/badge/Domain-Authentication%20%26%20Authorization-64748b) ![Feature](https://img.shields.io/badge/Feature-JWT%20Access%20Tokens-6b7280)
![Transport](https://img.shields.io/badge/Transport-Authorization%20Bearer-78716c) ![Security](https://img.shields.io/badge/Risk-Identity%20Spoofing-52525b)
![API](https://img.shields.io/badge/Affects-REST%20Controllers-71717a) ![Realtime](https://img.shields.io/badge/Affects-Game%20Session%20Identity-737373)
[![Status](https://img.shields.io/badge/PR%20Guide-Implementation%20Spec-4b5563)](https://github.com/SE2-Gruppenprojekt/se2-group-codebase/discussions/874)

- Closes #854 
- Closes #855 
- Closes #856 
- Closes #857 
- Closes #858 
- Closes #859 
- Closes #860 
- Closes #861 
- Closes #862 
- Related to #863

This document explains the backend JWT implementation that is currently in the
codebase. It follows the real code, not the earlier discarded version.

The goal of the feature is simple:

- stop trusting `X-User-Id`
- require a signed bearer token for protected requests
- keep the existing backend rule checks, but feed them a trusted user id

## 1. What changed at a high level

Before this refactor, protected endpoints accepted identity like this:

```kotlin
@PostMapping("/{gameId}/draw")
fun drawTile(
    @PathVariable gameId: String,
    @RequestHeader("X-User-Id") userId: String
): GameResponse
```

That meant the caller could pretend to be anyone.

Now protected endpoints use Spring Security authentication instead:

```kotlin
@PostMapping("/{gameId}/draw")
fun drawTile(
    @PathVariable gameId: String,
    authentication: Authentication
): GameResponse {
    return drawTileService.drawTile(gameId, authentication.name).toResponse()
}
```

The important change is this:

- earlier: user id came from the client directly
- now: user id comes from a JWT the backend verifies first

## 2. The new security building blocks

The core backend files are:

- [build.gradle.kts](../apps/backend/build.gradle.kts)
- [JwtProperties.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/JwtProperties.kt)
- [JwtService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/JwtService.kt)
- [JwtAuthenticationFilter.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt)
- [SecurityConfig.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt)
- [RestAuthenticationEntryPoint.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/RestAuthenticationEntryPoint.kt)
- [RestAccessDeniedHandler.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/RestAccessDeniedHandler.kt)

The backend now depends on:

- Spring Security
- `java-jwt`

It also reads JWT config from `application.yml`:

```yaml
app:
  auth:
    jwt:
      issuer: se2-group-backend
      secret: ...
      access-token-ttl-seconds: 86400
```

So the token logic is configurable instead of hardcoded.

## 3. How tokens are created and verified

[JwtService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/JwtService.kt)
is the single place that handles JWT creation and verification.

When the backend creates a token, it stores the authenticated user id in the
JWT `sub` claim:

```kotlin
fun issueAccessToken(userId: String): String {
    val now = Instant.now()
    val expiresAt = now.plusSeconds(jwtProperties.accessTokenTtlSeconds)
    return JWT.create()
        .withIssuer(jwtProperties.issuer)
        .withSubject(userId)
        .withIssuedAt(Date.from(now))
        .withExpiresAt(Date.from(expiresAt))
        .sign(algorithm)
}
```

When the backend receives a bearer token later, it verifies the signature and
extracts the same `sub` claim:

```kotlin
fun extractUserId(token: String): String {
    return try {
        verifier.verify(token).subject
            ?: throw InvalidBearerTokenAuthenticationException()
    } catch (_: Exception) {
        throw InvalidBearerTokenAuthenticationException()
    }
}
```

That means the backend now owns identity.

## 4. How a request becomes authenticated

[JwtAuthenticationFilter.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/JwtAuthenticationFilter.kt)
runs on incoming requests.

It does this in order:

1. read the `Authorization` header
2. check whether it starts with `Bearer `
3. verify the token through `JwtService`
4. create a Spring `Authentication`
5. store that authentication in the security context

Core part:

```kotlin
val userId = jwtService.extractUserId(token)
val authentication = UsernamePasswordAuthenticationToken.authenticated(
    userId,
    null,
    emptyList()
)
SecurityContextHolder.getContext().authentication = authentication
```

After that, controller methods can read the authenticated backend-trusted user
id through:

```kotlin
authentication.name
```

If the token is missing or invalid, the filter uses the JSON auth entry point
instead of falling back to Spring’s default HTML/security behavior.

## 5. Which endpoints are public and which are protected

This is controlled in
[SecurityConfig.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/SecurityConfig.kt).

Public endpoints:

- `/`
- `/robots.txt`
- `/sitemap.xml`
- `/actuator/health`
- `/v3/api-docs/**`
- `/swagger-ui/**`
- `/internal/security/**`
- `GET /api/leaderboard`
- `GET /api/lobbies`
- `POST /api/lobbies`
- `POST /api/lobbies/{lobbyId}/join`

Everything else is authenticated.

This split is intentional:

- players must be able to create a lobby before they have a token
- players must be able to join a lobby before they have a token
- once they have a token, all protected lobby/game actions require it

## 6. Where the first token comes from

There is no separate login system in this project. So the backend creates the
first authenticated session during lobby create and lobby join.

That logic lives in
[LobbyAuthenticationService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyAuthenticationService.kt).

On create:

```kotlin
val userId = UUID.randomUUID().toString()
val lobby = lobbyService.createLobby(userId, request)
val token = jwtService.issueAccessToken(userId)
```

On join:

```kotlin
val userId = UUID.randomUUID().toString()
val lobby = lobbyService.joinLobby(lobbyId, userId, request)
val token = jwtService.issueAccessToken(userId)
```

So the backend now generates the real user id itself.

That is why
[JoinLobbyRequest.kt](../apps/backend/src/main/kotlin/at/se2group/backend/dto/JoinLobbyRequest.kt)
no longer contains a `userId`.

## 7. The new create/join response shape

Lobby create and join no longer return only the lobby.

They now return:

```kotlin
data class AuthenticatedLobbyResponse(
    val accessToken: String,
    val lobby: LobbyResponse
)
```

That gives the frontend both things it needs:

- the first JWT session token
- the normal lobby payload

## 8. How the controllers changed

### LobbyController

Create and join are still public, but now go through
`LobbyAuthenticationService`:

```kotlin
@PostMapping
fun createLobby(
    @Valid @RequestBody request: CreateLobbyRequest
): AuthenticatedLobbyResponse {
    return lobbyAuthenticationService.createAuthenticatedLobby(request)
}
```

Protected lobby actions now use `Authentication` instead of `X-User-Id`:

```kotlin
fun updateLobbySettings(
    @PathVariable lobbyId: String,
    authentication: Authentication,
    @Valid @RequestBody request: UpdateLobbySettingsRequest
): LobbyResponse {
    return lobbyService.updateLobbySettings(
        lobbyId,
        authentication.name,
        request
    ).toResponse()
}
```

### GameController

The game controller follows the same pattern:

```kotlin
fun endTurn(
    @PathVariable gameId: String,
    authentication: Authentication,
    @Valid @RequestBody request: EndTurnRequest
): GameResponse {
    return endTurnService.endTurn(
        gameId,
        authentication.name,
        request
    ).toResponse()
}
```

So the service layer still receives a `userId: String`, but that value is now
trusted.

## 9. What changed in the services

The service layer stayed mostly stable. That was deliberate.

The main changes are:

### `LobbyService.joinLobby(...)`

It now receives the backend-generated user id directly:

```kotlin
fun joinLobby(lobbyId: String, userId: String, request: JoinLobbyRequest): Lobby
```

Instead of trusting `request.userId`, it uses the server-generated `userId`.

### Participant-gated reads

Two read methods now enforce membership:

```kotlin
fun getLobbyForUser(lobbyId: String, userId: String): Lobby
fun getGameForUser(gameId: String, userId: String): ConfirmedGame
```

Those methods reject users who are not part of the lobby/game.

This matters because simple read access is also an authorization boundary now,
not only mutations.

## 10. Error behavior

Missing or invalid bearer auth now returns a stable `401` JSON payload through
[RestAuthenticationEntryPoint.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/RestAuthenticationEntryPoint.kt):

```json
{
  "errorCode": "UNAUTHORIZED",
  "errorMessage": "Missing or invalid bearer token",
  "violations": []
}
```

Normal backend authorization failures, such as “host only” or “not a
participant”, still map to `403` through the existing exception handling path.

## 11. OpenAPI and tests

OpenAPI now declares a bearer scheme in
[OpenApiSecurityConfiguration.kt](../apps/backend/src/main/kotlin/at/se2group/backend/security/OpenApiSecurityConfiguration.kt).

Tests were updated so the backend contract is actually enforced:

- [GameControllerTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/api/GameControllerTest.kt)
- [LobbyControllerTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/api/LobbyControllerTest.kt)
- [OpenApiDocsTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/api/OpenApiDocsTest.kt)
- [GameServiceGetTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/game/service/GameServiceGetTest.kt)
- [LobbyServiceGetTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceGetTest.kt)
- [LobbyServiceJoinTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/LobbyServiceJoinTest.kt)
- [JwtServiceTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/security/JwtServiceTest.kt)

The backend test suite passes with:

```bash
./gradlew :apps:backend:test
```

## 12. Final result

After this implementation:

- `X-User-Id` is no longer used for protected backend auth
- the backend signs and verifies JWT access tokens
- create/join issue the first token
- protected lobby/game endpoints require bearer auth
- lobby/game reads are participant-protected
- service-level rule checks still work, but now with a trusted identity source

That is the full backend auth switch.
