### PR TITLE
ci/fix(security)(workflow)(rest api)(zap): align `OWASP ZAP` AF scan with `JWT` backend authentication

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -59,8 +59,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Run frontend tests
-        run: ./gradlew :apps:android:app:testDebugUnitTest jacocoTestReport
+      - name: Run frontend debug tests
+        run: ./gradlew clean :apps:android:app:testDebugUnitTest
+
+      - name: Run frontend release coverage task
+        run: ./gradlew :apps:android:app:testReleaseUnitTest :apps:android:app:jacocoTestReport
 
       - name: Run frontend Sonar analysis
         uses: SonarSource/sonarqube-scan-action@v6

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,15 +76,25 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
-          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
-          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken // empty')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken // empty')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
             fi
           done
+
+          if [ -n "$SCAN_HOST_ACCESS_TOKEN" ] && [ -n "$SCAN_GUEST_ACCESS_TOKEN" ]; then
+            SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+            SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+            SCAN_JOIN_USER_ID_LINE=""
+          else
+            SCAN_HOST_AUTH_HEADER="X-User-Id:$SCAN_HOST_USER_ID"
+            SCAN_GUEST_AUTH_HEADER="X-User-Id:$SCAN_GUEST_USER_ID"
+            SCAN_JOIN_USER_ID_LINE='            "userId": "scan-join-user",'
+          fi
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"
@@ -93,6 +103,9 @@ jobs:
             echo "SCAN_GUEST_USER_ID=$SCAN_GUEST_USER_ID"
             echo "SCAN_HOST_ACCESS_TOKEN=$SCAN_HOST_ACCESS_TOKEN"
             echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
+            echo "SCAN_HOST_AUTH_HEADER=$SCAN_HOST_AUTH_HEADER"
+            echo "SCAN_GUEST_AUTH_HEADER=$SCAN_GUEST_AUTH_HEADER"
+            echo "SCAN_JOIN_USER_ID_LINE=$SCAN_JOIN_USER_ID_LINE"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -102,6 +115,9 @@ jobs:
             -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
             -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
             -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
+            -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+            -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+            -e "s|__SCAN_JOIN_USER_ID_LINE__|$SCAN_JOIN_USER_ID_LINE|g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -115,7 +131,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_ACCESS_TOKEN:-}" ] && [ -n "${SCAN_GUEST_ACCESS_TOKEN:-}" ]; then
+          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_AUTH_HEADER:-}" ] && [ -n "${SCAN_GUEST_AUTH_HEADER:-}" ]; then
             sed \
               -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
               -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
@@ -123,6 +139,9 @@ jobs:
               -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
               -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
               -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
+              -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+              -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+              -e "s|__SCAN_JOIN_USER_ID_LINE__|${SCAN_JOIN_USER_ID_LINE:-}|g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,25 +76,19 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
-          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken // empty')"
-          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken // empty')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
             fi
           done
 
-          if [ -n "$SCAN_HOST_ACCESS_TOKEN" ] && [ -n "$SCAN_GUEST_ACCESS_TOKEN" ]; then
-            SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
-            SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
-            SCAN_JOIN_USER_ID_LINE=""
-          else
-            SCAN_HOST_AUTH_HEADER="X-User-Id:$SCAN_HOST_USER_ID"
-            SCAN_GUEST_AUTH_HEADER="X-User-Id:$SCAN_GUEST_USER_ID"
-            SCAN_JOIN_USER_ID_LINE='            "userId": "scan-join-user",'
-          fi
+          SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+          SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+          SCAN_JOIN_USER_ID_LINE=""
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -76,8 +76,10 @@ jobs:
           SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
           SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
           SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
+          SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+          SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
 
-          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID"; do
+          for value in "$SCAN_LOBBY_ID" "$SCAN_GAME_ID" "$SCAN_HOST_USER_ID" "$SCAN_GUEST_USER_ID" "$SCAN_HOST_ACCESS_TOKEN" "$SCAN_GUEST_ACCESS_TOKEN"; do
             if [ -z "$value" ] || [ "$value" = "null" ]; then
               echo "Scan fixture endpoint returned incomplete data"
               exit 1
@@ -89,6 +91,8 @@ jobs:
             echo "SCAN_GAME_ID=$SCAN_GAME_ID"
             echo "SCAN_HOST_USER_ID=$SCAN_HOST_USER_ID"
             echo "SCAN_GUEST_USER_ID=$SCAN_GUEST_USER_ID"
+            echo "SCAN_HOST_ACCESS_TOKEN=$SCAN_HOST_ACCESS_TOKEN"
+            echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -96,6 +100,8 @@ jobs:
             -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
             -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
             -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+            -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
+            -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -109,12 +115,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ]; then
+          if [ -n "${SCAN_LOBBY_ID:-}" ] && [ -n "${SCAN_GAME_ID:-}" ] && [ -n "${SCAN_HOST_USER_ID:-}" ] && [ -n "${SCAN_GUEST_USER_ID:-}" ] && [ -n "${SCAN_HOST_ACCESS_TOKEN:-}" ] && [ -n "${SCAN_GUEST_ACCESS_TOKEN:-}" ]; then
             sed \
               -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
               -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
               -e "s/__SCAN_HOST_USER_ID__/$SCAN_HOST_USER_ID/g" \
               -e "s/__SCAN_GUEST_USER_ID__/$SCAN_GUEST_USER_ID/g" \
