### PR TITLE
ci(workflow)(script)(activity): expand organization activity reports with richer GitHub metrics

### DIFF
--- a/.github/scripts/generate_org_user_activity.py
+++ b/.github/scripts/generate_org_user_activity.py
@@ -6,8 +6,8 @@ import os
 import urllib.parse
 import urllib.request
 from collections import defaultdict
-from datetime import datetime
-
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Optional
 
 ORG = os.environ["TARGET_ORGANIZATION"]
 SINCE = os.environ["REPORT_SINCE"]
@@ -16,6 +16,32 @@ TOKEN = os.environ["GH_TOKEN"]
 REPORTS_DIR = os.environ.get("REPORTS_DIR", "reports")
 
 os.makedirs(REPORTS_DIR, exist_ok=True)
+
+START = datetime.fromisoformat(SINCE.replace("Z", "+00:00"))
+END = datetime.fromisoformat(UNTIL.replace("Z", "+00:00"))
+GENERATED_AT = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+USER_METRIC_KEYS = [
+    "commits",
+    "issuesOpened",
+    "issuesClosed",
+    "issueComments",
+    "prConversationComments",
+    "prsOpened",
+    "prsMerged",
+    "prsClosedUnmerged",
+    "prReviewComments",
+    "prReviews",
+    "prApprovals",
+    "prChangeRequests",
+    "prReviewDismissals",
+]
+
+REVIEW_STATE_TO_METRIC = {
+    "APPROVED": "prApprovals",
+    "CHANGES_REQUESTED": "prChangeRequests",
+    "DISMISSED": "prReviewDismissals",
+}
 
 
 def gh_get(url: str):
@@ -49,11 +75,40 @@ def paginate(url: str):
     return items
 
 
-def in_window(iso_value: str) -> bool:
-    value = datetime.fromisoformat(iso_value.replace("Z", "+00:00"))
-    start = datetime.fromisoformat(SINCE.replace("Z", "+00:00"))
-    end = datetime.fromisoformat(UNTIL.replace("Z", "+00:00"))
-    return start <= value < end
+def paginate_until(url: str, date_field: str):
+    items = []
+    next_url = url
+    while next_url:
+        data, headers = gh_get(next_url)
+        if not isinstance(data, list):
+            raise RuntimeError(f"Expected list response for {next_url}")
+        stop = False
+        for item in data:
+            field_value = item.get(date_field)
+            if field_value and parse_iso(field_value) < START:
+                stop = True
+                break
+            items.append(item)
+        if stop:
+            break
+        link = headers.get("Link", "")
+        next_url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                next_url = part[part.find("<") + 1:part.find(">")]
+                break
+    return items
+
+
+def parse_iso(iso_value: str) -> datetime:
+    return datetime.fromisoformat(iso_value.replace("Z", "+00:00"))
+
+
+def in_window(iso_value: Optional[str]) -> bool:
+    if not iso_value:
+        return False
+    value = parse_iso(iso_value)
+    return START <= value < END
 
 
 def actor_name(value):
@@ -64,23 +119,79 @@ def actor_name(value):
     return None
 
 
