### PR TITLE
feat(backend,shared)(gameplay): add starting tile configuration option and fix pass-turn auto-draw handling

### DIFF
--- a/apps/android/app/src/main/java/at/aau/serg/android/core/network/mapper/LobbyNetworkMapper.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/core/network/mapper/LobbyNetworkMapper.kt
@@ -19,7 +19,9 @@ fun LobbyResponse.toDomain(): Lobby =
         settings = LobbySettings(
             maxPlayers = maxPlayers,
             isPrivate = isPrivate,
-            allowGuests = allowGuests
+            allowGuests = allowGuests,
+            requireInitialMeld = requireInitialMeld,
+            startingTiles = startingTiles
         ),
         currentGameId = currentGameId
     )

--- a/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateViewModel.kt
+++ b/apps/android/app/src/main/java/at/aau/serg/android/ui/screens/lobby/create/LobbyCreateViewModel.kt
@@ -44,7 +44,9 @@ class LobbyCreateViewModel(
                     displayName = user.displayName,
                     maxPlayers = state.maxPlayers,
                     isPrivate = state.isPrivate,
-                    allowGuests = true
+                    allowGuests = true,
+                    requireInitialMeld = state.requireInitialMeld,
+                    startingTiles = state.startingTiles
                 )
             )
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/CreateLobbyRequest.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/CreateLobbyRequest.kt
@@ -13,6 +13,9 @@ val maxPlayers: Int = 4,
 
 val isPrivate: Boolean = false,
 val allowGuests: Boolean = true,
-val requireInitialMeld: Boolean = true
+val requireInitialMeld: Boolean = true,
+
+@field:Min(1, message = "startingTiles must be at least 1")
+val startingTiles: Int = 14
 
 )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyResponse.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/dto/LobbyResponse.kt
@@ -9,5 +9,6 @@ data class LobbyResponse(
     val isPrivate: Boolean,
     val allowGuests: Boolean,
     val requireInitialMeld: Boolean = true,
+    val startingTiles: Int = 14,
     val currentGameId: String? = null
 )

--- a/apps/backend/src/main/kotlin/at/se2group/backend/mapper/LobbyMapper.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/mapper/LobbyMapper.kt
@@ -26,7 +26,8 @@ fun LobbyEntity.toDomain(): Lobby =
             maxPlayers = maxPlayers,
             isPrivate = isPrivate,
             allowGuests = allowGuests,
-            requireInitialMeld = requireInitialMeld
+            requireInitialMeld = requireInitialMeld,
+            startingTiles = startingTiles
         ),
         currentGameId = null
     )
@@ -39,6 +40,8 @@ fun Lobby.toEntity(existing: LobbyEntity? = null): LobbyEntity =
         maxPlayers = settings.maxPlayers,
         isPrivate = settings.isPrivate,
         allowGuests = settings.allowGuests,