+              -e "s/__SCAN_HOST_ACCESS_TOKEN__/$SCAN_HOST_ACCESS_TOKEN/g" \
+              -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/workflows/backend-security-af.yml
+++ b/.github/workflows/backend-security-af.yml
@@ -88,7 +88,6 @@ jobs:
 
           SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
           SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
-          SCAN_JOIN_USER_ID_LINE=""
 
           {
             echo "SCAN_LOBBY_ID=$SCAN_LOBBY_ID"
@@ -99,7 +98,6 @@ jobs:
             echo "SCAN_GUEST_ACCESS_TOKEN=$SCAN_GUEST_ACCESS_TOKEN"
             echo "SCAN_HOST_AUTH_HEADER=$SCAN_HOST_AUTH_HEADER"
             echo "SCAN_GUEST_AUTH_HEADER=$SCAN_GUEST_AUTH_HEADER"
-            echo "SCAN_JOIN_USER_ID_LINE=$SCAN_JOIN_USER_ID_LINE"
           } >> "$GITHUB_ENV"
 
           sed \
@@ -111,7 +109,6 @@ jobs:
             -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
             -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
             -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
-            -e "s|__SCAN_JOIN_USER_ID_LINE__|$SCAN_JOIN_USER_ID_LINE|g" \
             .github/zap/backend-automation-plan.yaml \
             > .github/zap/backend-automation-plan.generated.yaml
 
@@ -135,7 +132,6 @@ jobs:
               -e "s/__SCAN_GUEST_ACCESS_TOKEN__/$SCAN_GUEST_ACCESS_TOKEN/g" \
               -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
               -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
-              -e "s|__SCAN_JOIN_USER_ID_LINE__|${SCAN_JOIN_USER_ID_LINE:-}|g" \
               .github/zap/backend-automation-plan.yaml \
               > .github/zap/backend-automation-plan.generated.yaml
           else

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -72,6 +72,8 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -80,7 +82,6 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies
         method: POST
         headers:
-          - "X-User-Id:scan-ephemeral-user"
           - "Content-Type:application/json"
         data: |
           {
@@ -100,7 +101,6 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
-            "userId": "scan-join-user",
             "displayName": "Scan Join User"
           }
         responseCode: 404
@@ -111,7 +111,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
         method: PATCH
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -127,12 +127,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/ready
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/unready
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -141,7 +141,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/leave
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -150,7 +150,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: DELETE
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 204
 
   - type: requestor
@@ -159,7 +159,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -168,7 +168,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
         method: POST
         headers:
-          - "X-User-Id:__SCAN_GUEST_USER_ID__"
+          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -177,7 +177,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: DELETE
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
 
   - type: requestor
@@ -185,6 +185,8 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -193,7 +195,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draft
         method: PUT
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -221,7 +223,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 200
 
   - type: requestor
@@ -230,7 +232,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/end-turn
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -263,11 +265,13 @@ jobs:
     requests:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