-activity = defaultdict(
+def parse_issue_number(issue_url: str) -> Optional[int]:
+    if not issue_url:
+        return None
+    try:
+        return int(issue_url.rstrip("/").rsplit("/", 1)[-1])
+    except (TypeError, ValueError):
+        return None
+
+
+activity: Dict[str, dict] = defaultdict(
     lambda: {
         "login": "",
         "email": "",
+        "isBot": False,
+        "isOrganizationMember": False,
         "isActive": False,
         "commits": 0,
-        "issues": 0,
+        "issuesOpened": 0,
+        "issuesClosed": 0,
         "issueComments": 0,
-        "prComments": 0,
+        "prConversationComments": 0,
+        "prsOpened": 0,
+        "prsMerged": 0,
+        "prsClosedUnmerged": 0,
+        "prReviewComments": 0,
+        "prReviews": 0,
+        "prApprovals": 0,
+        "prChangeRequests": 0,
+        "prReviewDismissals": 0,
+        "repositoriesTouched": set(),
+        "repositoriesTouchedCount": 0,
+        "activityDates": set(),
+        "firstActivityAt": None,
+        "lastActivityAt": None,
+        "totalEvents": 0,
     }
 )
+
+repo_activity: Dict[str, dict] = defaultdict(
+    lambda: {
+        "repo": "",
+        "commits": 0,
+        "issuesOpened": 0,
+        "issuesClosed": 0,
+        "issueComments": 0,
+        "prConversationComments": 0,
+        "prsOpened": 0,
+        "prsMerged": 0,
+        "prsClosedUnmerged": 0,
+        "prReviewComments": 0,
+        "prReviews": 0,
+        "prApprovals": 0,
+        "prChangeRequests": 0,
+        "prReviewDismissals": 0,
+        "activeUsers": set(),
+        "totalEvents": 0,
+    }
+)
+
+
+def classify_bot(login: str) -> bool:
+    lower = login.lower()
+    return login.endswith("[bot]") or lower.startswith("github-actions") or lower.endswith("bot")
+
 
 members = paginate(f"https://api.github.com/orgs/{ORG}/members?per_page=100")
 member_logins = {member["login"].lower(): member["login"] for member in members}
 for member in members:
     login = member["login"]
-    activity[login]["login"] = login
+    entry = activity[login]
+    entry["login"] = login
+    entry["isBot"] = classify_bot(login)
+    entry["isOrganizationMember"] = True
 
 
 def fallback_login_from_commit(commit):
@@ -103,8 +214,35 @@ def fallback_login_from_commit(commit):
 
 repos = paginate(f"https://api.github.com/orgs/{ORG}/repos?per_page=100&type=all")
 
+
+def record_metric(login: str, repo_name: str, metric: str, when: Optional[str] = None, amount: int = 1):
+    entry = activity[login]
+    entry["login"] = login
+    entry["isBot"] = classify_bot(login)
+    entry["isOrganizationMember"] = login.lower() in member_logins
+    entry["isActive"] = True
+    entry[metric] += amount
+    entry["repositoriesTouched"].add(repo_name)
+    entry["repositoriesTouchedCount"] = len(entry["repositoriesTouched"])
+    entry["totalEvents"] += amount
+
+    repo_entry = repo_activity[repo_name]
+    repo_entry["repo"] = repo_name
+    repo_entry[metric] += amount
+    repo_entry["activeUsers"].add(login)
+    repo_entry["totalEvents"] += amount
+
+    if when and in_window(when):
+        entry["activityDates"].add(when[:10])
+        if entry["firstActivityAt"] is None or when < entry["firstActivityAt"]:
+            entry["firstActivityAt"] = when
+        if entry["lastActivityAt"] is None or when > entry["lastActivityAt"]:
+            entry["lastActivityAt"] = when
+
+
 for repo in repos:
     repo_name = repo["name"]
+    issue_kind_by_number = {}
 
     commits_url = (
         f"https://api.github.com/repos/{ORG}/{repo_name}/commits"
@@ -119,9 +257,8 @@ for repo in repos:
         )
         if not login:
             continue
-        activity[login]["login"] = login
-        activity[login]["isActive"] = True
-        activity[login]["commits"] += 1
+        when = commit.get("commit", {}).get("author", {}).get("date") or commit.get("commit", {}).get("committer", {}).get("date")
+        record_metric(login, repo_name, "commits", when=when)
 
     issues_url = (
         f"https://api.github.com/repos/{ORG}/{repo_name}/issues"
@@ -129,14 +266,17 @@ for repo in repos:
     )
     issues = paginate(issues_url)
     for issue in issues:
-        if "pull_request" in issue:
+        issue_number = issue.get("number")
+        is_pr = "pull_request" in issue
+        if issue_number is not None:
+            issue_kind_by_number[issue_number] = "pr" if is_pr else "issue"
+        if is_pr:
             continue
-        created_at = issue.get("created_at")
         login = actor_name(issue.get("user"))
-        if created_at and login and in_window(created_at):
-            activity[login]["login"] = login
-            activity[login]["isActive"] = True
-            activity[login]["issues"] += 1
+        if login and in_window(issue.get("created_at")):
+            record_metric(login, repo_name, "issuesOpened", when=issue.get("created_at"))
+        if login and in_window(issue.get("closed_at")):
+            record_metric(login, repo_name, "issuesClosed", when=issue.get("closed_at"))
 
     issue_comments_url = (
         f"https://api.github.com/repos/{ORG}/{repo_name}/issues/comments"
@@ -146,10 +286,41 @@ for repo in repos:
     for comment in issue_comments:
         created_at = comment.get("created_at")
         login = actor_name(comment.get("user"))
-        if created_at and login and in_window(created_at):
-            activity[login]["login"] = login
-            activity[login]["isActive"] = True
-            activity[login]["issueComments"] += 1
+        if not (created_at and login and in_window(created_at)):
+            continue
+        issue_number = parse_issue_number(comment.get("issue_url"))
+        issue_kind = issue_kind_by_number.get(issue_number)
+        metric = "prConversationComments" if issue_kind == "pr" else "issueComments"
+        record_metric(login, repo_name, metric, when=created_at)
+
+    pulls_url = (
+        f"https://api.github.com/repos/{ORG}/{repo_name}/pulls"
+        f"?state=all&sort=updated&direction=desc&per_page=100"
+    )
+    pulls = paginate_until(pulls_url, "updated_at")
+    relevant_pr_numbers = []
+    for pr in pulls:
+        number = pr["number"]
+        if in_window(pr.get("created_at")):
+            login = actor_name(pr.get("user"))
+            if login:
+                record_metric(login, repo_name, "prsOpened", when=pr.get("created_at"))
+            relevant_pr_numbers.append(number)
+            continue
+        if in_window(pr.get("merged_at")):
+            login = actor_name(pr.get("merged_by")) or actor_name(pr.get("user"))
+            if login:
+                record_metric(login, repo_name, "prsMerged", when=pr.get("merged_at"))
+            relevant_pr_numbers.append(number)
+            continue
+        if pr.get("merged_at") is None and in_window(pr.get("closed_at")):
+            login = actor_name(pr.get("user"))
+            if login:
+                record_metric(login, repo_name, "prsClosedUnmerged", when=pr.get("closed_at"))
+            relevant_pr_numbers.append(number)
+            continue
+        if in_window(pr.get("updated_at")):
+            relevant_pr_numbers.append(number)
 
     pr_comments_url = (
         f"https://api.github.com/repos/{ORG}/{repo_name}/pulls/comments"
@@ -160,26 +331,206 @@ for repo in repos:
         created_at = comment.get("created_at")
         login = actor_name(comment.get("user"))
         if created_at and login and in_window(created_at):
-            activity[login]["login"] = login
-            activity[login]["isActive"] = True
-            activity[login]["prComments"] += 1
+            record_metric(login, repo_name, "prReviewComments", when=created_at)
 
-rows = sorted(
-    activity.values(),
-    key=lambda item: (
-        not item["isActive"],
-        -(item["commits"] + item["issues"] + item["issueComments"] + item["prComments"]),
-        item["login"].lower(),
-    ),
-)
+    for pr_number in sorted(set(relevant_pr_numbers)):
+        reviews_url = f"https://api.github.com/repos/{ORG}/{repo_name}/pulls/{pr_number}/reviews?per_page=100"
+        reviews = paginate(reviews_url)
+        for review in reviews:
+            submitted_at = review.get("submitted_at")
+            login = actor_name(review.get("user"))
+            if not (submitted_at and login and in_window(submitted_at)):
+                continue
+            record_metric(login, repo_name, "prReviews", when=submitted_at)
+            state_metric = REVIEW_STATE_TO_METRIC.get((review.get("state") or "").upper())
+            if state_metric:
+                record_metric(login, repo_name, state_metric, when=submitted_at)
+
+
+def sort_user_rows(values: Iterable[dict]):
+    return sorted(
+        values,
+        key=lambda item: (
+            not item["isActive"],
+            -item["totalEvents"],
+            -item["commits"],
+            item["login"].lower(),
+        ),
+    )
+
+
+user_rows = []
+for item in activity.values():
+    row = {k: v for k, v in item.items() if k not in {"repositoriesTouched", "activityDates"}}
+    repos_touched = sorted(item["repositoriesTouched"])
+    activity_dates = sorted(item["activityDates"])
+    row["repositoriesTouched"] = repos_touched
+    row["activityDates"] = activity_dates
+    row["activityDays"] = len(activity_dates)
+    user_rows.append(row)
+
+user_rows = sort_user_rows(user_rows)
+
+repo_rows = []
+for item in repo_activity.values():
+    row = dict(item)
+    row["activeUsers"] = sorted(item["activeUsers"])
+    row["activeUsersCount"] = len(item["activeUsers"])
+    repo_rows.append(row)
+
+repo_rows = sorted(repo_rows, key=lambda item: (-item["totalEvents"], item["repo"].lower()))
+
+active_users = [item for item in user_rows if item["isActive"]]
+active_humans = [item for item in active_users if not item["isBot"]]
+active_bots = [item for item in active_users if item["isBot"]]
+
+summary = {
+    "memberCount": len(members),
+    "repositoryCount": len(repos),
+    "activeActors": len(active_users),
+    "activeHumans": len(active_humans),
+    "activeBots": len(active_bots),
+    "inactiveListedMembers": len([item for item in user_rows if item["isOrganizationMember"] and not item["isActive"]]),
+    "totals": {metric: sum(item[metric] for item in user_rows) for metric in USER_METRIC_KEYS},
+}
+summary["totals"]["totalEvents"] = sum(item["totalEvents"] for item in user_rows)
+
+
+def top_actor(metric: str):
+    candidates = [item for item in user_rows if item[metric] > 0]
+    if not candidates:
+        return None
+    winner = max(candidates, key=lambda item: (item[metric], item["totalEvents"], item["login"].lower()))
+    return {"login": winner["login"], metric: winner[metric]}
+
+
+summary["leaders"] = {
+    "commits": top_actor("commits"),
+    "issuesOpened": top_actor("issuesOpened"),
+    "prsOpened": top_actor("prsOpened"),
+    "prsMerged": top_actor("prsMerged"),
+    "prReviews": top_actor("prReviews"),
+    "totalEvents": top_actor("totalEvents"),
+}
+
+report = {
+    "organization": ORG,
+    "generatedAt": GENERATED_AT,
+    "reportSince": SINCE,
+    "reportUntil": UNTIL,
+    "windowDays": (END - START).days,
+    "summary": summary,
+    "users": user_rows,
+    "repositories": repo_rows,
+}
+
+
+def yes_no(value: bool) -> str:
+    return "Yes" if value else "No"
+
+
+def render_markdown(report_obj: dict) -> str:
+    lines = []
+    summary_obj = report_obj["summary"]
+    totals = summary_obj["totals"]
+    lines.append("# Organization User Activity Report")
+    lines.append("")
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"This report summarizes GitHub organization activity for **{report_obj['organization']}** between **{report_obj['reportSince'][:10]}** and **{report_obj['reportUntil'][:10]}**.")
+    lines.append("")
+    lines.append("## Executive Summary")
+    lines.append("")
+    lines.append(f"- Repositories scanned: **{summary_obj['repositoryCount']}**")
+    lines.append(f"- Organization members discovered: **{summary_obj['memberCount']}**")
+    lines.append(f"- Active actors: **{summary_obj['activeActors']}**")
+    lines.append(f"- Active humans: **{summary_obj['activeHumans']}**")
+    lines.append(f"- Active bots: **{summary_obj['activeBots']}**")
+    lines.append(f"- Total tracked events: **{totals['totalEvents']}**")
+    lines.append("")
+    lines.append("| Metric | Total |")
+    lines.append("| --- | ---: |")
+    for metric in USER_METRIC_KEYS + ["totalEvents"]:
+        lines.append(f"| {metric} | {totals[metric]} |")
+    lines.append("")
+    lines.append("## Top Actors")
+    lines.append("")
+    lines.append("| Category | Actor | Value |")
+    lines.append("| --- | --- | ---: |")
+    for metric, leader in summary_obj["leaders"].items():
+        if leader:
+            value = leader[metric]
+            lines.append(f"| {metric} | `{leader['login']}` | {value} |")
+    lines.append("")
+    lines.append("## User Activity")
+    lines.append("")
+    lines.append("| User | Bot | Org Member | Active | Total | Commits | Issues Opened | Issues Closed | PRs Opened | PRs Merged | Reviews | Review Comments | Repos Touched | First Activity | Last Activity |")
+    lines.append("| --- | :---: | :---: | :---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |")
+    for item in report_obj["users"]:
+        lines.append(
+            f"| `{item['login']}` | {yes_no(item['isBot'])} | {yes_no(item['isOrganizationMember'])} | {yes_no(item['isActive'])} | {item['totalEvents']} | {item['commits']} | {item['issuesOpened']} | {item['issuesClosed']} | {item['prsOpened']} | {item['prsMerged']} | {item['prReviews']} | {item['prReviewComments']} | {item['repositoriesTouchedCount']} | {item['firstActivityAt'] or ''} | {item['lastActivityAt'] or ''} |"
+        )
+    lines.append("")
+    lines.append("## Repository Activity")
+    lines.append("")
+    lines.append("| Repository | Total | Active Users | Commits | Issues Opened | PRs Opened | PRs Merged | Reviews |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    for item in report_obj["repositories"]:
+        lines.append(
+            f"| `{item['repo']}` | {item['totalEvents']} | {item['activeUsersCount']} | {item['commits']} | {item['issuesOpened']} | {item['prsOpened']} | {item['prsMerged']} | {item['prReviews']} |"
+        )
+    lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append("- `issueComments` counts comments on non-PR issues.")
+    lines.append("- `prConversationComments` counts top-level issue-style comments on PR conversations.")
+    lines.append("- `prReviewComments` counts inline PR review comments from the pull-request review API.")
+    lines.append("- `prReviews` counts submitted review events. Approvals and change requests are broken out separately.")
+    lines.append("- Commits are attributed to the GitHub author/committer login when available, with a fallback heuristic from commit metadata for organization members.")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
 
 with open(os.path.join(REPORTS_DIR, "organization_user_activity.json"), "w", encoding="utf-8") as fh:
-    json.dump(rows, fh, indent=2)
+    json.dump(report, fh, indent=2)
 
+csv_fields = [
+    "login",
+    "isBot",
+    "isOrganizationMember",
+    "isActive",
+    "totalEvents",
+    *USER_METRIC_KEYS,
+    "repositoriesTouchedCount",
+    "activityDays",
+    "firstActivityAt",
+    "lastActivityAt",
+    "repositoriesTouched",
+]
 with open(os.path.join(REPORTS_DIR, "organization_user_activity.csv"), "w", newline="", encoding="utf-8") as fh:
-    writer = csv.DictWriter(
-        fh,
-        fieldnames=["login", "email", "isActive", "commits", "issues", "issueComments", "prComments"],
-    )
+    writer = csv.DictWriter(fh, fieldnames=csv_fields)
     writer.writeheader()
-    writer.writerows(rows)
+    for row in user_rows:
+        serializable = dict(row)
+        serializable["repositoriesTouched"] = ";".join(row["repositoriesTouched"])
+        serializable.pop("email", None)
+        serializable.pop("activityDates", None)
+        writer.writerow({key: serializable.get(key, "") for key in csv_fields})
+
+with open(os.path.join(REPORTS_DIR, "organization_repository_activity.csv"), "w", newline="", encoding="utf-8") as fh:
+    fieldnames = [
+        "repo",
+        "totalEvents",
+        *USER_METRIC_KEYS,
+        "activeUsersCount",
+        "activeUsers",
+    ]
+    writer = csv.DictWriter(fh, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in repo_rows:
+        serializable = dict(row)
+        serializable["activeUsers"] = ";".join(row["activeUsers"])
+        writer.writerow({key: serializable.get(key, "") for key in fieldnames})
+
+with open(os.path.join(REPORTS_DIR, "organization_user_activity.md"), "w", encoding="utf-8") as fh:
+    fh.write(render_markdown(report))

--- a/.github/workflows/user-activity-report-exact-range.yml
+++ b/.github/workflows/user-activity-report-exact-range.yml
@@ -38,133 +38,6 @@ jobs:
           GH_TOKEN: ${{ secrets.ORG_ACTIVITY_REPORT_TOKEN }}
         run: python3 .github/scripts/generate_org_user_activity.py
 
-      - name: Build markdown report
-        run: |
-          python3 <<'PY'
-          import json
-          import os
-
-          since = os.environ["REPORT_SINCE"][:10]
-          until = os.environ["REPORT_UNTIL"][:10]
-          org = os.environ["TARGET_ORGANIZATION"]
-
-          with open("reports/organization_user_activity.json", "r", encoding="utf-8") as fh:
-              rows = json.load(fh)
-
-          total_commits = sum(item["commits"] for item in rows)
-          total_issues = sum(item["issues"] for item in rows)
-          total_issue_comments = sum(item["issueComments"] for item in rows)
-          total_pr_comments = sum(item["prComments"] for item in rows)
-          active = [item for item in rows if item["isActive"]]
-          inactive = [item for item in rows if not item["isActive"]]
-
-          bot_names = {"github-actions[bot]", "sonarqubecloud[bot]", "Copilot"}
-          humans = [item for item in rows if item["login"] not in bot_names]
-          active_humans = [item for item in humans if item["isActive"]]
-          bots = [item for item in rows if item["login"] in bot_names]
-
-          def top_by(key):
-              candidates = [item for item in rows if item[key] > 0]
-              return max(candidates, key=lambda item: item[key]) if candidates else None
-
-          def yes_no(value):
-              return "Yes" if value else "No"
-
-          lines = []
-          lines.append("# Organization User Activity Report")
-          lines.append("")
-          lines.append("## Overview")
-          lines.append("")
-          lines.append(f"This report summarizes GitHub organization activity for **{org}** ")
-          lines.append(f"for the exact reporting period **{since} to {until}**.")
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Report Metadata")
-          lines.append("")
-          lines.append("| Field | Value |")
-          lines.append("| --- | --- |")
-          lines.append(f"| Organization | `{org}` |")
-          lines.append("| Activity window | Exact fixed range |")
-          lines.append(f"| Date span | `{since}` to `{until}` |")
-          lines.append("| Source workflow | `Organization User Activity Report (Exact Range)` |")
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Executive Summary")
-          lines.append("")
-          lines.append(f"- Active actors: **{len(active)}**")
-          lines.append(f"- Inactive listed actors: **{len(inactive)}**")
-          lines.append(f"- Active human contributors: **{len(active_humans)}**")
-          lines.append("")
-          lines.append("| Metric | Total |")
-          lines.append("| --- | ---: |")
-          lines.append(f"| Commits | {total_commits} |")
-          lines.append(f"| Issues | {total_issues} |")
-          lines.append(f"| Issue comments | {total_issue_comments} |")
-          lines.append(f"| Pull request comments | {total_pr_comments} |")
-          lines.append("")
-
-          top_commits = top_by("commits")
-          top_issues = top_by("issues")
-          top_issue_comments = top_by("issueComments")
-          top_pr_comments = top_by("prComments")
-          lines.append("### Highlights")
-          lines.append("")
-          if top_commits:
-              lines.append(f"- Most commits: `{top_commits['login']}` with **{top_commits['commits']}**")
-          if top_issues:
-              lines.append(f"- Most issues: `{top_issues['login']}` with **{top_issues['issues']}**")
-          if top_issue_comments:
-              lines.append(f"- Most issue comments: `{top_issue_comments['login']}` with **{top_issue_comments['issueComments']}**")
-          if top_pr_comments:
-              lines.append(f"- Most PR comments: `{top_pr_comments['login']}` with **{top_pr_comments['prComments']}**")
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Full Activity Table")
-          lines.append("")
-          lines.append("| User / Actor | Active | Commits | Issues | Issue Comments | PR Comments |")
-          lines.append("| --- | :---: | ---: | ---: | ---: | ---: |")
-          for item in rows:
-              lines.append(
-                  f"| `{item['login']}` | {yes_no(item['isActive'])} | {item['commits']} | {item['issues']} | {item['issueComments']} | {item['prComments']} |"
-              )
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Human Contributor Activity")
-          lines.append("")
-          lines.append("| User | Active | Commits | Issues | Issue Comments | PR Comments |")
-          lines.append("| --- | :---: | ---: | ---: | ---: | ---: |")
-          for item in humans:
-              lines.append(
-                  f"| `{item['login']}` | {yes_no(item['isActive'])} | {item['commits']} | {item['issues']} | {item['issueComments']} | {item['prComments']} |"
-              )
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Automated / Tool Activity")
-          lines.append("")
-          lines.append("| Actor | Active | Commits | Issues | Issue Comments | PR Comments |")
-          lines.append("| --- | :---: | ---: | ---: | ---: | ---: |")
-          for item in bots:
-              lines.append(
-                  f"| `{item['login']}` | {yes_no(item['isActive'])} | {item['commits']} | {item['issues']} | {item['issueComments']} | {item['prComments']} |"
-              )
-          lines.append("")
-          lines.append("---")
-          lines.append("")
-          lines.append("## Raw JSON Output")
-          lines.append("")
-          lines.append("```json")
-          lines.append(json.dumps(rows, indent=2))
-          lines.append("```")
-
-          with open("reports/report_md.md", "w", encoding="utf-8") as fh:
-              fh.write("\n".join(lines) + "\n")
-          PY
-
       - name: Publish report summary
         if: always()
         run: |
@@ -175,8 +48,8 @@ jobs:
             echo "- Date span: ${REPORT_SINCE:0:10} to ${REPORT_UNTIL:0:10}"
             echo "- Data source: direct GitHub organization and repository API queries"
             echo
-            if [ -f reports/report_md.md ]; then
-              head -n 80 reports/report_md.md
+            if [ -f reports/organization_user_activity.md ]; then
+              head -n 120 reports/organization_user_activity.md
             else
               echo "No markdown report was generated."
             fi
@@ -191,4 +64,5 @@ jobs:
           path: |
             reports/organization_user_activity.csv
             reports/organization_user_activity.json
-            reports/report_md.md
+            reports/organization_repository_activity.csv
+            reports/organization_user_activity.md

--- a/.github/workflows/user-activity-report-monthly.yml
+++ b/.github/workflows/user-activity-report-monthly.yml
@@ -1,11 +1,7 @@
 name: Organization User Activity Report (Monthly)
 
 on:
-  # Manual trigger is useful for regenerating a monthly report on demand.
   workflow_dispatch:
-  # Run automatically on the 21st day of every month at 07:00 UTC. This
-  # matches the requested cadence starting from May 21 and then repeating on
-  # June 21, July 21, and so on.
   schedule:
     - cron: "0 7 21 * *"
 
@@ -17,8 +13,6 @@ permissions:
   contents: read
 
 env:
-  # This repository lives inside the target organization, so the repository
-  # owner is the correct organization name for the action input.
   TARGET_ORGANIZATION: ${{ github.repository_owner }}
 
 jobs:
@@ -31,25 +25,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Analyze organization user activity
-        id: analyze_user_activity
-        uses: peter-murray/inactive-users-action@v1
-        with:
-          # Personal access token stored as a GitHub secret. It must belong to a
-          # user who can read the organization and all repositories to analyze.
-          token: ${{ secrets.ORG_ACTIVITY_REPORT_TOKEN }}
-          # Use the current repository owner so the workflow stays portable
-          # across repositories inside the same GitHub organization.
-          organization: ${{ env.TARGET_ORGANIZATION }}
-          # Monthly report: include the last 30 days of activity leading into
-          # the scheduled run on the 21st of the month.
-          activity_days: 30
-          # The marketplace action does not expose per-metric feature flags.
-          # It always generates its full built-in activity dataset, so the
-          # only meaningful reporting knobs are time window, output location,
-          # and API retry behavior.
-          octokit_max_retries: 15
-          outputDir: reports
+      - name: Resolve monthly reporting window
+        run: |
+          set -euo pipefail
+          REPORT_UNTIL="$(date -u +%Y-%m-%d)T00:00:00Z"
+          REPORT_SINCE="$(date -u -d '30 days ago' +%Y-%m-%d)T00:00:00Z"
+          {
+            echo "REPORT_SINCE=$REPORT_SINCE"
+            echo "REPORT_UNTIL=$REPORT_UNTIL"
+          } >> "$GITHUB_ENV"
+
+      - name: Generate monthly organization activity report
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ACTIVITY_REPORT_TOKEN }}
+        run: python3 .github/scripts/generate_org_user_activity.py
 
       - name: Publish report summary
         if: always()
@@ -58,24 +47,13 @@ jobs:
             echo "## Monthly Organization User Activity Report"
             echo
             echo "- Organization: $TARGET_ORGANIZATION"
-            echo "- Activity window: last 30 days"
-            echo "- Action metrics: full built-in activity dataset"
-            echo "- Octokit max retries: 15"
+            echo "- Date span: ${REPORT_SINCE:0:10} to ${REPORT_UNTIL:0:10}"
+            echo "- Data source: direct GitHub organization and repository API queries"
             echo
-            if [ -f "${{ steps.analyze_user_activity.outputs.report_csv }}" ]; then
-              echo "CSV report generated successfully."
-              echo
-              echo '```text'
-              head -n 20 "${{ steps.analyze_user_activity.outputs.report_csv }}"
-              echo '```'
+            if [ -f reports/organization_user_activity.md ]; then
+              head -n 120 reports/organization_user_activity.md
             else
-              echo "No CSV report was generated."
-            fi
-            echo
-            if [ -f "${{ steps.analyze_user_activity.outputs.report_json }}" ]; then
-              echo "JSON report generated successfully."
-            else
-              echo "No JSON report was generated."
+              echo "No markdown report was generated."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -86,5 +64,7 @@ jobs:
           name: organization-user-activity-report-monthly
           retention-days: 14
           path: |
-            ${{ steps.analyze_user_activity.outputs.report_csv }}
-            ${{ steps.analyze_user_activity.outputs.report_json }}
+            reports/organization_user_activity.csv
+            reports/organization_user_activity.json
+            reports/organization_repository_activity.csv
+            reports/organization_user_activity.md

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -45,8 +45,8 @@ jobs:
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
-            REPORT_SINCE="2026-05-28T00:00:00Z"
-            REPORT_UNTIL="2026-06-04T00:00:00Z"
+            REPORT_SINCE="2026-05-21T00:00:00Z"
+            REPORT_UNTIL="2026-05-28T00:00:00Z"
           elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"
             REPORT_UNTIL="${INPUT_REPORT_UNTIL}T00:00:00Z"

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -1,6 +1,9 @@
 name: Organization User Activity Report (Weekly)
 
 on:
+  push:
+    branches:
+      - "ci(workflow)(activity)/improve-activity-reporting"
   workflow_dispatch:
     inputs:
       report_since:
@@ -34,12 +37,17 @@ jobs:
 
       - name: Resolve weekly reporting window
         env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
           INPUT_REPORT_SINCE: ${{ inputs.report_since }}
           INPUT_REPORT_UNTIL: ${{ inputs.report_until }}
         run: |
           set -euo pipefail
 
-          if [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
+            REPORT_SINCE="2026-06-04T00:00:00Z"
+            REPORT_UNTIL="2026-06-11T00:00:00Z"
+          elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"
             REPORT_UNTIL="${INPUT_REPORT_UNTIL}T00:00:00Z"
           else

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -45,8 +45,8 @@ jobs:
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
-            REPORT_SINCE="2026-05-21T00:00:00Z"
-            REPORT_UNTIL="2026-05-28T00:00:00Z"
+            REPORT_SINCE="2026-04-23T00:00:00Z"
+            REPORT_UNTIL="2026-05-21T00:00:00Z"
           elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"
             REPORT_UNTIL="${INPUT_REPORT_UNTIL}T00:00:00Z"

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -67,20 +67,10 @@ jobs:
             echo "- Date span: ${REPORT_SINCE:0:10} to ${REPORT_UNTIL:0:10}"
             echo "- Data source: direct GitHub organization and repository API queries"
             echo
-            if [ -f reports/organization_user_activity.csv ]; then
-              echo "CSV report generated successfully."
-              echo
-              echo '```text'
-              head -n 20 reports/organization_user_activity.csv
-              echo '```'
+            if [ -f reports/organization_user_activity.md ]; then
+              head -n 120 reports/organization_user_activity.md
             else
-              echo "No CSV report was generated."
-            fi
-            echo
-            if [ -f reports/organization_user_activity.json ]; then
-              echo "JSON report generated successfully."
-            else
-              echo "No JSON report was generated."
+              echo "No markdown report was generated."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -93,3 +83,5 @@ jobs:
           path: |
             reports/organization_user_activity.csv
             reports/organization_user_activity.json
+            reports/organization_repository_activity.csv
+            reports/organization_user_activity.md

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -45,8 +45,8 @@ jobs:
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
-            REPORT_SINCE="2026-04-23T00:00:00Z"
-            REPORT_UNTIL="2026-05-21T00:00:00Z"
+            REPORT_SINCE="2026-06-11T00:00:00Z"
+            REPORT_UNTIL="2026-06-18T00:00:00Z"
           elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"
             REPORT_UNTIL="${INPUT_REPORT_UNTIL}T00:00:00Z"

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -45,7 +45,7 @@ jobs:
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
-            REPORT_SINCE="2026-06-11T00:00:00Z"
+            REPORT_SINCE="2026-05-21T00:00:00Z"
             REPORT_UNTIL="2026-06-18T00:00:00Z"
           elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"

--- a/.github/workflows/user-activity-report-weekly.yml
+++ b/.github/workflows/user-activity-report-weekly.yml
@@ -45,8 +45,8 @@ jobs:
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" = "ci(workflow)(activity)/improve-activity-reporting" ]; then
-            REPORT_SINCE="2026-06-04T00:00:00Z"
-            REPORT_UNTIL="2026-06-11T00:00:00Z"
+            REPORT_SINCE="2026-05-28T00:00:00Z"
+            REPORT_UNTIL="2026-06-04T00:00:00Z"
           elif [ -n "${INPUT_REPORT_SINCE:-}" ] && [ -n "${INPUT_REPORT_UNTIL:-}" ]; then
             REPORT_SINCE="${INPUT_REPORT_SINCE}T00:00:00Z"
             REPORT_UNTIL="${INPUT_REPORT_UNTIL}T00:00:00Z"


### PR DESCRIPTION
# PR Summary: Expanded Organization Activity Reporting

![Status](https://img.shields.io/badge/PR-Implementation-0f172a) ![Scope](https://img.shields.io/badge/Scope-CI-111827) ![Domain](https://img.shields.io/badge/Domain-Activity%20Reporting-1f2937)
![Feature](https://img.shields.io/badge/Feature-Richer%20GitHub%20Metrics-374151) ![Affects](https://img.shields.io/badge/Affects-Workflow%20Artifacts-4b5563) ![Affects](https://img.shields.io/badge/Affects-Report%20Schema-334155)

- Closes #896 
- Closes #897 
- Closes #898 
- Closes #899 
- Closes #900 

## Summary

This PR expands the organization activity report workflows from a small flat user list into a much richer reporting pipeline.

Before this change, the generated report only tracked a few coarse metrics:

- commits
- issues
- issue comments
- PR comments

That output was useful as a quick signal, but it left out a large part of the actual organization activity surface. It did not clearly distinguish issue lifecycle from PR lifecycle, did not show review activity, did not show repository-level activity distribution, and did not produce a structured summary that could be read directly from the workflow output.

This PR fixes that by:

- expanding the Python report generator
- standardizing all report workflows on the same generator
- generating richer JSON, CSV, repository CSV, and Markdown artifacts
- publishing a more useful summary directly in the GitHub Actions job summary

## Why This Change Exists

The current report shape is too shallow for real analysis.

For example, this old row:

```json
{
  "login": "kingjulien1",
  "email": "",
  "isActive": true,
  "commits": 45,
  "issues": 71,
  "issueComments": 1,
  "prComments": 20
}
```

does not answer several important questions:

- Were the issues opened or closed?
- Were the PR interactions review comments or top-level conversation comments?
- How many PRs were merged?
- Who is actively reviewing code versus only opening PRs?
- Which repositories saw the most activity?
- Which users touched the largest number of repositories?
- Are bots responsible for a meaningful share of visible activity?

This PR makes the reporting output much more complete and much easier to interpret.

## Main Changes

### 1. The JSON output is now a real report object

Instead of emitting a plain array of user rows, the generator now emits a structured report object.

Example shape:

```json
{
  "organization": "SE2-Gruppenprojekt",
  "generatedAt": "2026-06-13T15:12:00Z",
  "reportSince": "2026-06-06T00:00:00Z",
  "reportUntil": "2026-06-13T00:00:00Z",
  "windowDays": 7,
  "summary": {
    "memberCount": 8,
    "repositoryCount": 4,
    "activeActors": 6,
    "activeHumans": 4,
    "activeBots": 2,
    "inactiveListedMembers": 2,
    "totals": {
      "commits": 71,
      "issuesOpened": 13,
      "issuesClosed": 8,
      "prsOpened": 10,
      "prsMerged": 7,
      "prReviews": 19,
      "totalEvents": 162
    },
    "leaders": {
      "commits": { "login": "alice", "commits": 24 },
      "prsMerged": { "login": "bob", "prsMerged": 4 }
    }
  },
  "users": [],
  "repositories": []
}
```

This gives downstream users a stable top-level structure:

- metadata
- summary
- per-user detail
- per-repository detail

### 2. User activity is much more detailed

The generator now collects and stores these metrics per actor:

```text
commits
issuesOpened
issuesClosed
issueComments
prConversationComments
prsOpened
prsMerged
prsClosedUnmerged
prReviewComments
prReviews
prApprovals
prChangeRequests
prReviewDismissals
totalEvents
repositoriesTouchedCount
activityDays
firstActivityAt
lastActivityAt
```

This makes the report much better at distinguishing different contributor roles.

Examples:

- a user opening many PRs but doing no reviews
- a user mainly contributing through code review
- a bot writing comments but not committing code
- a maintainer closing issues and merging PRs

### 3. Repository-level reporting was added

The old report only showed activity by user.

This PR also creates repository-level aggregation so you can see which repositories had the most activity and what kind of activity happened there.

Example repository row:

```csv
repo,totalEvents,commits,issuesOpened,prsOpened,prsMerged,prReviews,activeUsersCount
se2-group-codebase,84,31,6,8,5,13,5
```

This helps answer:

- which repositories are most active
- where review activity is concentrated
- where issue activity is concentrated
- how many users touched each repository

### 4. PR lifecycle and review activity are now tracked explicitly

This is one of the biggest improvements in the PR.

The generator now scans:

- PR list endpoints
- PR review comment endpoints
- PR review submission endpoints

That allows the report to distinguish:

- PRs opened
- PRs merged
- PRs closed without merge
- inline review comments
- review submissions
- approvals
- change requests
- review dismissals

Example of the new logic:

```python
state_metric = REVIEW_STATE_TO_METRIC.get((review.get("state") or "").upper())
if state_metric:
    record_metric(login, repo_name, state_metric, when=submitted_at)
```

This is important because review activity is often one of the most meaningful collaboration signals in a repository.

### 5. Issue comments and PR conversation comments are now separated

Previously, the output was too coarse. A comment on an issue and a top-level comment on a pull request were not clearly separated in a way that made analysis reliable.

This PR now distinguishes:

- `issueComments`
- `prConversationComments`
- `prReviewComments`

That means three different categories:

1. comments on normal issues
2. top-level conversation comments on PRs
3. inline review comments on PR diffs

This makes the resulting activity picture much more accurate.

### 6. The workflows now all use the same reporting engine

Before this PR:

- weekly used the custom Python script
- monthly used a third-party action
- exact-range used the custom Python script plus its own extra Markdown builder

That meant the three workflows did not really behave the same way and did not produce the same report structure.

This PR removes that inconsistency.

Now:

- weekly
- monthly
- exact-range

all use the same generator:

```text
.github/scripts/generate_org_user_activity.py
```

This is cleaner because:

- one source of truth
- one schema
- one report style
- one place to extend metrics later

### 7. The monthly workflow no longer depends on the external action

The monthly workflow previously used:

```text
peter-murray/inactive-users-action@v1
```

This PR replaces that with the repository’s own direct GitHub API generator.

That improves control over:

- which metrics are collected
- output structure
- report consistency
- future maintainability

It also means monthly reports now match weekly and exact-range reports instead of following a separate reporting model.

## New Artifacts

The workflows now upload four main report artifacts:

```text
reports/organization_user_activity.json
reports/organization_user_activity.csv
reports/organization_repository_activity.csv
reports/organization_user_activity.md
```

### Artifact purposes

`organization_user_activity.json`
- structured machine-readable report

`organization_user_activity.csv`
- flat user-level spreadsheet export

`organization_repository_activity.csv`
- flat repository-level spreadsheet export

`organization_user_activity.md`
- readable human-oriented summary report

## Workflow Summary Improvements

The workflows now show the generated Markdown report directly in the GitHub Actions step summary instead of just printing the first lines of a CSV file.

Previous style:

```text
login,email,isActive,commits,issues,issueComments,prComments
alice,,True,12,4,0,3
```

New style:

```md
## Executive Summary

- Repositories scanned: **4**
- Organization members discovered: **8**
- Active actors: **6**
- Total tracked events: **162**
```

This is much easier to review directly inside the Actions UI.

## Implementation Notes

### Report window metadata

The generator now stores exact report metadata:

```python
report = {
    "organization": ORG,
    "generatedAt": GENERATED_AT,
    "reportSince": SINCE,
    "reportUntil": UNTIL,
    "windowDays": (END - START).days,
    ...
}
```

That makes each generated artifact self-describing.

### Actor classification

Actors are now classified as bots or humans:

```python
def classify_bot(login: str) -> bool:
    lower = login.lower()
    return login.endswith("[bot]") or lower.startswith("github-actions") or lower.endswith("bot")
```

That allows the report to separate:

- active humans
- active bots

which is useful because automation activity can otherwise distort the interpretation of real contributor activity.

### Repository-touch tracking

Every time a user produces a tracked event in a repository, that repository is added to the user’s touched-repository set.

Example:

```python
entry["repositoriesTouched"].add(repo_name)
entry["repositoriesTouchedCount"] = len(entry["repositoriesTouched"])
```

This makes it easy to see whether a contributor is:

- active in only one repository
- or working across a broader part of the organization

### Activity timestamps

The generator now stores:

- `firstActivityAt`
- `lastActivityAt`
- `activityDays`

This helps understand not only volume, but also how activity is distributed across the reporting window.

## Important Output Contract Change

One important change in this PR is that the JSON file is no longer a plain list.

Old shape:

```json
[
  { "login": "alice", "commits": 12 }
]
```

New shape:

```json
{
  "summary": { ... },
  "users": [ ... ],
  "repositories": [ ... ]
}
```

That is the correct long-term shape, but it means any downstream consumer that expects the old array-only JSON contract must be updated.

## Files Changed

Core generator:

- [generate_org_user_activity.py](/Users/julianblaschke/Desktop/se2-group-codebase/.github/scripts/generate_org_user_activity.py)

Workflows:

- [user-activity-report-weekly.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/user-activity-report-weekly.yml)
- [user-activity-report-monthly.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/user-activity-report-monthly.yml)
- [user-activity-report-exact-range.yml](/Users/julianblaschke/Desktop/se2-group-codebase/.github/workflows/user-activity-report-exact-range.yml)

## Expected Outcome

After this PR:

- weekly, monthly, and exact-range activity reports all behave consistently
- activity reports provide much more useful contributor insight
- the Actions UI summary is directly readable
- repository-level trends become visible
- PR lifecycle and review work become first-class metrics
- downstream tooling has a more structured machine-readable JSON contract

## Suggested Validation

1. Run the weekly workflow manually.
2. Download all generated artifacts.
3. Check that:
   - `organization_user_activity.json` contains `summary`, `users`, and `repositories`
   - `organization_user_activity.csv` contains the expanded user columns
   - `organization_repository_activity.csv` is present
   - `organization_user_activity.md` renders correctly
4. Run the monthly workflow manually and confirm the artifact schema matches weekly.
5. Run the exact-range workflow for a short date span and confirm the same schema and summary layout are produced.

## Suggested Commit Message

```text
docs(ci): add detailed pr description for expanded organization activity reporting
```