+        requireInitialMeld = settings.requireInitialMeld,
+        startingTiles = settings.startingTiles,
         createdAt = existing?.createdAt ?: Instant.now(),
         players = players.map {
             val existingPlayer = existing?.players?.firstOrNull { persisted -> persisted.userId == it.userId }
@@ -70,6 +73,7 @@ fun Lobby.toResponse(currentGameId: String? = this.currentGameId): LobbyResponse
         isPrivate = settings.isPrivate,
         allowGuests = settings.allowGuests,
         requireInitialMeld = settings.requireInitialMeld,
+        startingTiles = settings.startingTiles,
         currentGameId = currentGameId,
         players = players.map {
             LobbyPlayerResponse(

--- a/apps/backend/src/main/kotlin/at/se2group/backend/persistence/LobbyEntity.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/persistence/LobbyEntity.kt
@@ -35,6 +35,9 @@ class LobbyEntity(
     @Column(name = "allow_guests", nullable = false)
     var allowGuests: Boolean = true,
 
+    @Column(name = "starting_tiles", nullable = false)
+    var startingTiles: Int = 14,
+
     @Column(name = "created_at", nullable = false)
     var createdAt: Instant = Instant.now(),
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -143,6 +143,7 @@ class EndTurnService(
         confirmedGame: ConfirmedGame,
         draft: TurnDraft
     ): ConfirmedGame {
+        val drawnTile = draft.drawnTile
         val updatedPlayers = confirmedGame.players.map { player ->
             if (player.userId == draft.playerUserId) {
                 player.copy(rackTiles = draft.rackTiles)
@@ -154,8 +155,8 @@ class EndTurnService(
         return confirmedGame.copy(
             players = updatedPlayers,
             boardSets = draft.boardSets,
-            drawPile = if (draft.drawnTile != null) {
-                confirmedGame.drawPile.filterNot { it.tileId == draft.drawnTile.tileId }
+            drawPile = if (drawnTile != null) {
+                confirmedGame.drawPile.filterNot { it.tileId == drawnTile.tileId }
             } else {
                 confirmedGame.drawPile
             }

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/EndTurnService.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import shared.models.game.domain.ConfirmedGame
 import shared.models.game.domain.GameStatus
+import shared.models.game.domain.Tile
 import shared.models.game.domain.TurnDraft
 import shared.models.game.request.EndTurnRequest
 import java.time.Instant
@@ -63,6 +64,7 @@ class EndTurnService(
         check(game.currentPlayerUserId == userId) { NOT_CURRENT_PLAYER }
         check(draftEntity.playerUserId == userId) { NOT_DRAFT_OWNER }
 
+        val persistedDraft = draftEntity.toDomain()
         val submittedDraft = request.toDomain(gameId, userId)
 
         val validation = rummikubRuleService.validateSubmittedDraft(
@@ -75,7 +77,13 @@ class EndTurnService(
             throw InvalidTurnSubmissionException(validation)
         }
 
-        val committedGame = commitDraftToConfirmedGame(game, submittedDraft)
+        val finalizedDraft = maybeAutoDrawTile(
+            confirmedGame = game,
+            persistedDraft = persistedDraft,
+            submittedDraft = submittedDraft
+        )
+
+        val committedGame = commitDraftToConfirmedGame(game, finalizedDraft)
             .applyInitialMeldCompletion(userId)
 
         // Turn metrics are recorded before potential game finalization so the
@@ -145,8 +153,43 @@ class EndTurnService(
 
         return confirmedGame.copy(
             players = updatedPlayers,
-            boardSets = draft.boardSets
+            boardSets = draft.boardSets,
+            drawPile = if (draft.drawnTile != null) {
+                confirmedGame.drawPile.filterNot { it.tileId == draft.drawnTile.tileId }
+            } else {
+                confirmedGame.drawPile
+            }
         )
+    }
+
+    private fun maybeAutoDrawTile(
+        confirmedGame: ConfirmedGame,
+        persistedDraft: TurnDraft,
+        submittedDraft: TurnDraft
+    ): TurnDraft {
+        if (persistedDraft.drawnTile != null) {
+            return submittedDraft
+        }
+
+        if (!isPassTurnWithoutDraw(confirmedGame, submittedDraft)) {
+            return submittedDraft
+        }
+
+        val topTile = confirmedGame.drawPile.firstOrNull() ?: return submittedDraft
+
+        return submittedDraft.copy(
+            rackTiles = submittedDraft.rackTiles + topTile,
+            drawnTile = topTile
+        )
+    }
+
+    private fun isPassTurnWithoutDraw(
+        confirmedGame: ConfirmedGame,
+        submittedDraft: TurnDraft
+    ): Boolean {
+        val actingPlayer = confirmedGame.players.first { it.userId == submittedDraft.playerUserId }
+        return submittedDraft.boardSets == confirmedGame.boardSets &&
+            submittedDraft.rackTiles == actingPlayer.rackTiles
     }
 
     /**

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/GameInitializationService.kt
@@ -57,7 +57,8 @@ class GameInitializationService(
         val shuffledTiles = tileShuffleService.shuffleTiles(tilePoolGenerationService.createTilePool())
         val playersWithHands = tileShuffleService.distributedHands(
             lobby.toGamePlayers(),
-            shuffledTiles
+            shuffledTiles,
+            lobby.settings.startingTiles
         )
         val firstPlayer = playersWithHands.firstByTurnOrder()
         val confirmedGame = ConfirmedGame(

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/LobbyService.kt
@@ -122,7 +122,8 @@ class LobbyService(
                 maxPlayers = request.maxPlayers,
                 isPrivate = request.isPrivate,
                 allowGuests = request.allowGuests,
-                requireInitialMeld = request.requireInitialMeld
+                requireInitialMeld = request.requireInitialMeld,
+                startingTiles = request.startingTiles
             )
         )
 

--- a/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
+++ b/apps/backend/src/main/kotlin/at/se2group/backend/service/TileShuffleService.kt
@@ -24,13 +24,6 @@ class TileShuffleService {
     /**
      * Internal constants used by [TileShuffleService].
      */
-    companion object {
-        /**
-         * Number of tiles each player receives at the start of a game.
-         */
-        private const val HAND_SIZE = 14
-    }
-
     /**
      * Returns a shuffled copy of the provided tile list.
      *
@@ -49,7 +42,7 @@ class TileShuffleService {
      * Distributes starting hands to all provided players.
      *
      * Tiles are assigned in order from the provided tile list. Each player
-     * receives exactly [HAND_SIZE] consecutive tiles, and the returned player
+     * receives exactly [handSize] consecutive tiles, and the returned player
      * list preserves the original player order.
      *
      * This method does not shuffle tiles itself, so callers are expected to pass
@@ -60,21 +53,26 @@ class TileShuffleService {
      * @return a new player list where each player contains their assigned rack
      * tiles.
      * @throws IllegalArgumentException if there are not enough tiles available to
-     * distribute [HAND_SIZE] tiles to every player.
+     * distribute [handSize] tiles to every player.
      */
     fun distributedHands(
         players: List<GamePlayer>,
-        tiles: List<Tile>
+        tiles: List<Tile>,
+        handSize: Int
     ): List<GamePlayer> {
-        val requiredTiles = players.size * HAND_SIZE
+        require(handSize > 0) {
+            "handSize must be greater than 0"
+        }
+
+        val requiredTiles = players.size * handSize
         // Fail early if the provided tile pool cannot cover all starting hands.
         require(tiles.size >= requiredTiles) {
-            "Not enough tiles to distribute $HAND_SIZE tiles to ${players.size} players"
+            "Not enough tiles to distribute $handSize tiles to ${players.size} players"
         }
 
         return players.mapIndexed { index, player ->
-            val handStart = index * HAND_SIZE
-            player.copy(rackTiles = tiles.subList(handStart, handStart + HAND_SIZE))
+            val handStart = index * handSize
+            player.copy(rackTiles = tiles.subList(handStart, handStart + handSize))
         }
     }
 

--- a/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/game/service/EndTurnServiceTest.kt
@@ -203,6 +203,43 @@ class EndTurnServiceTest {
     }
 
     @Test
+    fun `auto draws tile on pass turn when player has not drawn yet`() {
+        val game = gameEntity(
+            user1Rack = mutableListOf(tile("old-rack-tile")),
+            user2Rack = mutableListOf(tile("user-2-rack")),
+            drawPile = mutableListOf(tile("draw-top"), tile("draw-next"))
+        )
+
+        whenever(gameRepository.findById("game-1"))
+            .thenReturn(Optional.of(game))
+
+        whenever(turnDraftRepository.findByGameId("game-1"))
+            .thenReturn(draftEntity())
+
+        whenever(rummikubRuleService.validateSubmittedDraft(any(), any(), any()))
+            .thenReturn(valid())
+
+        whenever(gameRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        whenever(turnDraftRepository.save(any()))
+            .thenAnswer { it.arguments[0] }
+
+        val result = endTurnService.endTurn(
+            gameId = "game-1",
+            userId = "user-1",
+            request = EndTurnRequest(
+                boardSets = emptyList(),
+                rackTiles = listOf(TileRequest("old-rack-tile", "RED", 5, false))
+            )
+        )
+
+        val actingPlayer = result.players.first { it.userId == "user-1" }
+        assertEquals(listOf("old-rack-tile", "draw-top"), actingPlayer.rackTiles.map { it.tileId })
+        assertEquals(listOf("draw-next"), result.drawPile.map { it.tileId })
+    }
+
+    @Test
     fun `commits valid joker containing submitted draft`() {
         val realRuleService = RummikubRuleService(
             TileConservationService(),
@@ -453,6 +490,7 @@ class EndTurnServiceTest {
         status: GameStatus = GameStatus.ACTIVE,
         user1Rack: MutableList<TileEmbeddable> = mutableListOf(),
         user2Rack: MutableList<TileEmbeddable> = mutableListOf(),
+        drawPile: MutableList<TileEmbeddable> = mutableListOf(),
         hasCompletedInitialMeld: Boolean = false
     ): GameEntity {
         val game = GameEntity(
@@ -460,7 +498,8 @@ class EndTurnServiceTest {
             lobbyId = "lobby-1",
             currentPlayerUserId = currentPlayerUserId,
             status = status,
-            createdAt = Instant.parse("2026-04-27T18:00:00Z")
+            createdAt = Instant.parse("2026-04-27T18:00:00Z"),
+            drawPile = drawPile
         )
 
         game.players = mutableListOf(

--- a/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
+++ b/apps/backend/src/test/kotlin/at/se2group/backend/lobby/service/TileShuffleServiceTest.kt
@@ -25,14 +25,14 @@ class TileShuffleServiceTest {
     }
 
     @Test
-    fun `distributedHands gives each player 14 tiles in order`() {
+    fun `distributedHands gives each player requested tiles in order`() {
         val players = listOf(
             GamePlayer(userId = "user-1", displayName = "Alice", turnOrder = 0),
             GamePlayer(userId = "user-2", displayName = "Bob", turnOrder = 1)
         )
         val tiles = createNumberedTiles(1, 28)
 
-        val result = tileShuffleService.distributedHands(players, tiles)
+        val result = tileShuffleService.distributedHands(players, tiles, 14)
 
         assertEquals(2, result.size)
         assertIterableEquals(tiles.subList(0, 14), result[0].rackTiles)
@@ -50,7 +50,7 @@ class TileShuffleServiceTest {
         val tiles = createNumberedTiles(1, 27)
 
         val exception = assertThrows<IllegalArgumentException> {
-            tileShuffleService.distributedHands(players, tiles)
+            tileShuffleService.distributedHands(players, tiles, 14)
         }
 
         assertEquals("Not enough tiles to distribute 14 tiles to 2 players", exception.message)

--- a/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbySettings.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/domain/LobbySettings.kt
@@ -4,5 +4,6 @@ data class LobbySettings(
     val maxPlayers: Int = 4,
     val isPrivate: Boolean = false,
     val allowGuests: Boolean = true,
-    val requireInitialMeld: Boolean = true
+    val requireInitialMeld: Boolean = true,
+    val startingTiles: Int = 14
 )

--- a/apps/shared/src/main/kotlin/shared/models/lobby/request/CreateLobbyRequest.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/request/CreateLobbyRequest.kt
@@ -5,5 +5,6 @@ data class CreateLobbyRequest(
     val maxPlayers: Int = 4,
     val isPrivate: Boolean = false,
     val allowGuests: Boolean = true,
-    val requireInitialMeld: Boolean = true
+    val requireInitialMeld: Boolean = true,
+    val startingTiles: Int = 14
 )

--- a/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyResponse.kt
+++ b/apps/shared/src/main/kotlin/shared/models/lobby/response/LobbyResponse.kt
@@ -9,5 +9,6 @@ data class LobbyResponse(
     val isPrivate: Boolean,
     val allowGuests: Boolean,
     val requireInitialMeld: Boolean = true,
+    val startingTiles: Int = 14,
     val currentGameId: String? = null
 )


### PR DESCRIPTION
# PR Description: Starting Tiles Configuration and End-Turn Auto-Draw Fix

![Scope](https://img.shields.io/badge/Scope-Backend%20%26%20Android-475569) ![Domain](https://img.shields.io/badge/Domain-Lobby%20Setup%20%26%20Turn%20Flow-64748b) ![Gameplay](https://img.shields.io/badge/Gameplay-Rack%20Initialization%20%26%20Pass%20Turns-737373)
![Feature](https://img.shields.io/badge/Feature-Starting%20Tiles%20Config-6b7280) ![Fix](https://img.shields.io/badge/Fix-End%20Turn%20Auto%20Draw-52525b) ![API](https://img.shields.io/badge/API-Create%20Lobby%20Request-71717a) ![Status](https://img.shields.io/badge/PR-Ready%20for%20Review-4b5563)

- Closes #674 
- Closes #231 
- Closes #232 
- Closes #373 

## Summary

This PR combines two closely related gameplay changes:

- it makes the number of starting tiles configurable during lobby creation
- it fixes the backend turn-finalization flow so a player who ends a turn
  without drawing a required tile receives that tile automatically

Together, these changes tighten the setup-to-gameplay contract: lobby settings
now define how many tiles each player starts with, and the backend now enforces
the expected draw behavior when a player passes without having drawn first.

## Why this PR exists

Two issues were present in the current flow:

1. the starting hand size was effectively fixed in backend game initialization
2. a player could end a pass turn without having drawn a tile first, and the
   backend did not always repair that state automatically

That led to two gaps:

- lobby setup could not control the initial rack size
- end-turn handling could produce an invalid gameplay outcome for pass turns

This PR closes both gaps.

## What changed

### 1. Configurable starting tiles

The create-lobby request now includes a `startingTiles` field. That value is
carried through shared models, Android request creation, backend lobby
creation, persistence, lobby responses, and finally game initialization.

The new request shape is:

```json
{
  "hostDisplayName": "Alice",
  "maxPlayers": 4,
  "isPrivate": false,
  "allowGuests": true,
  "requireInitialMeld": false,
  "startingTiles": 14
}
```

The backend then uses that configured value when distributing opening hands
instead of relying on a hardcoded tile count.

Conceptually, the initialization flow changed from:

```text
lobby created -> game starts -> every player receives 14 tiles
```

to:

```text
lobby created with startingTiles -> game starts -> every player receives that configured amount
```

### 2. End-turn pass auto-draw fix

The backend end-turn flow now detects the case where:

- the acting player did not already draw a tile
- the submitted turn is effectively a pass turn
- the draw pile still contains tiles

In that case, the backend automatically draws the next tile and adds it to the
player's rack before committing the confirmed game state.

That means a pass-turn flow now behaves like this:

```text
player submits unchanged board + unchanged rack
-> backend recognizes pass without prior draw
-> backend draws top tile
-> tile is added to the player's rack
-> tile is removed from draw pile
-> turn is committed
```

## Backend impact

### Lobby setup

The backend now:

- accepts `startingTiles` on create-lobby requests
- validates the value with a lower bound
- persists it on the lobby entity
- exposes it again in lobby responses
- uses it when generating initial player hands

This keeps the lobby configuration and the actual started game in sync.

### Turn handling

The backend end-turn flow now repairs pass turns that would otherwise skip the
required draw behavior.

The important behavioral rule is:

```text
if the player passes and has not drawn yet, the backend draws for them automatically
```

That is intentionally narrow. It does not redraw in arbitrary cases. It only
applies to pass-turn handling where the submitted draft leaves the board and the
acting player's rack effectively unchanged before the automatic draw.

## Android / shared impact

The Android create-lobby flow now sends `startingTiles` explicitly instead of
depending on backend-only defaults.

Shared request and response models were updated so both sides agree on the
contract.

That means:

- Android can choose the configured starting hand size
- backend receives and stores it
- lobby responses expose the configured value consistently

## Validation and safety

This PR is low-risk in shape but important in behavior:

- the starting-tile change extends an existing request/response contract in a
  straightforward way
- the auto-draw fix is scoped to pass-turn finalization and avoids changing
  unrelated turn-submission behavior

The backend auto-draw logic is also careful to update both:

- the acting player's rack
- the draw pile

so the confirmed game state remains internally consistent after the turn ends.

## Result

After this PR:

- lobby creation can define how many tiles players start with
- game initialization respects that configured number
- pass turns can no longer complete without the required draw being applied by
  the backend

This makes the game setup more flexible and the turn resolution logic more
robust.