+        headers:
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {
@@ -291,12 +295,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
         method: POST
         headers:
-          - "X-User-Id:__SCAN_HOST_USER_ID__"
+          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
           - "Content-Type:application/json"
         data: |
           {

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -101,7 +101,6 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
-__SCAN_JOIN_USER_ID_LINE__
             "displayName": "Scan Join User"
           }
         responseCode: 404

--- a/.github/zap/backend-automation-plan.yaml
+++ b/.github/zap/backend-automation-plan.yaml
@@ -73,7 +73,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -101,6 +101,7 @@ jobs:
           - "Content-Type:application/json"
         data: |
           {
+__SCAN_JOIN_USER_ID_LINE__
             "displayName": "Scan Join User"
           }
         responseCode: 404
@@ -111,7 +112,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/settings
         method: PATCH
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -127,12 +128,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/ready
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/unready
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -141,7 +142,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__/leave
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -150,7 +151,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
         method: DELETE
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 204
 
   - type: requestor
@@ -159,7 +160,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/start
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -168,7 +169,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby/leave
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_GUEST_ACCESS_TOKEN__"
+          - "__SCAN_GUEST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -177,7 +178,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/lobbies/zap-missing-lobby
         method: DELETE
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
 
   - type: requestor
@@ -186,7 +187,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -195,7 +196,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draft
         method: PUT
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -223,7 +224,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 200
 
   - type: requestor
@@ -232,7 +233,7 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/end-turn
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -266,12 +267,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game
         method: GET
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draft
         method: PUT
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {
@@ -295,12 +296,12 @@ jobs:
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/draw
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
         responseCode: 404
       - url: https://se2-group-codebase.onrender.com/api/games/zap-missing-game/end-turn
         method: POST
         headers:
-          - "Authorization:Bearer __SCAN_HOST_ACCESS_TOKEN__"
+          - "__SCAN_HOST_AUTH_HEADER__"
           - "Content-Type:application/json"
         data: |
           {

--- a/apps/android/app/src/test/java/at/aau/serg/android/core/network/game/GameWebSocketServiceTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/core/network/game/GameWebSocketServiceTest.kt
@@ -93,7 +93,9 @@ class GameWebSocketServiceTest {
                 "status": "ACTIVE",
                 "createdAt": "2026-01-01T00:00:00Z",
                 "startedAt": null,
-                "finishedAt": null
+                "finishedAt": null,
+                "totalTurnsCompleted": 0,
+                "winnerUserId": null
               }
             }
         """.trimIndent()

--- a/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/GameNetworkMapperTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/core/network/mapper/GameNetworkMapperTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import shared.models.game.domain.*
+import shared.models.game.response.GamePlayerMetricsResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
 import shared.models.game.response.TileResponse
@@ -15,6 +16,16 @@ import java.time.Instant
 
 class GameNetworkMapperTest {
     private val fakeDate: String = "2025-01-01T10:00:00Z"
+    private val emptyMetrics = GamePlayerMetricsResponse(
+        turnsCompleted = 0,
+        tilesPlayed = 0,
+        meldsCreated = 0,
+        pointsPlayed = 0,
+        tilesRemainingAtEnd = null,
+        penaltyPointsAtEnd = null,
+        winner = false,
+        finishPosition = null
+    )
 
     @Test
     fun numberedTile_to_tileRequest() {
@@ -104,7 +115,8 @@ class GameNetworkMapperTest {
             rackTiles = listOf(TileResponse("t1", "RED", 5, false)),
             hasCompletedInitialMeld = true,
             score = 100,
-            joinedAt = now
+            joinedAt = now,
+            metrics = emptyMetrics
         )
 
         val domain = response.toDomain()
@@ -129,7 +141,8 @@ class GameNetworkMapperTest {
                     rackTiles = emptyList(),
                     hasCompletedInitialMeld = false,
                     score = 0,
-                    joinedAt = fakeDate
+                    joinedAt = fakeDate,
+                    metrics = emptyMetrics
                 )
             ),
             drawPile = emptyList(),
@@ -148,7 +161,9 @@ class GameNetworkMapperTest {
             drawPileCount = 0,
             currentTurnPlayerId = "u1",
             turnDeadline = fakeDate,
-            remainingTurnSeconds = 0
+            remainingTurnSeconds = 0,
+            totalTurnsCompleted = 0,
+            winnerUserId = null
         )
 
         val domain = response.toDomain()
@@ -174,7 +189,8 @@ class GameNetworkMapperTest {
                     rackTiles = emptyList(),
                     hasCompletedInitialMeld = false,
                     score = 0,
-                    joinedAt = fakeDate
+                    joinedAt = fakeDate,
+                    metrics = emptyMetrics
                 )
             ),
             drawPile = emptyList(),
@@ -187,7 +203,9 @@ class GameNetworkMapperTest {
             drawPileCount = 0,
             currentTurnPlayerId = "u1",
             turnDeadline = "null",
-            remainingTurnSeconds = 0
+            remainingTurnSeconds = 0,
+            totalTurnsCompleted = 0,
+            winnerUserId = null
         )
 
         val domain = response.toDomain()

--- a/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
+++ b/apps/android/app/src/test/java/at/aau/serg/android/ui/screens/game/GameViewModelTest.kt
@@ -46,6 +46,7 @@ import shared.models.game.event.GameUpdatedEvent
 import shared.models.game.event.TurnChangedEvent
 import shared.models.game.event.TurnTimedOutEvent
 import shared.models.game.response.BoardSetResponse
+import shared.models.game.response.GamePlayerMetricsResponse
 import shared.models.game.response.GamePlayerResponse
 import shared.models.game.response.GameResponse
 import shared.models.game.response.TileResponse
@@ -89,6 +90,17 @@ class GameViewModelTest {
         ),
     )
 
+    private val emptyMetrics = GamePlayerMetricsResponse(
+        turnsCompleted = 0,
+        tilesPlayed = 0,
+        meldsCreated = 0,
+        pointsPlayed = 0,
+        tilesRemainingAtEnd = null,
+        penaltyPointsAtEnd = null,
+        winner = false,
+        finishPosition = null
+    )
+
     private val fakeGameResponse: GameResponse = GameResponse(
         gameId = "FakeGame1",
         lobbyId = "FakeLobby1",
@@ -100,7 +112,8 @@ class GameViewModelTest {
                 rackTiles = emptyList(),
                 hasCompletedInitialMeld = false,
                 score = 0,
-                joinedAt = "2026-05-08T10:00:00Z"
+                joinedAt = "2026-05-08T10:00:00Z",
+                metrics = emptyMetrics
             )
         ),
         board = emptyList(),
@@ -113,7 +126,9 @@ class GameViewModelTest {
         status = GameStatus.WAITING.toString(),
         createdAt = "2026-05-08T10:00:00Z",
         startedAt = "2026-05-08T10:00:00Z",
-        finishedAt = "2026-05-08T10:00:00Z"
+        finishedAt = "2026-05-08T10:00:00Z",
+        totalTurnsCompleted = 0,
+        winnerUserId = null
     )
 
     fun setTestGameState() {

--- a/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt
@@ -1,5 +1,6 @@
 package at.se2group.backend.api
 
+import at.se2group.backend.security.JwtService
 import at.se2group.backend.service.SecurityScanFixtureService
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.beans.factory.annotation.Value
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 )
 class SecurityScanFixtureController(
     private val securityScanFixtureService: SecurityScanFixtureService,
+    private val jwtService: JwtService,
     @Value("\${app.scan-fixture.secret:}") private val expectedSecret: String
 ) {
 
@@ -37,7 +39,9 @@ class SecurityScanFixtureController(
             hostUserId = state.hostUserId,
             guestUserId = state.guestUserId,
             gameId = state.gameId,
-            draftOwnerUserId = state.draftOwnerUserId
+            draftOwnerUserId = state.draftOwnerUserId,
+            hostAccessToken = jwtService.issueAccessToken(state.hostUserId),
+            guestAccessToken = jwtService.issueAccessToken(state.guestUserId)
         )
     }
 }
@@ -47,5 +51,7 @@ data class SecurityScanFixtureResponse(
     val hostUserId: String,
     val guestUserId: String,
     val gameId: String,
-    val draftOwnerUserId: String
+    val draftOwnerUserId: String,
+    val hostAccessToken: String,
+    val guestAccessToken: String
 )

--- a/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt
@@ -70,6 +70,8 @@ class SecurityScanFixtureControllerTest {
                 jsonPath("$.guestUserId") { value(SecurityScanFixtureService.SCAN_GUEST_USER_ID) }
                 jsonPath("$.gameId") { value(SecurityScanFixtureService.SCAN_GAME_ID) }
                 jsonPath("$.draftOwnerUserId") { value(SecurityScanFixtureService.SCAN_HOST_USER_ID) }
+                jsonPath("$.hostAccessToken") { isNotEmpty() }
+                jsonPath("$.guestAccessToken") { isNotEmpty() }
             }
 
         assertTrue(lobbyRepository.findById(SecurityScanFixtureService.SCAN_OPEN_LOBBY_ID).isPresent)

--- a/docs/zap-af-workflow-guide.md
+++ b/docs/zap-af-workflow-guide.md
@@ -1,0 +1,639 @@
+# OWASP ZAP AF Workflow Guide
+
+![Scope](https://img.shields.io/badge/Scope-Backend%20Security-475569)
+![Workflow](https://img.shields.io/badge/Workflow-ZAP%20Automation%20Framework-64748b)
+![Auth](https://img.shields.io/badge/Auth-JWT%20Bearer-6b7280)
+![Fixtures](https://img.shields.io/badge/Fixtures-Deterministic%20Scan%20State-78716c)
+![Runtime](https://img.shields.io/badge/Runtime-Render%20Deployed%20Backend-52525b)
+![CI](https://img.shields.io/badge/CI-GitHub%20Actions-4b5563)
+
+## Purpose
+
+This document explains, from start to finish, how the OWASP ZAP Automation
+Framework workflow works in this repository.
+
+It covers:
+
+- what the workflow is scanning
+- how the backend scan fixtures are created
+- how JWT authentication fits into the scan
+- which GitHub and Render settings are required
+- how the generated AF plan is built
+- how to debug failures when the workflow breaks
+
+This guide is specifically about:
+
+- [.github/workflows/backend-security-af.yml](../.github/workflows/backend-security-af.yml)
+- [.github/zap/backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)
+- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)
+- [SecurityScanFixtureService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt)
+
+---
+
+## High-level overview
+
+The ZAP AF workflow does **not** scan the backend blindly.
+
+Instead, it uses a prepared backend fixture so that it can make meaningful,
+repeatable requests against:
+
+- a real open lobby
+- a real active game
+- a real draft
+- real users with valid authentication
+
+The flow looks like this:
+
+1. GitHub Actions waits until the deployed backend is reachable on Render.
+2. The workflow calls an internal backend endpoint:
+   - `POST /internal/security/scan-fixture`
+3. The backend recreates deterministic scan data:
+   - prepared lobby
+   - prepared active game
+   - prepared host user
+   - prepared guest user
+4. The backend returns:
+   - fixture ids
+   - JWT access tokens for the prepared users
+5. The workflow injects those values into the generated ZAP AF plan.
+6. ZAP executes the plan against the deployed backend.
+7. Reports and endpoint coverage artifacts are generated and uploaded.
+
+That means the scan is not just "pinging endpoints". It is exercising real API
+flows using the same JWT auth model that real clients use.
+
+---
+
+## Which workflow runs this
+
+The workflow file is:
+
+- [.github/workflows/backend-security-af.yml](../.github/workflows/backend-security-af.yml)
+
+It runs on:
+
+- manual `workflow_dispatch`
+- backend-related pull requests
+- pushes to `main`
+- a weekly schedule
+
+Its target is the deployed Render backend:
+
+```yaml
+env:
+  BACKEND_BASE_URL: https://se2-group-codebase.onrender.com
+  HEALTH_URL: https://se2-group-codebase.onrender.com/actuator/health
+```
+
+So the scan always tests the deployed backend, not a temporary local server
+inside GitHub Actions.
+
+---
+
+## Why scan fixtures exist
+
+Many protected endpoints cannot be scanned meaningfully without state.
+
+Examples:
+
+- `GET /api/lobbies/{id}`
+- `PATCH /api/lobbies/{id}/settings`
+- `POST /api/games/{id}/draw`
+- `POST /api/games/{id}/end-turn`
+
+Those need:
+
+- a real lobby id
+- a real game id
+- a real player who belongs to that lobby/game
+- valid authorization
+
+Without fixtures, the AF plan would mostly hit:
+
+- `401 Unauthorized`
+- `404 Not Found`
+- or invalid-state conflicts
+
+That would not prove that the positive paths still work.
+
+So the backend creates deterministic scan fixtures before ZAP runs.
+
+---
+
+## The internal fixture endpoint
+
+The workflow bootstraps everything through:
+
+```http
+POST /internal/security/scan-fixture
+X-Scan-Secret: <secret>
+```
+
+This endpoint is implemented in:
+
+- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)
+
+It is intentionally:
+
+- hidden from OpenAPI
+- protected by a dedicated scan secret
+- enabled only when scan fixtures are explicitly turned on
+
+Core behavior:
+
+```kotlin
+@PostMapping("/scan-fixture")
+fun createScanFixture(
+    @RequestHeader("X-Scan-Secret", required = false) providedSecret: String?
+): SecurityScanFixtureResponse
+```
+
+If the secret is missing or wrong, the endpoint rejects the request.
+
+If the secret is valid, it calls:
+
+```kotlin
+val state = securityScanFixtureService.recreateFixture()
+```
+
+and returns a response containing both ids and JWTs.
+
+---
+
+## What the fixture response looks like
+
+The workflow expects a JSON response with this shape:
+
+```json
+{
+  "lobbyId": "scan-open-lobby",
+  "hostUserId": "scan-host-user",
+  "guestUserId": "scan-guest-user",
+  "gameId": "scan-game-1",
+  "draftOwnerUserId": "scan-host-user",
+  "hostAccessToken": "<jwt>",
+  "guestAccessToken": "<jwt>"
+}
+```
+
+Meaning of each field:
+
+- `lobbyId`
+  - the prepared open lobby used for positive lobby-state requests
+- `hostUserId`
+  - the prepared host player identity
+- `guestUserId`
+  - the prepared guest player identity
+- `gameId`
+  - the prepared active game used for positive game-state requests
+- `draftOwnerUserId`
+  - the user who currently owns the prepared draft
+- `hostAccessToken`
+  - valid backend-issued JWT for `hostUserId`
+- `guestAccessToken`
+  - valid backend-issued JWT for `guestUserId`
+
+These token fields are critical after the JWT auth refactor. The AF workflow is
+now JWT-only and expects those fields to exist.
+
+---
+
+## How the backend creates those JWTs
+
+The fixture controller does not invent tokens manually. It uses the same
+backend JWT service that the rest of the application uses.
+
+Relevant code pattern:
+
+```kotlin
+hostAccessToken = jwtService.issueAccessToken(state.hostUserId)
+guestAccessToken = jwtService.issueAccessToken(state.guestUserId)
+```
+
+This matters because the scan should authenticate exactly like normal backend
+clients do:
+
+- same JWT issuer
+- same signature
+- same expiry logic
+- same subject claim (`sub`)
+
+So the ZAP scan is not using fake auth. It is using real backend-issued bearer
+tokens.
+
+---
+
+## Where the fixture state itself comes from
+
+The fixture ids are created by:
+
+- [SecurityScanFixtureService.kt](../apps/backend/src/main/kotlin/at/se2group/backend/service/SecurityScanFixtureService.kt)
+
+That service recreates deterministic backend state for the scan.
+
+Important point:
+
+- the workflow does **not** create the fixture itself
+- the backend service creates it
+- the workflow only requests it and consumes the returned ids/tokens
+
+This is why names like `scan-open-lobby` and `scan-game-1` show up in reports.
+
+The service seeds known state so the AF plan can rely on it repeatedly.
+
+---
+
+## Why Render must run the updated backend code
+
+The AF workflow runs against:
+
+```text
+https://se2-group-codebase.onrender.com
+```
+
+So even if your branch contains the correct code locally, the workflow still
+depends on what Render is currently serving.
+
+This is the most important operational point in the whole setup:
+
+> The deployed backend on Render must already include the updated
+> `SecurityScanFixtureController` implementation that returns
+> `hostAccessToken` and `guestAccessToken`.
+
+If Render is still on an older backend version, the fixture endpoint may return
+only ids and no JWT token fields.
+
+Then this workflow step will fail:
+
+```bash
+SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+```
+
+and the guard will stop the scan:
+
+```bash
+if [ -z "$value" ] || [ "$value" = "null" ]; then
+  echo "Scan fixture endpoint returned incomplete data"
+  exit 1
+fi
+```
+
+So when the AF workflow says:
+
+```text
+Scan fixture endpoint returned incomplete data
+```
+
+the first thing to check is whether Render is running the updated backend code.
+
+---
+
+## Required configuration in GitHub and Render
+
+## GitHub Actions
+
+In the repository settings:
+
+`Settings -> Secrets and variables -> Actions`
+
+you need the repository secret:
+
+```text
+ZAP_SCAN_FIXTURE_SECRET
+```
+
+This is the secret that GitHub sends in the request header:
+
+```http
+X-Scan-Secret: <secret>
+```
+
+## Render backend
+
+In the backend service environment variables, you need:
+
+```text
+APP_SCAN_FIXTURE_ENABLED=true
+APP_SCAN_FIXTURE_SECRET=<same value as ZAP_SCAN_FIXTURE_SECRET>
+```
+
+These do two things:
+
+- enable the internal fixture endpoint
+- make sure the endpoint only responds when the correct secret is provided
+
+The values must match between:
+
+- GitHub secret: `ZAP_SCAN_FIXTURE_SECRET`
+- Render env var: `APP_SCAN_FIXTURE_SECRET`
+
+If they do not match, the fixture request will fail with `403 Forbidden`.
+
+---
+
+## How the workflow uses the fixture response
+
+After the fixture response comes back, the workflow extracts values with `jq`:
+
+```bash
+SCAN_LOBBY_ID="$(echo "$FIXTURE_JSON" | jq -r '.lobbyId')"
+SCAN_GAME_ID="$(echo "$FIXTURE_JSON" | jq -r '.gameId')"
+SCAN_HOST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.hostUserId')"
+SCAN_GUEST_USER_ID="$(echo "$FIXTURE_JSON" | jq -r '.guestUserId')"
+SCAN_HOST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.hostAccessToken')"
+SCAN_GUEST_ACCESS_TOKEN="$(echo "$FIXTURE_JSON" | jq -r '.guestAccessToken')"
+```
+
+Then it constructs reusable auth headers:
+
+```bash
+SCAN_HOST_AUTH_HEADER="Authorization:Bearer $SCAN_HOST_ACCESS_TOKEN"
+SCAN_GUEST_AUTH_HEADER="Authorization:Bearer $SCAN_GUEST_ACCESS_TOKEN"
+```
+
+Then it substitutes placeholders in the AF plan:
+
+```bash
+sed \
+  -e "s/__SCAN_LOBBY_ID__/$SCAN_LOBBY_ID/g" \
+  -e "s/__SCAN_GAME_ID__/$SCAN_GAME_ID/g" \
+  -e "s|__SCAN_HOST_AUTH_HEADER__|$SCAN_HOST_AUTH_HEADER|g" \
+  -e "s|__SCAN_GUEST_AUTH_HEADER__|$SCAN_GUEST_AUTH_HEADER|g" \
+  .github/zap/backend-automation-plan.yaml \
+  > .github/zap/backend-automation-plan.generated.yaml
+```
+
+So ZAP never runs against the placeholder template directly. It runs against the
+generated concrete plan.
+
+---
+
+## The AF plan template
+
+The template is:
+
+- [.github/zap/backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)
+
+This file contains:
+
+- public requests
+- positive lobby-state requests
+- positive game-state requests
+- negative-path requests
+- report generation steps
+
+Examples of protected requests now using JWT placeholders:
+
+```yaml
+- url: https://se2-group-codebase.onrender.com/api/lobbies/__SCAN_LOBBY_ID__
+  method: GET
+  headers:
+    - "__SCAN_HOST_AUTH_HEADER__"
+  responseCode: 200
+```
+
+```yaml
+- url: https://se2-group-codebase.onrender.com/api/games/__SCAN_GAME_ID__/draw
+  method: POST
+  headers:
+    - "__SCAN_HOST_AUTH_HEADER__"
+  responseCode: 200
+```
+
+This is the JWT-specific alignment. Before the auth refactor, these protected
+requests used `X-User-Id`. Now they use backend-issued bearer tokens.
+
+---
+
+## Public vs protected requests
+
+Not every request in the AF plan should carry a JWT.
+
+### Public requests stay public
+
+Examples:
+
+- `GET /`
+- `GET /robots.txt`
+- `GET /sitemap.xml`
+- `GET /actuator/health`
+- `GET /api/leaderboard`
+- `GET /api/lobbies`
+- invalid `POST /api/lobbies`
+- missing `POST /api/lobbies/{id}/join`
+
+These do not need bearer auth.
+
+### Protected requests must use JWT
+
+Examples:
+
+- `GET /api/lobbies/{id}`
+- `PATCH /api/lobbies/{id}/settings`
+- `POST /api/lobbies/{id}/ready`
+- `POST /api/lobbies/{id}/leave`
+- `DELETE /api/lobbies/{id}`
+- `GET /api/games/{id}`
+- `PUT /api/games/{id}/draft`
+- `POST /api/games/{id}/draw`
+- `POST /api/games/{id}/end-turn`
+
+These must use valid bearer tokens or they should fail with `401`.
+
+---
+
+## Why some negative-path requests still expect `404`
+
+Some protected requests intentionally target missing resources, for example:
+
+- missing lobby id
+- missing game id
+
+These still send a valid JWT.
+
+Why:
+
+- without auth, they would fail too early with `401`
+- with auth, they correctly reach the controller/service layer
+- then the backend can return the intended `404`
+
+So the scan is checking both:
+
+- authentication boundary
+- correct missing-resource behavior behind that boundary
+
+---
+
+## Reports and artifacts
+
+After ZAP runs, the workflow generates:
+
+- `zap-af-report.md`
+- `zap-af-report.html`
+- `zap-af-report.json`
+- `zap-af-endpoint-coverage.md`
+- `.github/zap/backend-automation-plan.generated.yaml`
+
+These artifacts are the fastest way to confirm whether the scan executed the
+expected JWT-authenticated request path after a deployment.
+
+The most useful files for debugging are:
+
+## 1. `backend-automation-plan.generated.yaml`
+
+This tells you what ZAP actually ran after placeholder substitution.
+
+Use this to answer:
+
+- did the workflow inject the real lobby/game ids?
+- did it inject `Authorization: Bearer ...` headers?
+- did the join request body match the current DTO shape?
+
+## 2. `zap-af-endpoint-coverage.md`
+
+This summarizes:
+
+- which endpoints were exercised
+- expected status codes
+- response profile
+
+## 3. `zap-af-report.md`
+
+This is the human-readable ZAP alert report.
+
+## 4. `zap-af-report.json`
+
+This is the machine-readable version for deeper inspection.
+
+---
+
+## How to verify that JWT mode is really being used
+
+A clean AF report with zero alerts does **not** by itself prove that the scan
+used JWT auth correctly.
+
+The definitive check is the generated plan artifact:
+
+look at:
+
+```text
+.github/zap/backend-automation-plan.generated.yaml
+```
+
+If protected requests contain:
+
+```yaml
+Authorization:Bearer <token>
+```
+
+then the scan is truly running in JWT mode.
+
+That is the file you should inspect whenever you want to confirm that the scan
+is aligned with the current auth contract.
+
+---
+
+## Typical failure modes
+
+## 1. `Scan fixture endpoint returned incomplete data`
+
+Most likely causes:
+
+- Render is running an older backend version
+- the deployed fixture controller does not yet return token fields
+- the backend code on Render is behind your branch
+
+Fix:
+
+- deploy the updated backend to Render
+- rerun the workflow
+
+## 2. `403 Forbidden` on `/internal/security/scan-fixture`
+
+Most likely causes:
+
+- `ZAP_SCAN_FIXTURE_SECRET` missing in GitHub
+- `APP_SCAN_FIXTURE_SECRET` missing in Render
+- values do not match
+
+Fix:
+
+- set both secrets
+- ensure they are identical
+
+## 3. `404` or `401` where a positive protected endpoint should return `200`
+
+Most likely causes:
+
+- fixture ids are wrong
+- generated plan did not substitute properly
+- fixture tokens are missing or invalid
+- Render backend and local workflow contract are out of sync
+
+Fix:
+
+- inspect `backend-automation-plan.generated.yaml`
+- inspect fixture endpoint response shape
+
+## 4. Health check never becomes reachable
+
+Most likely causes:
+
+- Render service asleep or unhealthy
+- backend deployment broken
+
+Fix:
+
+- check Render deploy logs
+- verify `/actuator/health` manually
+
+---
+
+## Manual verification with curl
+
+If you want to verify the fixture endpoint manually, call it directly:
+
+```bash
+curl -fsS \
+  -X POST "https://se2-group-codebase.onrender.com/internal/security/scan-fixture" \
+  -H "X-Scan-Secret: <your-secret>"
+```
+
+Expected result:
+
+```json
+{
+  "lobbyId": "scan-open-lobby",
+  "hostUserId": "scan-host-user",
+  "guestUserId": "scan-guest-user",
+  "gameId": "scan-game-1",
+  "draftOwnerUserId": "scan-host-user",
+  "hostAccessToken": "<jwt>",
+  "guestAccessToken": "<jwt>"
+}
+```
+
+If the token fields are missing, the deployed backend is not on the required
+version yet.
+
+---
+
+## Final mental model
+
+The AF workflow is best understood like this:
+
+- GitHub Actions does not create scan state itself
+- the backend creates scan state
+- the backend also mints JWTs for the scan users
+- the workflow injects those values into a generated AF plan
+- ZAP runs that concrete plan against the deployed Render backend
+
+So the scan is only correct when all three pieces match:
+
+1. backend fixture code
+2. workflow extraction/substitution logic
+3. AF request plan
+
+If those stay aligned, the ZAP AF scan continues to test the real backend
+security model even after major authentication changes.


### PR DESCRIPTION
# PR Summary: Align OWASP ZAP AF Scan with JWT Backend Authentication

![Scope](https://img.shields.io/badge/Scope-Security-475569) ![Domain](https://img.shields.io/badge/Domain-ZAP%20Automation%20Framework-64748b) ![Feature](https://img.shields.io/badge/Feature-JWT%20Scan%20Compatibility-6b7280)
![Affects](https://img.shields.io/badge/Affects-Backend%20Fixture%20Endpoint-78716c) ![Affects](https://img.shields.io/badge/Affects-GitHub%20Actions%20Workflow-52525b)
![Affects](https://img.shields.io/badge/Affects-AF%20Request%20Plan-71717a) ![Status](https://img.shields.io/badge/PR%20Description-Summary-4b5563)

- Closes #886 
- Closes #887 
- Closes #888 
- Closes #889 
- Closes #890 
- Closes #891 

## Summary

This PR keeps the OWASP ZAP Automation Framework scan working after the backend
switched from `X-User-Id` to JWT bearer authentication.

Before this change, the AF scan still used the old transport model:

```http
X-User-Id: user-1
```

That no longer matches the backend contract. Protected lobby and game endpoints
now require:

```http
Authorization: Bearer <jwt>
```

Without this PR, the next AF scan would start failing on protected requests with
`401 Unauthorized`, even though the backend auth implementation itself is
correct.

This PR fixes that mismatch by letting the AF fixture endpoint mint deterministic
JWTs for the prepared scan users and then wiring those tokens into the generated
automation plan.

---

## Problem

The current ZAP AF setup depended on assumptions that were true before the JWT
refactor:

- protected endpoints accepted `X-User-Id`
- `GET /api/lobbies/{id}` and `GET /api/games/{id}` behaved like public reads in
  the scan plan
- the join-lobby request body still matched the old DTO shape

After the JWT PR, those assumptions are stale.

That creates two concrete risks:

1. the scan starts returning `401` on protected requests
2. the scan stops reflecting the real security boundary of the backend

The second risk matters more. If the scan bypasses the real auth contract, it is
no longer testing the same behavior that production clients use.

---

## What this PR changes

## 1. The scan fixture endpoint now returns JWTs

The internal fixture endpoint already prepares deterministic scan state:

- open lobby
- active lobby
- active game
- known host user
- known guest user

This PR extends that response so it also returns backend-issued access tokens for
those prepared users.

That keeps the ZAP setup simple:

- the fixture endpoint still creates the state
- the workflow still calls exactly one endpoint to bootstrap the scan
- the AF plan gets real bearer tokens without hardcoding secrets or token logic

Example response shape:

```json
{
  "lobbyId": "scan-open-lobby",
  "hostUserId": "scan-host-user",
  "guestUserId": "scan-guest-user",
  "gameId": "scan-game",
  "draftOwnerUserId": "scan-host-user",
  "hostAccessToken": "<jwt>",
  "guestAccessToken": "<jwt>"
}
```

Relevant file:

- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)

---

## 2. The GitHub Actions workflow now exports those tokens

The AF workflow already calls the internal fixture endpoint and extracts the ids
from the JSON response.

This PR extends that step so it also extracts:

- `hostAccessToken`
- `guestAccessToken`

and writes them into the generated plan through placeholder substitution.

That means the workflow remains data-driven:

- call fixture endpoint
- parse JSON
- replace placeholders in `.github/zap/backend-automation-plan.yaml`
- run `zaproxy/action-af`

Relevant file:

- [backend-security-af.yml](../.github/workflows/backend-security-af.yml)

---

## 3. The AF plan now uses bearer auth on protected endpoints

Every protected lobby/game request in the plan now uses:

```http
Authorization: Bearer __SCAN_HOST_ACCESS_TOKEN__
```

or:

```http
Authorization: Bearer __SCAN_GUEST_ACCESS_TOKEN__
```

depending on which prepared fixture user should perform the action.

This affects:

- protected lobby reads
- lobby settings updates
- ready / unready
- leave
- delete
- protected game reads
- draft updates
- draw
- end turn
- protected negative-path requests that should still return `404` instead of
  failing earlier with `401`

Relevant file:

- [backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)

---

## 4. Stale request shapes were cleaned up

While aligning the auth model, the AF plan was also updated to match the current
backend DTO contract.

Two important fixes:

### Create lobby negative-path request

The invalid create-lobby request no longer sends an `X-User-Id` header, because
create-lobby is public and now bootstraps identity server-side.

### Join lobby negative-path request

The missing-lobby join request body no longer sends a `userId` field, because
the backend `JoinLobbyRequest` now only needs:

```json
{
  "displayName": "Scan Join User"
}
```

This keeps the scan aligned with the real API contract instead of only the auth
layer.

---

## Why this approach

This PR could have tried to weaken the scan path by making some routes public or
by adding special-case auth bypasses for ZAP.

That would be the wrong design.

The chosen approach is better because:

- production auth stays unchanged
- the scan uses the same bearer-token model as real clients
- the only special hook is the already-internal fixture bootstrap endpoint
- the scan remains realistic and maintainable

So this PR improves scan compatibility **without** weakening the backend
security boundary.

---

## Files changed

- [SecurityScanFixtureController.kt](../apps/backend/src/main/kotlin/at/se2group/backend/api/SecurityScanFixtureController.kt)
- [SecurityScanFixtureControllerTest.kt](../apps/backend/src/test/kotlin/at/se2group/backend/api/SecurityScanFixtureControllerTest.kt)
- [backend-security-af.yml](../.github/workflows/backend-security-af.yml)
- [backend-automation-plan.yaml](../.github/zap/backend-automation-plan.yaml)

---

## Validation

The backend fixture controller test was updated so the new token fields are
checked explicitly.

Validated locally with:

```bash
./gradlew :apps:backend:test --tests at.se2group.backend.api.SecurityScanFixtureControllerTest
./gradlew :apps:backend:test
```

Expected scan behavior after this PR:

- public endpoints still scan anonymously
- protected endpoints scan with valid bearer tokens
- missing protected resources still return `404`
- the AF workflow does not depend on stale `X-User-Id` transport

---

## Expected outcome

After this PR:

- the JWT backend auth PR no longer breaks the AF scan
- the ZAP AF plan matches the real backend auth contract
- the scan remains useful as a security signal after the authentication refactor

This is the correct follow-up to the JWT backend PR because it keeps the
security tooling aligned with the actual protocol instead of the old one.
